### PR TITLE
Add deployer client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: lint
+lint: $(GOLANGCI_LINT) generate ## Lint codebase
+	$(GOLANGCI_LINT) run -v --fast=false --max-issues-per-linter 0 --max-same-issues 0 --timeout 5m	
+
 ifeq ($(shell go env GOOS),darwin) # Use the darwin/amd64 binary until an arm64 version is available
 KUBEBUILDER_ASSETS ?= $(shell $(SETUP_ENVTEST) use --use-env -p path --arch amd64 $(KUBEBUILDER_ENVTEST_KUBERNETES_VERSION))
 else

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/deployer/client.go
+++ b/pkg/deployer/client.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var getClientLock = &sync.Mutex{}
+
+const (
+	numOfWorker = 10
+)
+
+// deployer represents a client implementing the DeployerInterface
+type deployer struct {
+	log logr.Logger
+	client.Client
+
+	ctx context.Context
+
+	mu *sync.Mutex
+
+	// A request represents a request to deploy a feature in a CAPI cluster.
+
+	// dirty contains all requests that have requested to configure a feature
+	// and are currenlty waiting to be served.
+	dirty []string
+
+	// inProgress contains all request that are currently being served.
+	inProgress []string
+
+	// jobQueue contains all requests that needs to be served
+	jobQueue []requestParams
+
+	// results contains results for processed request
+	results map[string]error
+
+	// features contains currently registered feature ID
+	features map[string]bool
+}
+
+var deployerInstance *deployer
+
+// GetClient return a deployer client, implementing the DeployerInterface
+func GetClient(ctx context.Context, l logr.Logger, c client.Client) *deployer {
+	if deployerInstance == nil {
+		getClientLock.Lock()
+		defer getClientLock.Unlock()
+		if deployerInstance == nil {
+			l.V(1).Info("Creating single instance now.")
+			deployerInstance = &deployer{log: l, Client: c, ctx: ctx}
+			// numOfWorker is set to 10 by default. This can be overridden
+			// using an env variable
+			deployerInstance.startWorkloadWorkers(ctx, numOfWorker, l)
+		}
+	}
+
+	return deployerInstance
+}
+
+func (d *deployer) RegisterFeatureID(
+	featureID string,
+) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if _, ok := d.features[featureID]; ok {
+		return fmt.Errorf("featureID %s is already registered", featureID)
+	}
+
+	d.features[featureID] = true
+	return nil
+}
+
+func (d *deployer) Deploy(
+	ctx context.Context,
+	clusterNamespace, clusterName, featureID string,
+	f requestHandler,
+) error {
+	key := getKey(clusterNamespace, clusterName, featureID)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.features[featureID]; !ok {
+		return fmt.Errorf("featureID %s is not registered", featureID)
+	}
+
+	// Search if request is in dirty. Drop it if already there
+	for i := range d.dirty {
+		if d.dirty[i] == key {
+			d.log.V(10).Info("request is already present in dirty")
+			return nil
+		}
+	}
+
+	// Since we got a new request, if a result was saved, clear it.
+	d.log.V(10).Info("removing result from previous request if any")
+	delete(d.results, key)
+
+	d.log.V(10).Info("request added to dirty")
+	d.dirty = append(d.dirty, key)
+
+	// Push to queue if not already in progress
+	for i := range d.inProgress {
+		if d.inProgress[i] == key {
+			d.log.V(10).Info("request is already in inProgress")
+			return nil
+		}
+	}
+
+	d.log.V(10).Info("request added to jobQueue")
+	req := requestParams{key: key, handler: f}
+	d.jobQueue = append(d.jobQueue, req)
+
+	return nil
+}
+
+func (d *deployer) GetResult(
+	ctx context.Context,
+	clusterNamespace, clusterName, featureID string,
+) Result {
+	responseParam, err := getRequestStatus(d, clusterNamespace, clusterName, featureID)
+	if err != nil {
+		return Result{
+			ResultStatus: Unavailable,
+			Err:          nil,
+		}
+	}
+
+	if responseParam == nil {
+		return Result{
+			ResultStatus: InProgress,
+			Err:          nil,
+		}
+	}
+
+	if responseParam.err != nil {
+		return Result{
+			ResultStatus: Failed,
+			Err:          responseParam.err,
+		}
+	}
+
+	return Result{
+		ResultStatus: Deployed,
+	}
+}

--- a/pkg/deployer/client_test.go
+++ b/pkg/deployer/client_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/projectsveltos/cluster-api-feature-manager/pkg/deployer"
+)
+
+var _ = Describe("Client", func() {
+	It("RegisterFeatureID returns error only if featureID is already registered", func() {
+		featureID := util.RandomString(5)
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		err = d.RegisterFeatureID(featureID)
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("GetResult returns result when available", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		r := map[string]error{key: nil}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		result := d.GetResult(ctx, ns, name, featureID)
+		Expect(result.Err).To(BeNil())
+		Expect(result.ResultStatus).To(Equal(deployer.Deployed))
+	})
+
+	It("GetResult returns result when available with error", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		r := map[string]error{key: fmt.Errorf("failed to deploy")}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		result := d.GetResult(ctx, ns, name, featureID)
+		Expect(result.Err).ToNot(BeNil())
+		Expect(result.ResultStatus).To(Equal(deployer.Failed))
+	})
+
+	It("GetResult returns InProgress when request is still queued (currently in progress)", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		result := d.GetResult(ctx, ns, name, featureID)
+		Expect(result.Err).To(BeNil())
+		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
+	})
+
+	It("GetResult returns InProgress when request is still queued (currently queued)", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		d.SetJobQueue(key, nil)
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+
+		result := d.GetResult(ctx, ns, name, featureID)
+		Expect(result.Err).To(BeNil())
+		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
+	})
+
+	It("GetResult returns Unavailable when request is not queued/in progress and result not available", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		result := d.GetResult(ctx, ns, name, featureID)
+		Expect(result.Err).To(BeNil())
+		Expect(result.ResultStatus).To(Equal(deployer.Unavailable))
+	})
+
+	It("Deploy returns an error when featureID is not registered", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+
+		err := d.Deploy(ctx, ns, name, featureID, nil)
+		Expect(err).ToNot(BeNil())
+	})
+
+	It("Deploy does nothing if already in the dirty set", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		d.SetDirty([]string{key})
+		Expect(len(d.GetDirty())).To(Equal(1))
+
+		err = d.Deploy(ctx, ns, name, featureID, nil)
+		Expect(err).To(BeNil())
+		Expect(len(d.GetDirty())).To(Equal(1))
+		Expect(len(d.GetInProgress())).To(Equal(0))
+		Expect(len(d.GetJobQueue())).To(Equal(0))
+	})
+
+	It("Deploy adds to inProgress", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		err = d.Deploy(ctx, ns, name, featureID, nil)
+		Expect(err).To(BeNil())
+		Expect(len(d.GetDirty())).To(Equal(1))
+		Expect(len(d.GetInProgress())).To(Equal(0))
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+	})
+
+	It("Deploy if already in progress, does not add to jobQueue", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		err = d.Deploy(ctx, ns, name, featureID, nil)
+		Expect(err).To(BeNil())
+		Expect(len(d.GetDirty())).To(Equal(1))
+		Expect(len(d.GetInProgress())).To(Equal(1))
+		Expect(len(d.GetJobQueue())).To(Equal(0))
+	})
+
+	It("Deploy removes existing result", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		r := map[string]error{key: nil}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		err = d.Deploy(ctx, ns, name, featureID, nil)
+		Expect(err).To(BeNil())
+		Expect(len(d.GetDirty())).To(Equal(1))
+		Expect(len(d.GetInProgress())).To(Equal(0))
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+		Expect(len(d.GetResults())).To(Equal(0))
+	})
+})

--- a/pkg/deployer/deployer_suite_test.go
+++ b/pkg/deployer/deployer_suite_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/projectsveltos/cluster-api-feature-manager/pkg/deployer"
+)
+
+const namespacePrefix = "worker"
+
+var (
+	cancel context.CancelFunc
+)
+
+func TestDeployer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deployer Suite")
+}
+
+var _ = BeforeSuite(func() {
+	By("Creating deployer client")
+	c := fake.NewClientBuilder().WithObjects(nil...).Build()
+	var ctx context.Context
+	ctx, cancel = context.WithCancel(context.TODO())
+	deployer.GetClient(ctx, klogr.New(), c)
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+})

--- a/pkg/deployer/export_test.go
+++ b/pkg/deployer/export_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+var (
+	GetKey          = getKey
+	GetFromKey      = getFromKey
+	RemoveFromSlice = removeFromSlice
+
+	StoreResult      = storeResult
+	GetRequestStatus = getRequestStatus
+	ProcessRequests  = processRequests
+)
+
+func (d *deployer) SetInProgress(inProgress []string) {
+	d.inProgress = inProgress
+}
+
+func (d *deployer) GetInProgress() []string {
+	return d.inProgress
+}
+
+func (d *deployer) SetDirty(dirty []string) {
+	d.dirty = dirty
+}
+
+func (d *deployer) GetDirty() []string {
+	return d.dirty
+}
+
+func (d *deployer) SetJobQueue(key string, handler requestHandler) {
+	reqParam := requestParams{
+		key:     key,
+		handler: handler,
+	}
+	d.jobQueue = []requestParams{reqParam}
+}
+
+func (d *deployer) GetJobQueue() []requestParams {
+	return d.jobQueue
+}
+
+func (d *deployer) SetResults(results map[string]error) {
+	d.results = results
+}
+
+func (d *deployer) ClearInternalStruct() {
+	d.dirty = make([]string, 0)
+	d.inProgress = make([]string, 0)
+	d.jobQueue = make([]requestParams, 0)
+	d.results = make(map[string]error)
+	d.features = make(map[string]bool)
+}
+
+func (d *deployer) GetResults() map[string]error {
+	return d.results
+}
+
+func IsResponseDeployed(resp *responseParams) bool {
+	return resp != nil && resp.err == nil
+}
+
+func IsResponseFailed(resp *responseParams) bool {
+	return resp != nil && resp.err != nil
+}

--- a/pkg/deployer/request_interface.go
+++ b/pkg/deployer/request_interface.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+)
+
+type ResultStatus int64
+
+const (
+	Deployed ResultStatus = iota
+	InProgress
+	Failed
+	Unavailable
+)
+
+func (r ResultStatus) String() string {
+	switch r {
+	case Deployed:
+		return "deployed"
+	case InProgress:
+		return "in-progress"
+	case Failed:
+		return "failed"
+	case Unavailable:
+		return "unavailable"
+	}
+	return "unavailable"
+}
+
+type Result struct {
+	ResultStatus
+	Err error
+}
+
+type DeployerInterface interface {
+	// RegisterFeatureID allows registering a feature ID.
+	// If a featureID is already registered, it returns an error.
+	RegisterFeatureID(
+		featureID string,
+	) error
+
+	// Deploy creates a request to deploy a feature in a given
+	// CAPI cluster.
+	// When worker is available to fulfill such request, requestHandler
+	// will be invoked in the worker context.
+	// If featureID is not registered, an error will be returned.
+	Deploy(
+		ctx context.Context,
+		clusterNamespace, clusterName, featureID string,
+		f requestHandler,
+	) error
+
+	// GetResult returns result for a given request.
+	GetResult(
+		ctx context.Context,
+		clusterNamespace, clusterName, featureID string,
+	) Result
+}

--- a/pkg/deployer/worker.go
+++ b/pkg/deployer/worker.go
@@ -1,0 +1,244 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// A "request" represents the need to deploy a feature in a CAPI cluster.
+//
+// When a request arrives, the flow is following:
+// - when a request to configure feature in a CAPI cluster arrives,
+// it is first added to the dirty set or dropped if it already present in the
+// dirty set;
+// - pushed to the jobQueue only if it is not presented in inProgress.
+//
+// When a worker is ready to serve a request, it gets the request from the
+// front of the jobQueue.
+// The request is also added to the inProgress set and removed from the dirty set.
+//
+// If a request, currently in the inProgress arrives again, such request is only added
+// to the dirty set, not to the queue. This guarantees that a request to deploy a feature
+// in a CAPI cluster is never process more than once in parallel.
+//
+// When worker is done, the request is removed from the inProgress set.
+// If the same request is also present in the dirty set, it is added back to the back of the jobQueue.
+
+const (
+	separator = ":::"
+)
+
+type requestHandler func(ctx context.Context, c client.Client, clusterNamespace, clusterName, featureID string) error
+
+type requestParams struct {
+	key     string
+	handler requestHandler
+}
+
+type responseParams struct {
+	requestParams
+	err error
+}
+
+var (
+	controlClusterClient client.Client
+)
+
+// startWorkloadWorkers initializes all internal structures and starts
+// pool of workers
+// - numWorker is number of requested workers
+// - c is the kubernetes client to access control cluster
+func (d *deployer) startWorkloadWorkers(ctx context.Context, numOfWorker int, logger logr.Logger) {
+	d.mu = &sync.Mutex{}
+	d.dirty = make([]string, 0)
+	d.inProgress = make([]string, 0)
+	d.jobQueue = make([]requestParams, 0)
+	d.results = make(map[string]error)
+	d.features = make(map[string]bool)
+
+	for i := 0; i < numOfWorker; i++ {
+		go processRequests(d, i, logger.WithValues("worker", fmt.Sprintf("%d", i)))
+	}
+}
+
+// getKey returns a unique ID for a request provided:
+// - clusterNamespace and clusterName which are the namespace/name of the CAPI
+// cluster where feature needs to be deployed;
+// - featureID is a unique identifier for the feature that needs to be deployed.
+func getKey(clusterNamespace, clusterName, featureID string) string {
+	return clusterNamespace + separator + clusterName + separator + featureID
+}
+
+// getFromKey given a unique request key, returns:
+// - clusterNamespace and clusterName which are the namespace/name of the CAPI
+// cluster where feature needs to be deployed;
+// - featureID is a unique identifier for the feature that needs to be deployed.
+func getFromKey(key string) (namespace, name, featureID string) {
+	info := strings.Split(key, separator)
+	namespace = info[0]
+	name = info[1]
+	featureID = info[2]
+	return
+}
+
+func processRequests(d *deployer, i int, logger logr.Logger) {
+	id := i
+	var params *requestParams
+
+	logger.V(1).Info(fmt.Sprintf("started worker %d", id))
+
+	for {
+		if params != nil {
+			l := logger.WithValues("key", params.key)
+			ns, name, featureID := getFromKey(params.key)
+			l.Info(fmt.Sprintf("worker: %d processing request", id))
+			err := params.handler(d.ctx, controlClusterClient, ns, name, featureID)
+			storeResult(d, params.key, err, params.handler, logger)
+		}
+		params = nil
+		select {
+		case <-time.After(1 * time.Second):
+			d.mu.Lock()
+			if len(d.jobQueue) > 0 {
+				// take a request from queue and remove it from queue
+				params = &requestParams{key: d.jobQueue[0].key, handler: d.jobQueue[0].handler}
+				d.jobQueue = d.jobQueue[1:]
+				l := logger.WithValues("key", params.key)
+				l.V(10).Info("take from jobQueue")
+				// Add to inProgress
+				l.V(10).Info("add to inProgress")
+				d.inProgress = append(d.inProgress, params.key)
+				// If present remove from dirty
+				for i := range d.dirty {
+					if d.dirty[i] == params.key {
+						l.V(10).Info("remove from dirty")
+						d.dirty = removeFromSlice(d.dirty, i)
+						break
+					}
+				}
+			}
+			d.mu.Unlock()
+		case <-d.ctx.Done():
+			logger.V(1).Info("context cancelled")
+			return
+		}
+	}
+}
+
+// doneProcessing does following:
+// - set results for further in time lookup
+// - remove key from inProgress
+// - if key is in dirty, remove it from there and add it to the back of the jobQueue
+func storeResult(d *deployer, key string, err error, handler requestHandler, logger logr.Logger) {
+	d.mu.Lock()
+
+	// Remove from inProgress
+	for i := range d.inProgress {
+		if d.inProgress[i] != key {
+			continue
+		}
+		logger.V(10).Info("remove from inProgress")
+		d.inProgress = removeFromSlice(d.inProgress, i)
+		break
+	}
+
+	if err != nil {
+		logger.V(5).Info(fmt.Sprintf("added to result with err %s", err.Error()))
+	} else {
+		logger.V(5).Info("added to result")
+	}
+	d.results[key] = err
+
+	// if key is in dirty, remove from there and push to jobQueue
+	for i := range d.dirty {
+		if d.dirty[i] != key {
+			continue
+		}
+		logger.V(10).Info("add to jobQueue")
+		d.jobQueue = append(d.jobQueue, requestParams{key: d.dirty[i], handler: handler})
+		logger.V(10).Info("remove from dirty")
+		d.dirty = removeFromSlice(d.dirty, i)
+		logger.V(10).Info("remove result")
+		delete(d.results, key)
+		break
+	}
+
+	d.mu.Unlock()
+}
+
+// getRequestStatus gets requests status.
+// If result is available it returns the result.
+// If request is still queued, responseParams is nil and an error is nil.
+// If result is not available and request is neither queued nor already processed, it returns an error to indicate that.
+func getRequestStatus(d *deployer, clusterNamespace, clusterName, featureID string) (*responseParams, error) {
+
+	key := getKey(clusterNamespace, clusterName, featureID)
+
+	logger := d.log.WithValues("key", key)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	logger.V(5).Info("searching result")
+	if _, ok := d.results[key]; ok {
+		logger.V(5).Info("request already processed, result present. returning result.")
+		if d.results[key] != nil {
+			logger.V(5).Info("returning a response with an error")
+		}
+		resp := responseParams{
+			requestParams: requestParams{
+				key: key,
+			},
+			err: d.results[key],
+		}
+		logger.V(5).Info("removing result")
+		delete(d.results, key)
+		return &resp, nil
+	}
+
+	for i := range d.inProgress {
+		if d.inProgress[i] == key {
+			logger.V(5).Info("request is still in inProgress, so being processed")
+			return nil, nil
+		}
+	}
+
+	for i := range d.jobQueue {
+		if d.jobQueue[i].key == key {
+			logger.V(5).Info("request is still in jobQueue, so waiting to be processed.")
+			return nil, nil
+		}
+	}
+
+	// if we get here it means, we have no response for this workload cluster, nor the
+	// request is queued or being processed
+	logger.V(5).Info("request has not been processed nor is currently queued.")
+	return nil, fmt.Errorf("request has not been processed nor is currently queued")
+}
+
+func removeFromSlice(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	return s[:len(s)-1]
+}

--- a/pkg/deployer/worker_test.go
+++ b/pkg/deployer/worker_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2022. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog/v2/klogr"
+	"sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/projectsveltos/cluster-api-feature-manager/pkg/deployer"
+)
+
+var messages chan string
+
+func writeToChannelHandler(ctx context.Context, c client.Client, namespace, name, featureID string) error {
+	By("writeToChannelHandler: writing to channel")
+	messages <- "done deploying"
+	return nil
+}
+
+func doNothingHandler(ctx context.Context, c client.Client, namespace, name, featureID string) error {
+	return nil
+}
+
+var _ = Describe("Worker", func() {
+	It("getKey and getFromKey return correct values", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		outNs, outName, outFeatureID := deployer.GetFromKey(key)
+		Expect(outNs).To(Equal(ns))
+		Expect(outName).To(Equal(name))
+		Expect(outFeatureID).To(Equal(featureID))
+	})
+
+	It("removeFromSlice should remove element from slice", func() {
+		tmp := []string{"eng", "sale", "hr"}
+		tmp = deployer.RemoveFromSlice(tmp, 1)
+		Expect(len(tmp)).To(Equal(2))
+		Expect(tmp[0]).To(Equal("eng"))
+		Expect(tmp[1]).To(Equal("hr"))
+
+		tmp = deployer.RemoveFromSlice(tmp, 1)
+		Expect(len(tmp)).To(Equal(1))
+
+		tmp = deployer.RemoveFromSlice(tmp, 0)
+		Expect(len(tmp)).To(Equal(0))
+	})
+
+	It("storeResult saves results and removes key from inProgress", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		deployer.StoreResult(d, key, nil, doNothingHandler, klogr.New())
+		Expect(len(d.GetInProgress())).To(Equal(0))
+	})
+
+	It("storeResult saves results and removes key from dirty and adds to jobQueue", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		d.SetDirty([]string{key})
+		Expect(len(d.GetDirty())).To(Equal(1))
+
+		deployer.StoreResult(d, key, nil, doNothingHandler, klogr.New())
+		Expect(len(d.GetInProgress())).To(Equal(0))
+		Expect(len(d.GetDirty())).To(Equal(0))
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+	})
+
+	It("getRequestStatus returns result when available", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		r := map[string]error{key: nil}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		resp, err := deployer.GetRequestStatus(d, ns, name, featureID)
+		Expect(err).To(BeNil())
+		Expect(resp).ToNot(BeNil())
+		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
+	})
+
+	It("getRequestStatus returns result when available and reports error", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		r := map[string]error{key: fmt.Errorf("failed to deploy")}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		resp, err := deployer.GetRequestStatus(d, ns, name, featureID)
+		Expect(err).To(BeNil())
+		Expect(resp).ToNot(BeNil())
+		Expect(deployer.IsResponseFailed(resp)).To(BeTrue())
+	})
+
+	It("getRequestStatus returns nil response when request is still queued (currently in progress)", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		resp, err := deployer.GetRequestStatus(d, ns, name, featureID)
+		Expect(err).To(BeNil())
+		Expect(resp).To(BeNil())
+	})
+
+	It("getRequestStatus returns nil response when request is still queued (currently queued)", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		d := deployer.GetClient(context.TODO(), klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+
+		d.SetJobQueue(key, nil)
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+
+		resp, err := deployer.GetRequestStatus(d, ns, name, featureID)
+		Expect(err).To(BeNil())
+		Expect(resp).To(BeNil())
+	})
+
+	It("processRequests proces request and stores results", func() {
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		featureID := util.RandomString(5)
+		key := deployer.GetKey(ns, name, featureID)
+		d.SetJobQueue(key, writeToChannelHandler)
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+
+		messages = make(chan string)
+
+		go deployer.ProcessRequests(d, 1, klogr.New())
+
+		gotResult := false
+		go func() {
+			// wait for processRequest to process the request
+			// processRequest processes queued request every second
+			<-messages
+			By("read from channel. Request is processed")
+			gotResult = true
+			cancel()
+		}()
+
+		// wait for result to be available
+		Eventually(func() bool {
+			return gotResult
+		}, 20*time.Second, time.Second).Should(BeTrue())
+
+		resp, err := deployer.GetRequestStatus(d, ns, name, featureID)
+		Expect(err).To(BeNil())
+		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
+	})
+})


### PR DESCRIPTION
deployer client can be used to deploy features in a CAPI cluster.
It has workers. Each worker runs in a separate goroutine and picks
a queued job.

Following queues are used:
- dirty contains all requests that have requested to configure a feature
and are currenlty waiting to be served;
- inProgress contains all request that are currently being served;
- jobQueue contains all requests that needs to be served;
- results contains results for processed request.

A new request is added to dirty and in jobQueue,unless already
present. If a result for such request was available, result is cleared.
When a worker picks a request, such request is moved from jobQueue to
inProgress.
When a request is completed, successfully or not, then:
- result is stored in results;
- request is removed from InProgress;
- if request is in dirty, it gets removed from there and added to
jobQueue.