### PR TITLE
ClusterFeature transformations

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/controllers/clusterfeature_controller_test.go
+++ b/controllers/clusterfeature_controller_test.go
@@ -19,6 +19,7 @@ package controllers_test
 import (
 	"context"
 	"reflect"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -99,9 +100,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureName := client.ObjectKey{
@@ -133,9 +138,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -171,9 +180,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		Expect(err).To(BeNil())
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		err = controllers.CreateClusterSummary(reconciler, context.TODO(),
@@ -239,9 +252,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		Expect(err).To(BeNil())
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		err = controllers.UpdateClusterSummary(reconciler, context.TODO(),
@@ -307,9 +324,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		Expect(err).To(BeNil())
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		err = controllers.UpdateClusterSummary(reconciler, context.TODO(),
@@ -366,9 +387,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		err := controllers.DeleteClusterSummary(reconciler, context.TODO(), clusterSummary)
@@ -395,9 +420,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -445,9 +474,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -525,9 +558,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -578,9 +615,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -627,9 +668,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{
@@ -677,9 +722,13 @@ var _ = Describe("ClusterFeature: Reconciler", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		reconciler := &controllers.ClusterFeatureReconciler{
-			Client: c,
-			Log:    klogr.New(),
-			Scheme: scheme,
+			Client:            c,
+			Log:               klogr.New(),
+			Scheme:            scheme,
+			ClusterMap:        make(map[string]*controllers.Set),
+			ClusterFeatureMap: make(map[string]*controllers.Set),
+			ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+			Mux:               sync.Mutex{},
 		}
 
 		clusterFeatureScope, err := scope.NewClusterFeatureScope(scope.ClusterFeatureScopeParams{

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -68,9 +68,13 @@ var _ = BeforeSuite(func() {
 	}
 
 	clusterFeatureReconciler = &controllers.ClusterFeatureReconciler{
-		Client: testEnv.Client,
-		Log:    klogr.New(),
-		Scheme: scheme,
+		Client:            testEnv.Client,
+		Log:               klogr.New(),
+		Scheme:            scheme,
+		ClusterMap:        make(map[string]*controllers.Set),
+		ClusterFeatureMap: make(map[string]*controllers.Set),
+		ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+		Mux:               sync.Mutex{},
 	}
 
 	dep := fakedeployer.GetClient(context.TODO(), klogr.New(), testEnv.Client)

--- a/main.go
+++ b/main.go
@@ -100,9 +100,13 @@ func main() {
 	}
 
 	if err = (&controllers.ClusterFeatureReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("ClusterFeature"),
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		Log:               ctrl.Log.WithName("controllers").WithName("ClusterFeature"),
+		ClusterMap:        make(map[string]*controllers.Set),
+		ClusterFeatureMap: make(map[string]*controllers.Set),
+		ClusterFeatures:   make(map[string]configv1alpha1.Selector),
+		Mux:               sync.Mutex{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterFeature")
 		os.Exit(1)


### PR DESCRIPTION
ClusterFeatures need to be reconciled when CAPI Cluster labels change.
Before this PR, inside the MapFunc, code used to List all
ClusterFeatures to find the ones that needed to be reconciled.

Above approach is though incorrect. If listing all ClusterFeatures fail,
nothing will be requeued.

This PR, similar to ClusterSummary approach, introduces internal
data structures for ClusterFeatureReconciler and uses those instead of a
list inside the MapFunc.