### PR TITLE
ClusterSummary cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,11 +122,11 @@ create-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL) $(ENVSUBST) ## Create a new kin
 	@echo "Create a workload cluster"
 	$(KUBECTL) apply -f $(KIND_CLUSTER_YAML)
 
-	@echo "get kubeconfig to access workload cluster"
-	$(KIND) get kubeconfig --name $(WORKLOAD_CLUSTER_NAME) > test/fv/workload_kubeconfig
-
 	@echo "Start projectsveltos"
 	$(MAKE) deploy-projectsveltos
+
+	@echo "get kubeconfig to access workload cluster"
+	$(KIND) get kubeconfig --name $(WORKLOAD_CLUSTER_NAME) > test/fv/workload_kubeconfig
 
 
 .PHONY: delete-cluster

--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -18,14 +18,10 @@ package controllers
 
 import (
 	"context"
-	"crypto/sha256"
 	"fmt"
 	"reflect"
 
-	"github.com/gdexlab/go-render/render"
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/projectsveltos/cluster-api-feature-manager/api/v1alpha1"
@@ -46,6 +42,14 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 	f feature) error {
 	clusterSummary := clusterSummaryScope.ClusterSummary
 
+	// If undeploying feature is in progress, wait for it to complete.
+	// Otherwise, if we redeploy feature while same feature is still being cleaned up, if two workers process those request in
+	// parallel some resources might end up missing.
+	if r.Deployer.IsInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Name,
+		string(configv1alpha1.FeatureRole), true) {
+		return fmt.Errorf(fmt.Sprintf("cleanup of %s still in progress. Wait before redeploying", string(f.id)))
+	}
+
 	// Get hash of current configuration (at this very precise moment)
 	currentHash, err := f.currentHash(ctx, r.Client, clusterSummaryScope, r.Log)
 	if err != nil {
@@ -60,11 +64,18 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 		return nil
 	}
 
+	// Feature is not deployed yet
 	if reflect.DeepEqual(hash, currentHash) {
 		// Configuration has not changed. Check if a result is available.
 		result := r.Deployer.GetResult(ctx, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			clusterSummaryScope.Name(), string(configv1alpha1.FeatureRole))
-		r.updateFeatureStatus(clusterSummaryScope, configv1alpha1.FeatureRole, result, hash)
+			clusterSummaryScope.Name(), string(f.id), false)
+		status := r.convertResultStatus(result)
+		if status == nil {
+			// No result is available, Request to deploy will be queued. So mark it as Provisioning
+			s := configv1alpha1.FeatureStatusProvisioning
+			status = &s
+		}
+		r.updateFeatureStatus(clusterSummaryScope, configv1alpha1.FeatureRole, status, hash, result.Err)
 		if result.ResultStatus == deployer.Deployed || result.ResultStatus == deployer.InProgress {
 			return nil
 		}
@@ -74,7 +85,46 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 	// Feature must be (re)deployed.
 
 	if err := r.Deployer.Deploy(ctx, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-		clusterSummary.Name, string(f.id), f.deploy); err != nil {
+		clusterSummary.Name, string(f.id), false, f.deploy); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *ClusterSummaryReconciler) undeployFeature(ctx context.Context, clusterSummaryScope *scope.ClusterSummaryScope,
+	f feature) error {
+	clusterSummary := clusterSummaryScope.ClusterSummary
+
+	// If deploying feature is in progress, wait for it to complete.
+	// Otherwise, if we cleanup feature while same feature is still being provisioned, if two workers process those request in
+	// parallel some resources might be left over.
+	if r.Deployer.IsInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Name,
+		string(configv1alpha1.FeatureRole), false) {
+		return fmt.Errorf(fmt.Sprintf("deploying %s still in progress. Wait before cleanup", string(f.id)))
+	}
+
+	if r.isFeatureRemoved(clusterSummaryScope, f.id) {
+		// feature is removed. Nothing to do.
+		return nil
+	}
+
+	result := r.Deployer.GetResult(ctx, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummaryScope.Name(), string(f.id), true)
+	status := r.convertResultStatus(result)
+	if status == nil || result.ResultStatus == deployer.InProgress {
+		// No result is available or removing this feature is in progress. Since this is a cleanup,
+		// mark it as removing
+		s := configv1alpha1.FeatureStatusRemoving
+		status = &s
+	}
+	r.updateFeatureStatus(clusterSummaryScope, configv1alpha1.FeatureRole, status, nil, result.Err)
+	if result.ResultStatus == deployer.Removed || result.ResultStatus == deployer.InProgress {
+		return nil
+	}
+
+	if err := r.Deployer.Deploy(ctx, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.Name, string(f.id), true, f.deploy); err != nil {
 		return err
 	}
 
@@ -82,7 +132,7 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 }
 
 // isFeatureDeployed returns true if feature is marked as deployed (present in FeatureSummaries and status
-// is set to Provisioned). In such case, hash corresponding to the deployed configuration is returned.
+// is set to Provisioned).
 func (r *ClusterSummaryReconciler) isFeatureDeployed(clusterSummaryScope *scope.ClusterSummaryScope,
 	featureID configv1alpha1.FeatureID) bool {
 	clusterSummary := clusterSummaryScope.ClusterSummary
@@ -91,6 +141,23 @@ func (r *ClusterSummaryReconciler) isFeatureDeployed(clusterSummaryScope *scope.
 		fs := clusterSummary.Status.FeatureSummaries[i]
 		if fs.FeatureID == featureID {
 			if fs.Status == configv1alpha1.FeatureStatusProvisioned {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isFeatureRemoved returns true if feature is marked as removed (present in FeatureSummaries and status
+// is set to Removed).
+func (r *ClusterSummaryReconciler) isFeatureRemoved(clusterSummaryScope *scope.ClusterSummaryScope,
+	featureID configv1alpha1.FeatureID) bool {
+	clusterSummary := clusterSummaryScope.ClusterSummary
+
+	for i := range clusterSummary.Status.FeatureSummaries {
+		fs := clusterSummary.Status.FeatureSummaries[i]
+		if fs.FeatureID == featureID {
+			if fs.Status == configv1alpha1.FeatureStatusRemoved {
 				return true
 			}
 		}
@@ -114,50 +181,46 @@ func (r *ClusterSummaryReconciler) getHash(clusterSummaryScope *scope.ClusterSum
 }
 
 func (r *ClusterSummaryReconciler) updateFeatureStatus(clusterSummaryScope *scope.ClusterSummaryScope,
-	featureID configv1alpha1.FeatureID, result deployer.Result, hash []byte) {
+	featureID configv1alpha1.FeatureID, status *configv1alpha1.FeatureStatus, hash []byte, statusError error) {
+	if status == nil {
+		return
+	}
 
-	switch result.ResultStatus {
-	case deployer.Deployed:
+	switch *status {
+	case configv1alpha1.FeatureStatusProvisioned:
 		clusterSummaryScope.SetFeatureStatus(featureID, configv1alpha1.FeatureStatusProvisioned, hash)
 		clusterSummaryScope.SetFailureMessage(featureID, nil)
-	case deployer.InProgress:
+	case configv1alpha1.FeatureStatusRemoved:
+		clusterSummaryScope.SetFeatureStatus(featureID, configv1alpha1.FeatureStatusRemoved, hash)
+		clusterSummaryScope.SetFailureMessage(featureID, nil)
+	case configv1alpha1.FeatureStatusProvisioning:
 		clusterSummaryScope.SetFeatureStatus(featureID, configv1alpha1.FeatureStatusProvisioning, hash)
-	case deployer.Failed:
+	case configv1alpha1.FeatureStatusRemoving:
+		clusterSummaryScope.SetFeatureStatus(featureID, configv1alpha1.FeatureStatusRemoving, hash)
+	case configv1alpha1.FeatureStatusFailed:
 		clusterSummaryScope.SetFeatureStatus(featureID, configv1alpha1.FeatureStatusFailed, hash)
-		err := result.Err.Error()
+		err := statusError.Error()
 		clusterSummaryScope.SetFailureMessage(featureID, &err)
-	case deployer.Unavailable:
-		// Nothing to do here
 	}
 }
 
-///////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////// Per feature Hash functions
-///////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-// workloadRoleHash returns the hash of all the ClusterSummary referenced WorkloadRole Specs.
-func workloadRoleHash(ctx context.Context, c client.Client, clusterSummaryScope *scope.ClusterSummaryScope,
-	logger logr.Logger) ([]byte, error) {
-	h := sha256.New()
-	var config string
-
-	clusterSummary := clusterSummaryScope.ClusterSummary
-	for i := range clusterSummary.Spec.ClusterFeatureSpec.WorkloadRoles {
-		reference := &clusterSummary.Spec.ClusterFeatureSpec.WorkloadRoles[i]
-		workloadRole := &configv1alpha1.WorkloadRole{}
-		err := c.Get(ctx, types.NamespacedName{Name: reference.Name}, workloadRole)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				logger.Info(fmt.Sprintf("workloadRole %s does not exist yet", reference.Name))
-				continue
-			}
-			logger.Error(err, fmt.Sprintf("failed to get workloadRole %s", reference.Name))
-			return nil, err
-		}
-
-		config += render.AsCode(workloadRole.Spec)
+func (r *ClusterSummaryReconciler) convertResultStatus(result deployer.Result) *configv1alpha1.FeatureStatus {
+	switch result.ResultStatus {
+	case deployer.Deployed:
+		s := configv1alpha1.FeatureStatusProvisioned
+		return &s
+	case deployer.Failed:
+		s := configv1alpha1.FeatureStatusFailed
+		return &s
+	case deployer.InProgress:
+		s := configv1alpha1.FeatureStatusProvisioning
+		return &s
+	case deployer.Removed:
+		s := configv1alpha1.FeatureStatusRemoved
+		return &s
+	case deployer.Unavailable:
+		return nil
 	}
 
-	h.Write([]byte(config))
-	return h.Sum(nil), nil
+	return nil
 }

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -35,14 +35,16 @@ var (
 )
 
 var (
-	GetSecretData       = getSecretData
-	GetKubernetesClient = getKubernetesClient
-	GetRoleName         = getRoleName
+	GetSecretData          = getSecretData
+	GetKubernetesClient    = getKubernetesClient
+	GetRoleName            = getRoleName
+	AddClusterSummaryLabel = addClusterSummaryLabel
 
 	DeployNamespacedWorkloadRole = deployNamespacedWorkloadRole
 	DeployClusterWorkloadRole    = deployClusterWorkloadRole
 
-	WorkloadRoleHash = workloadRoleHash
+	UndeployStaleResources = undeployStaleResources
+	WorkloadRoleHash       = workloadRoleHash
 )
 
 var (
@@ -50,12 +52,21 @@ var (
 	GetHash             = (*ClusterSummaryReconciler).getHash
 	UpdateFeatureStatus = (*ClusterSummaryReconciler).updateFeatureStatus
 	DeployFeature       = (*ClusterSummaryReconciler).deployFeature
+	UndeployFeature     = (*ClusterSummaryReconciler).undeployFeature
+
+	DeployRoles         = (*ClusterSummaryReconciler).deployRoles
+	UndeployRoles       = (*ClusterSummaryReconciler).undeployRoles
+	ConvertResultStatus = (*ClusterSummaryReconciler).convertResultStatus
 
 	RequeueClusterSummaryForWorkloadRole = (*ClusterSummaryReconciler).requeueClusterSummaryForWorkloadRole
 )
 
 var (
 	GetClusterFeatureOwner = getClusterFeatureOwner
+)
+
+const (
+	ClusterSummaryLabelName = clusterSummaryLabelName
 )
 
 var (

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -19,17 +19,25 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/projectsveltos/cluster-api-feature-manager/api/v1alpha1"
 )
 
-const separator = "--"
+const (
+	separator                   = "--"
+	kubeconfigSecretNamePostfix = "-kubeconfig"
+)
 
 // GetClusterSummaryName returns the ClusterSummary name given a ClusterFeature name and
 // CAPI cluster Namespace/Name
@@ -62,4 +70,92 @@ func getClusterFeatureOwner(ctx context.Context, c client.Client,
 		}
 	}
 	return nil, nil
+}
+
+// getKubernetesClient returns a client to access CAPI Cluster
+func getKubernetesClient(ctx context.Context, logger logr.Logger, c client.Client,
+	clusterNamespace, clusterName string) (client.Client, error) {
+	kubeconfigContent, err := getSecretData(ctx, logger, c, clusterNamespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig, err := createKubeconfig(logger, kubeconfigContent)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		logger.Error(err, "BuildConfigFromFlags")
+		return nil, errors.Wrap(err, "BuildConfigFromFlags")
+	}
+	logger.V(10).Info("return new client")
+	return client.New(config, client.Options{})
+}
+
+// getSecretData verifies Cluster exists and returns the content of secret containing
+// the kubeconfig for CAPI cluster
+func getSecretData(ctx context.Context, logger logr.Logger, c client.Client,
+	clusterNamespace, clusterName string) ([]byte, error) {
+
+	logger.WithValues("namespace", clusterNamespace, "cluster", clusterName)
+	logger.V(10).Info("Get secret")
+	key := client.ObjectKey{
+		Namespace: clusterNamespace,
+		Name:      clusterName,
+	}
+
+	cluster := clusterv1.Cluster{}
+	if err := c.Get(ctx, key, &cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Info("Cluster does not exist")
+			return nil, errors.Wrap(err,
+				fmt.Sprintf("Cluster %s/%s does not exist",
+					clusterNamespace,
+					clusterName,
+				))
+		}
+		return nil, err
+	}
+
+	secretName := cluster.Name + kubeconfigSecretNamePostfix
+	logger = logger.WithValues("secret", secretName)
+
+	secret := &corev1.Secret{}
+	key = client.ObjectKey{
+		Namespace: clusterNamespace,
+		Name:      secretName,
+	}
+
+	if err := c.Get(ctx, key, secret); err != nil {
+		logger.Error(err, "failed to get secret")
+		return nil, errors.Wrap(err,
+			fmt.Sprintf("Failed to get secret %s/%s",
+				clusterNamespace, secretName))
+	}
+
+	for k, contents := range secret.Data {
+		logger.V(10).Info("Reading secret", "key", k)
+		return contents, nil
+	}
+
+	return nil, nil
+}
+
+// createKubeconfig creates a temporary file with the Kubeconfig to access CAPI cluster
+func createKubeconfig(logger logr.Logger, kubeconfigContent []byte) (string, error) {
+	tmpfile, err := ioutil.TempFile("", "kubeconfig")
+	if err != nil {
+		logger.Error(err, "failed to create temporary file")
+		return "", errors.Wrap(err, "ioutil.TempFile")
+	}
+	defer tmpfile.Close()
+
+	if _, err := tmpfile.Write(kubeconfigContent); err != nil {
+		logger.Error(err, "failed to write to temporary file")
+		return "", errors.Wrap(err, "failed to write to temporary file")
+	}
+
+	return tmpfile.Name(), nil
 }

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func main() {
 	ctx := context.Background()
 	deployer := deployer.GetClient(ctx, ctrl.Log.WithName("deployer"), mgr.GetClient())
 	if err := deployer.RegisterFeatureID(string(configv1alpha1.FeatureRole)); err != nil {
-		setupLog.Error(err, "failed to register feature")
+		setupLog.Error(err, "failed to register feature FeatureRole")
 		os.Exit(1)
 	}
 

--- a/pkg/deployer/client_test.go
+++ b/pkg/deployer/client_test.go
@@ -50,7 +50,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -62,7 +63,7 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Deployed))
 	})
@@ -72,7 +73,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -84,7 +86,7 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, cleanup)
 		Expect(result.Err).ToNot(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Failed))
 	})
@@ -94,7 +96,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := true
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -105,7 +108,7 @@ var _ = Describe("Client", func() {
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
 	})
@@ -115,7 +118,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -126,7 +130,7 @@ var _ = Describe("Client", func() {
 		d.SetJobQueue(key, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.InProgress))
 	})
@@ -136,6 +140,7 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
+		cleanup := true
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -143,7 +148,7 @@ var _ = Describe("Client", func() {
 		d := deployer.GetClient(ctx, klogr.New(), c)
 		defer d.ClearInternalStruct()
 
-		result := d.GetResult(ctx, ns, name, applicant, featureID)
+		result := d.GetResult(ctx, ns, name, applicant, featureID, cleanup)
 		Expect(result.Err).To(BeNil())
 		Expect(result.ResultStatus).To(Equal(deployer.Unavailable))
 	})
@@ -153,13 +158,14 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
+		cleanup := true
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 		d := deployer.GetClient(ctx, klogr.New(), c)
 
-		err := d.Deploy(ctx, ns, name, applicant, featureID, nil)
+		err := d.Deploy(ctx, ns, name, applicant, featureID, cleanup, nil)
 		Expect(err).ToNot(BeNil())
 	})
 
@@ -168,7 +174,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -182,7 +189,7 @@ var _ = Describe("Client", func() {
 		d.SetDirty([]string{key})
 		Expect(len(d.GetDirty())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, nil)
+		err = d.Deploy(ctx, ns, name, applicant, featureID, cleanup, nil)
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
 		Expect(len(d.GetInProgress())).To(Equal(0))
@@ -194,6 +201,7 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
+		cleanup := false
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -204,7 +212,7 @@ var _ = Describe("Client", func() {
 		err := d.RegisterFeatureID(featureID)
 		Expect(err).To(BeNil())
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, nil)
+		err = d.Deploy(ctx, ns, name, applicant, featureID, cleanup, nil)
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
 		Expect(len(d.GetInProgress())).To(Equal(0))
@@ -216,7 +224,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -230,7 +239,7 @@ var _ = Describe("Client", func() {
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, nil)
+		err = d.Deploy(ctx, ns, name, applicant, featureID, cleanup, nil)
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
 		Expect(len(d.GetInProgress())).To(Equal(1))
@@ -242,7 +251,8 @@ var _ = Describe("Client", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		c := fake.NewClientBuilder().WithObjects(nil...).Build()
 		ctx, cancel := context.WithCancel(context.TODO())
@@ -257,11 +267,48 @@ var _ = Describe("Client", func() {
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		err = d.Deploy(ctx, ns, name, applicant, featureID, nil)
+		err = d.Deploy(ctx, ns, name, applicant, featureID, cleanup, nil)
 		Expect(err).To(BeNil())
 		Expect(len(d.GetDirty())).To(Equal(1))
 		Expect(len(d.GetInProgress())).To(Equal(0))
 		Expect(len(d.GetJobQueue())).To(Equal(1))
+		Expect(len(d.GetResults())).To(Equal(0))
+	})
+
+	It("CleanupEntries removes features from internal data structure but inProgress", func() {
+		ns := namespacePrefix + util.RandomString(5)
+		name := namespacePrefix + util.RandomString(5)
+		applicant := util.RandomString(5)
+		featureID := util.RandomString(5)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
+
+		c := fake.NewClientBuilder().WithObjects(nil...).Build()
+		ctx, cancel := context.WithCancel(context.TODO())
+		defer cancel()
+		d := deployer.GetClient(ctx, klogr.New(), c)
+		defer d.ClearInternalStruct()
+
+		err := d.RegisterFeatureID(featureID)
+		Expect(err).To(BeNil())
+
+		r := map[string]error{key: nil}
+		d.SetResults(r)
+		Expect(len(d.GetResults())).To(Equal(1))
+
+		d.SetInProgress([]string{key})
+		Expect(len(d.GetInProgress())).To(Equal(1))
+
+		d.SetDirty([]string{key})
+		Expect(len(d.GetDirty())).To(Equal(1))
+
+		d.SetJobQueue(key, nil)
+		Expect(len(d.GetJobQueue())).To(Equal(1))
+
+		d.CleanupEntries(ns, name, applicant, featureID, cleanup)
+		Expect(len(d.GetDirty())).To(Equal(0))
+		Expect(len(d.GetInProgress())).To(Equal(1))
+		Expect(len(d.GetJobQueue())).To(Equal(0))
 		Expect(len(d.GetResults())).To(Equal(0))
 	})
 })

--- a/pkg/deployer/worker_test.go
+++ b/pkg/deployer/worker_test.go
@@ -54,13 +54,16 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := true
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
-		outNs, outName, outApplicant, outFeatureID := deployer.GetFromKey(key)
+		outNs, outName, outApplicant, outFeatureID, outCleanup, err := deployer.GetFromKey(key)
+		Expect(err).To(BeNil())
 		Expect(outNs).To(Equal(ns))
 		Expect(outName).To(Equal(name))
 		Expect(outApplicant).To(Equal(applicant))
 		Expect(outFeatureID).To(Equal(featureID))
+		Expect(outCleanup).To(Equal(cleanup))
 	})
 
 	It("getKey and getFromKey return correct values (applicant is empty)", func() {
@@ -68,13 +71,16 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := ""
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, false)
 
-		outNs, outName, outApplicant, outFeatureID := deployer.GetFromKey(key)
+		outNs, outName, outApplicant, outFeatureID, outCleanup, err := deployer.GetFromKey(key)
+		Expect(err).To(BeNil())
 		Expect(outNs).To(Equal(ns))
 		Expect(outName).To(Equal(name))
 		Expect(outApplicant).To(Equal(applicant))
 		Expect(outFeatureID).To(Equal(featureID))
+		Expect(outCleanup).To(Equal(cleanup))
 	})
 
 	It("removeFromSlice should remove element from slice", func() {
@@ -100,7 +106,8 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -117,7 +124,8 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
@@ -139,13 +147,14 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := true
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		r := map[string]error{key: nil}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
@@ -160,13 +169,14 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := true
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		r := map[string]error{key: fmt.Errorf("failed to deploy")}
 		d.SetResults(r)
 		Expect(len(d.GetResults())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).ToNot(BeNil())
 		Expect(deployer.IsResponseFailed(resp)).To(BeTrue())
@@ -181,12 +191,13 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		d.SetInProgress([]string{key})
 		Expect(len(d.GetInProgress())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -200,12 +211,13 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := false
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 
 		d.SetJobQueue(key, nil)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
 		Expect(err).To(BeNil())
 		Expect(resp).To(BeNil())
 	})
@@ -220,7 +232,8 @@ var _ = Describe("Worker", func() {
 		name := namespacePrefix + util.RandomString(5)
 		applicant := util.RandomString(5)
 		featureID := util.RandomString(5)
-		key := deployer.GetKey(ns, name, applicant, featureID)
+		cleanup := true
+		key := deployer.GetKey(ns, name, applicant, featureID, cleanup)
 		d.SetJobQueue(key, writeToChannelHandler)
 		Expect(len(d.GetJobQueue())).To(Equal(1))
 
@@ -243,7 +256,7 @@ var _ = Describe("Worker", func() {
 			return gotResult
 		}, 20*time.Second, time.Second).Should(BeTrue())
 
-		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID)
+		resp, err := deployer.GetRequestStatus(d, ns, name, applicant, featureID, cleanup)
 		Expect(err).To(BeNil())
 		Expect(deployer.IsResponseDeployed(resp)).To(BeTrue())
 	})


### PR DESCRIPTION
If sync mod is set to continuos:
- when a WorkloadRole instance is not referenced anymore, corresponding
Role/ClusterRole is removed from the CAPI Cluster;
- when a ClusterSummary is deleted, before removing the finalizer,
remove all Roles/ClusterRoles deployed by such ClusterSummary instance
in the CAPI Cluster

Also, given same feature can be deployed or undeployed from a CAPI
Cluster, DeployerInterface methods requires an extra argurment, a bool
to indicate whether that is a cleanup or a provision request.

When a provision request happens, logic first checks whether a cleanup
is in progress. If so, provision request errors out.
When a cleanup request happens, logic first checks whether a provision
is in progress. If so, cleanup request errors out.
That's because if a request to cleanup and a request to provision the same
feature in the same CAPI cluster go in parallel, the outcome might be buggy
(either some policies become stale or go missing).