### PR TITLE
Expose gatekeeper audit options

### DIFF
--- a/api/v1alpha1/clusterfeature_types.go
+++ b/api/v1alpha1/clusterfeature_types.go
@@ -58,7 +58,27 @@ type GatekeeperConfiguration struct {
 	// PolicyRef references ConfigMaps containing the Gatekeeper policies
 	// that need to be deployed in the workload cluster. This includes and it is not limited
 	// to contrainttemplates, configs, etc.
+	// +optional
 	PolicyRefs []corev1.ObjectReference `json:"policyRef,omitempty"`
+
+	// AuditInterval is the audit interval time.
+	// Disable audit interval by setting 0
+	// +kubebuilder:default:=60
+	// +optional
+	AuditInterval uint `json:"auditInterval,omitempty"`
+
+	// AuditChunkSize is the Kubernetes API chunking List results when retrieving
+	// cluster resources using discovery client
+	// +kubebuilder:default:=500
+	// +optional
+	AuditChunkSize uint `json:"auditChunkSize,omitempty"`
+
+	// AuditFromCache, if set to true, pull resources from OPA cache when auditing.
+	// Note that this requires replication of Kubernetes resources into OPA before
+	// they can be evaluated against the enforced policies
+	// +kubebuilder:default:=false
+	// +optional
+	AuditFromCache bool `json:"auditFromCache,omitempty"`
 }
 
 // InstallationMode specifies how prometheus is deployed in a CAPI Cluster.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/config/crd/bases/config.projectsveltos.io_clusterfeatures.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterfeatures.yaml
@@ -44,6 +44,23 @@ spec:
                   If not nil, Gatekeeper will be deployed in the workload cluster
                   along with, if any, specified Gatekeeper policies.
                 properties:
+                  auditChunkSize:
+                    default: 500
+                    description: AuditChunkSize is the Kubernetes API chunking List
+                      results when retrieving cluster resources using discovery client
+                    type: integer
+                  auditFromCache:
+                    default: false
+                    description: AuditFromCache, if set to true, pull resources from
+                      OPA cache when auditing. Note that this requires replication
+                      of Kubernetes resources into OPA before they can be evaluated
+                      against the enforced policies
+                    type: boolean
+                  auditInterval:
+                    default: 60
+                    description: AuditInterval is the audit interval time. Disable
+                      audit interval by setting 0
+                    type: integer
                   policyRef:
                     description: PolicyRef references ConfigMaps containing the Gatekeeper
                       policies that need to be deployed in the workload cluster. This

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -48,6 +48,24 @@ spec:
                       If not nil, Gatekeeper will be deployed in the workload cluster
                       along with, if any, specified Gatekeeper policies.
                     properties:
+                      auditChunkSize:
+                        default: 500
+                        description: AuditChunkSize is the Kubernetes API chunking
+                          List results when retrieving cluster resources using discovery
+                          client
+                        type: integer
+                      auditFromCache:
+                        default: false
+                        description: AuditFromCache, if set to true, pull resources
+                          from OPA cache when auditing. Note that this requires replication
+                          of Kubernetes resources into OPA before they can be evaluated
+                          against the enforced policies
+                        type: boolean
+                      auditInterval:
+                        default: 60
+                        description: AuditInterval is the audit interval time. Disable
+                          audit interval by setting 0
+                        type: integer
                       policyRef:
                         description: PolicyRef references ConfigMaps containing the
                           Gatekeeper policies that need to be deployed in the workload

--- a/controllers/handlers_gatekeeper_test.go
+++ b/controllers/handlers_gatekeeper_test.go
@@ -167,6 +167,9 @@ var _ = Describe("HandlersGatekeeper", func() {
 
 	It("deployGatekeeperInWorklaodCluster installs Gatekeeper CRDs in a cluster", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		clusterSummary.Spec.ClusterFeatureSpec.GatekeeperConfiguration = &configv1alpha1.GatekeeperConfiguration{}
+
 		Expect(controllers.DeployGatekeeperInWorklaodCluster(context.TODO(), c, klogr.New())).To(Succeed())
 
 		customResourceDefinitions := &apiextensionsv1.CustomResourceDefinitionList{}

--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -23,6 +23,8 @@ const Namespace = "gatekeeper-system"
 // Gatekeeper deployment names
 var Deployments = []string{"gatekeeper-audit", "gatekeeper-controller-manager"}
 
+const AuditDeployment = "gatekeeper-audit"
+
 var GatekeeperYAML = []byte(`apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
1. audit-chunk-size: Lower chunk size can reduce memory consumption
of the auditing Pod but can increase the number requests to the Kubernetes
API server;
2. audit-interval;
3. audit-from-cache: if set to true, pull resources from OPA cache when auditing.
Note that this requires replication of Kubernetes resources into OPA before
they can be evaluated against the enforced policies.