### PR TITLE
When Cluster is deleted, reconcile ClusterFeatures

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -23,7 +23,7 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/clusterfeature_predicate_test.go
+++ b/controllers/clusterfeature_predicate_test.go
@@ -68,7 +68,7 @@ var _ = Describe("ClusterFeature Predicates: ClusterPredicates", func() {
 		result := clusterPredicate.Create(e)
 		Expect(result).To(BeFalse())
 	})
-	It("Delete does not reprocess ", func() {
+	It("Delete does reprocess ", func() {
 		clusterPredicate := controllers.ClusterPredicates(logger)
 
 		e := event.DeleteEvent{
@@ -76,7 +76,7 @@ var _ = Describe("ClusterFeature Predicates: ClusterPredicates", func() {
 		}
 
 		result := clusterPredicate.Delete(e)
-		Expect(result).To(BeFalse())
+		Expect(result).To(BeTrue())
 	})
 	It("Update reprocesses when v1Cluster paused changes from true to false", func() {
 		clusterPredicate := controllers.ClusterPredicates(logger)

--- a/controllers/clusterfeature_predicates.go
+++ b/controllers/clusterfeature_predicates.go
@@ -87,8 +87,8 @@ func ClusterPredicates(logger logr.Logger) predicate.Funcs {
 				"cluster", e.Object.GetName(),
 			)
 			log.V(logs.LogVerbose).Info(
-				"Cluster did not match expected conditions.  Will not attempt to reconcile associated ClusterFeatures.")
-			return false
+				"Cluster deleted.  Will attempt to reconcile associated ClusterFeatures.")
+			return true
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			log := logger.WithValues("predicate", "genericEvent",


### PR DESCRIPTION
When a cluster is deleted, all ClusterSummaries created for it needs to be deleted. So ClusterFeatures need to be reconciled.