### PR TITLE
Consider reloader knob in the hash function

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -316,6 +316,10 @@ func helmHash(ctx context.Context, c client.Client, clusterSummaryScope *scope.C
 	h := sha256.New()
 	var config string
 
+	// If Reloader changes, Reloader needs to be deployed or undeployed
+	// So consider it in the hash
+	config += fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
+
 	clusterSummary := clusterSummaryScope.ClusterSummary
 	if clusterSummary.Spec.ClusterProfileSpec.HelmCharts == nil {
 		return h.Sum(nil), nil

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
+	"fmt"
 	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -607,7 +608,8 @@ var _ = Describe("Hash methods", func() {
 		})
 		Expect(err).To(BeNil())
 
-		config := render.AsCode(kyvernoChart)
+		config := fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
+		config += render.AsCode(kyvernoChart)
 		config += render.AsCode(nginxChart)
 		h := sha256.New()
 		h.Write([]byte(config))

--- a/controllers/handlers_kustomize.go
+++ b/controllers/handlers_kustomize.go
@@ -261,6 +261,10 @@ func kustomizationHash(ctx context.Context, c client.Client, clusterSummaryScope
 	h := sha256.New()
 	var config string
 
+	// If Reloader changes, Reloader needs to be deployed or undeployed
+	// So consider it in the hash
+	config += fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
+
 	config += render.AsCode(clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.KustomizationRefs)
 
 	for i := range clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.KustomizationRefs {

--- a/controllers/handlers_kustomize_test.go
+++ b/controllers/handlers_kustomize_test.go
@@ -21,6 +21,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -295,7 +296,7 @@ var _ = Describe("Hash methods", func() {
 		})
 		Expect(err).To(BeNil())
 
-		var config string
+		config := fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
 		config += render.AsCode(clusterSummary.Spec.ClusterProfileSpec.KustomizationRefs)
 		for i := 0; i < repoNum; i++ {
 			config += gitRepositories[i].Status.Artifact.Revision

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -324,6 +324,10 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummaryScope *sc
 	h := sha256.New()
 	var config string
 
+	// If Reloader changes, Reloader needs to be deployed or undeployed
+	// So consider it in the hash
+	config += fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
+
 	clusterSummary := clusterSummaryScope.ClusterSummary
 	for i := range clusterSummary.Spec.ClusterProfileSpec.PolicyRefs {
 		reference := &clusterSummary.Spec.ClusterProfileSpec.PolicyRefs[i]

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -363,7 +363,8 @@ var _ = Describe("Hash methods", func() {
 		})
 		Expect(err).To(BeNil())
 
-		config := render.AsCode(configMap1.Data)
+		config := fmt.Sprintf("%v", clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.Reloader)
+		config += render.AsCode(configMap1.Data)
 		config += render.AsCode(configMap2.Data)
 		h := sha256.New()
 		h.Write([]byte(config))


### PR DESCRIPTION
If Reloader knob changes, code that deploys resources in the managed clusters needs to be triggered again as Reloader instance needs to be either deployed or withdrawn from managed clusters.