### PR TITLE
Helm compliance validations

### DIFF
--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -422,6 +422,8 @@ func collectContent(ctx context.Context, clusterSummary *configv1alpha1.ClusterS
 				continue
 			}
 
+			section = elements[i]
+
 			if instantiateTemplate {
 				instance, err := instantiateTemplateValues(ctx, getManagementClusterConfig(), getManagementClusterClient(),
 					clusterSummary.Spec.ClusterType, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
@@ -460,6 +462,8 @@ func getUnstructured(section []byte, logger logr.Logger) ([]*unstructured.Unstru
 		if section == "" {
 			continue
 		}
+
+		section = elements[i]
 
 		policy, err := utils.GetUnstructured([]byte(section))
 		if err != nil {


### PR DESCRIPTION
When an Helm chart contains Custom Resource Definitions and instances of such resources, helm dry run will fail.
This behavior will be documented in sveltos documentation when covering add-on compliance policies.

Code has been adjusted to only run validation for Helm chart resources if there is at least one compliance policy. This will avoid un-necessarily run helm install in dry run mode.

Fixes #308 