### PR TITLE
Make management referenced resource name template

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -144,3 +144,7 @@ var (
 	ConvertResourceReportsToObjectReference = convertResourceReportsToObjectReference
 	ConvertHelmResourcesToObjectReference   = convertHelmResourcesToObjectReference
 )
+
+var (
+	GetMgmtResourceName = getMgmtResourceName
+)

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -262,6 +262,30 @@ var _ = Describe("getClusterProfileOwner ", func() {
 		Expect(currentClusterSummary).ToNot(BeNil())
 		Expect(currentClusterSummary.Name).To(Equal(clusterSummary.Name))
 	})
+
+	It("getMgmtResourceName returns the correct name", func() {
+		ref := &configv1alpha1.TemplateResourceRef{
+			Resource: corev1.ObjectReference{
+				Name: "{{ .ClusterNamespace }}-{{ .ClusterName }}",
+			},
+			Identifier: randomString(),
+		}
+
+		clusterSummary := &configv1alpha1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cs" + randomString(),
+			},
+			Spec: configv1alpha1.ClusterSummarySpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
+			},
+		}
+
+		value, err := controllers.GetMgmtResourceName(clusterSummary, ref)
+		Expect(err).To(BeNil())
+		Expect(value).To(Equal(cluster.Namespace + "-" + cluster.Name))
+	})
 })
 
 func getClusterRef(cluster client.Object) *corev1.ObjectReference {


### PR DESCRIPTION
When referencing resources present in the management cluster allow name to be a function of cluster info: cluster namespace, name and type.

For instance Sveltos might be instructed to create: 1.crossplane resources which end creating a google storage bucket for each matching cluster
2. take bucket information and then pass to resources in the managed cluster so to be used

In such a case, we want the crossplane Bucket resource to have a unique name per cluster. And we want Sveltos to know what that name is.

```
apiVersion: config.projectsveltos.io/v1alpha1
kind: ClusterProfile
metadata:
  name: deploy-resources
spec:
  clusterSelector: env=fv
  templateResourceRefs:
  - resource:
      apiVersion: storage.cp.upbound.io/v1beta1
      kind: Bucket
      name: bucket-{{ .ClusterNamespace }}-{{ .ClusterName }}
    identifier: Bucket
  policyRefs:
  - deploymentType: Local
    kind: ConfigMap
    name: bucket
    namespace: default
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: bucket
  namespace: default
  annotations:
    projectsveltos.io/template: "true"
data:
  bucket.yaml: |
    apiVersion: storage.gcp.upbound.io/v1beta1
    kind: Bucket
    metadata:
     name: bucket-{{ .Cluster.metadata.namespace }}-{{ .Cluster.metadata.name }}
     labels:
       docs.crossplane.io/example: provider-gcp
       clustername: {{ .Cluster.metadata.name }}
       clusternamespace: {{ .Cluster.metadata.namespace }}
    spec:
      forProvider:
        location: US
      providerConfigRef:
        name: default
```