### PR TITLE
Reconcile ClusterSummary when ConfigMap/Secret annotations change

### DIFF
--- a/controllers/clustersummary_predicates.go
+++ b/controllers/clustersummary_predicates.go
@@ -53,6 +53,13 @@ func ConfigMapPredicates(logger logr.Logger) predicate.Funcs {
 				return true
 			}
 
+			if !reflect.DeepEqual(oldConfigMap.Annotations, newConfigMap.Annotations) {
+				log.V(logs.LogVerbose).Info(
+					"ConfigMap Annotation changed. Will attempt to reconcile associated ClusterSummaries.",
+				)
+				return true
+			}
+
 			if !reflect.DeepEqual(oldConfigMap.BinaryData, newConfigMap.BinaryData) {
 				log.V(logs.LogVerbose).Info(
 					"ConfigMap BinaryData changed. Will attempt to reconcile associated ClusterSummaries.",
@@ -96,6 +103,13 @@ func SecretPredicates(logger logr.Logger) predicate.Funcs {
 			if !reflect.DeepEqual(oldSecret.Data, newSecret.Data) {
 				log.V(logs.LogVerbose).Info(
 					"Secret Data changed. Will attempt to reconcile associated ClusterSummaries.",
+				)
+				return true
+			}
+
+			if !reflect.DeepEqual(oldSecret.Annotations, newSecret.Annotations) {
+				log.V(logs.LogVerbose).Info(
+					"Secret Annotation changed. Will attempt to reconcile associated ClusterSummaries.",
 				)
 				return true
 			}

--- a/controllers/clustersummary_predicates_test.go
+++ b/controllers/clustersummary_predicates_test.go
@@ -147,6 +147,27 @@ var _ = Describe("Clustersummary Predicates: ConfigMapPredicates", func() {
 		result := configMapPredicate.Update(e)
 		Expect(result).To(BeFalse())
 	})
+
+	It("Update returns true when annotations changed", func() {
+		configMapPredicate := controllers.ConfigMapPredicates(logger)
+		configMap.Annotations = map[string]string{
+			"projectsveltos.io/template": "true",
+		}
+
+		oldConfigMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMap.Name,
+			},
+		}
+
+		e := event.UpdateEvent{
+			ObjectNew: configMap,
+			ObjectOld: oldConfigMap,
+		}
+
+		result := configMapPredicate.Update(e)
+		Expect(result).To(BeTrue())
+	})
 })
 
 var _ = Describe("Clustersummary Predicates: SecretPredicates", func() {
@@ -221,6 +242,27 @@ var _ = Describe("Clustersummary Predicates: SecretPredicates", func() {
 
 		result := secretPredicate.Update(e)
 		Expect(result).To(BeFalse())
+	})
+
+	It("Update returns true when annotations changed", func() {
+		secretPredicate := controllers.SecretPredicates(logger)
+		secret.Annotations = map[string]string{
+			"projectsveltos.io/template": "true",
+		}
+
+		oldSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: secret.Name,
+			},
+		}
+
+		e := event.UpdateEvent{
+			ObjectNew: secret,
+			ObjectOld: oldSecret,
+		}
+
+		result := secretPredicate.Update(e)
+		Expect(result).To(BeTrue())
 	})
 })
 


### PR DESCRIPTION
When annotations of a referenced ConfigMap/Secret changes, reconcile ClusterSummary pointing to it.

This fixes #315