### PR TITLE
ClusterSummary behavior when cluster is not found

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -44,6 +44,7 @@ var (
 	UpdateChartMap       = (*ClusterSummaryReconciler).updateChartMap
 	ShouldRedeploy       = (*ClusterSummaryReconciler).shouldRedeploy
 	CanRemoveFinalizer   = (*ClusterSummaryReconciler).canRemoveFinalizer
+	ReconcileDelete      = (*ClusterSummaryReconciler).reconcileDelete
 
 	ConvertResultStatus               = (*ClusterSummaryReconciler).convertResultStatus
 	RequeueClusterSummaryForReference = (*ClusterSummaryReconciler).requeueClusterSummaryForReference


### PR DESCRIPTION
When cluster associated to a ClusterSummary instance is deleted there is no cleanup needed in the cluster.
In such a case, ClusterSummaryReconciler can remove finalizer and simply clean internal data structures.

Tested locally:
1. make quickstart
2. create a ClusterProfile that deploys an helm chart in the managed cluster
3. kubectl delete cluster clusterapi-workload

Before this PR, clusterSummary and ClusterConfiguration instance were incorrectly left in the management cluster.

After this PR, ClusterSummary and ClusterConfiguration instance are deleted.

Fixes #325 