### PR TITLE
Drift-detection-manager resources in management cluster

### DIFF
--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -214,6 +214,7 @@ func deployDriftDetectionManager(ctx context.Context, remoteRestConfig *rest.Con
 	clusterNamespace, clusterName, mode string, clusterType libsveltosv1alpha1.ClusterType,
 	logger logr.Logger) error {
 
+	logger.V(logs.LogDebug).Info("deploy drift-detection-manager in managed cluster")
 	driftDetectionManagerYAML := string(driftdetection.GetDriftDetectionManagerYAML())
 
 	driftDetectionManagerYAML = prepareDriftDetectionManagerYAML(driftDetectionManagerYAML, clusterNamespace,
@@ -230,6 +231,7 @@ func deployDriftDetectionManagerInManagementCluster(ctx context.Context, restCon
 	clusterNamespace, clusterName, mode string, clusterType libsveltosv1alpha1.ClusterType,
 	logger logr.Logger) error {
 
+	logger.V(logs.LogDebug).Info("deploy drift-detection-manager in management cluster")
 	driftDetectionManagerYAML := string(driftdetection.GetDriftDetectionManagerInMgmtClusterYAML())
 
 	driftDetectionManagerYAML = prepareDriftDetectionManagerYAML(driftDetectionManagerYAML, clusterNamespace,
@@ -471,6 +473,7 @@ func getDriftDetectionManagerLabels(clusterNamespace, clusterName string,
 	lbls["cluster-namespace"] = clusterNamespace
 	lbls["cluster-name"] = clusterName
 	lbls["cluster-type"] = strings.ToLower(string(clusterType))
+	lbls["feature"] = "drift-detection"
 	return lbls
 }
 


### PR DESCRIPTION
Add an extra label identifying those resources are deployed for drift-detection feature.

Sveltos has two agents that can be deployed in the management cluster:
1. sveltos-agent
2. drift-detection-manager

By default those are installed in the managed cluster but sveltos has an option to be instructed to deploy those in the management cluster.

When deployed in the management cluster, those resources are in the `projectsveltos` namespace and a set of resources (service plus deployment) is deployed for each managed cluster.

Sveltos adds labels to those resources and use those labels to:
1. identify whether resources are already deployed
2. remove those resources when cluster is deleted

Before this PR, labels added on sveltos-agent resources and drift-detection-manager resources were same, so there was no way to differentiate.

This PR adds an extra label to solve this problem.