### PR TITLE
Add extra annotation

### DIFF
--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -475,7 +475,7 @@ var _ = Describe("HandlersUtils", func() {
 		// Because ClusterSummary is not referencing any ConfigMap/Resource and because test created a ClusterRole
 		// pretending it was created by this ClusterSummary instance, UndeployStaleResources will remove no instance as
 		// syncMode is dryRun and will report one instance (ClusterRole created above) would be undeployed
-		undeploy, err := controllers.UndeployStaleResources(context.TODO(), testEnv.Config, testEnv.Client,
+		undeploy, err := controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
 			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, nil, klogr.New())
 		Expect(err).To(BeNil())
 		Expect(len(undeploy)).To(Equal(1))
@@ -592,7 +592,7 @@ var _ = Describe("HandlersUtils", func() {
 		Expect(deployedGKVs).ToNot(BeEmpty())
 		// undeployStaleResources finds all instances of policies deployed because of clusterSummary and
 		// removes the stale ones.
-		_, err := controllers.UndeployStaleResources(context.TODO(), testEnv.Config, testEnv.Client,
+		_, err := controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
 			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, currentClusterRoles, klogr.New())
 		Expect(err).To(BeNil())
 
@@ -616,7 +616,7 @@ var _ = Describe("HandlersUtils", func() {
 		delete(currentClusterRoles, controllers.GetPolicyInfo(clusterRoleResource1))
 		delete(currentClusterRoles, controllers.GetPolicyInfo(clusterRoleResource2))
 
-		_, err = controllers.UndeployStaleResources(context.TODO(), testEnv.Config, testEnv.Client,
+		_, err = controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
 			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, currentClusterRoles, klogr.New())
 		Expect(err).To(BeNil())
 

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -333,8 +333,8 @@ func deployResourceSummaryInstance(ctx context.Context, remoteClient client.Clie
 					Name:      getResourceSummaryName(clusterNamespace, applicant),
 					Namespace: getResourceSummaryNamespace(),
 					Labels: map[string]string{
-						libsveltosv1alpha1.ClusterSummaryLabelName:      applicant,
-						libsveltosv1alpha1.ClusterSummaryLabelNamespace: clusterNamespace,
+						libsveltosv1alpha1.ClusterSummaryNameLabel:      applicant,
+						libsveltosv1alpha1.ClusterSummaryNamespaceLabel: clusterNamespace,
 					},
 				},
 			}
@@ -365,8 +365,8 @@ func deployResourceSummaryInstance(ctx context.Context, remoteClient client.Clie
 	if currentResourceSummary.Labels == nil {
 		currentResourceSummary.Labels = map[string]string{}
 	}
-	currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryLabelName] = applicant
-	currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryLabelNamespace] = clusterNamespace
+	currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryNameLabel] = applicant
+	currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryNamespaceLabel] = clusterNamespace
 
 	logger.V(logsettings.LogDebug).Info("resourceSummary instance already present. updating it.")
 	return remoteClient.Update(ctx, currentResourceSummary)

--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -124,14 +124,14 @@ func processResourceSummary(ctx context.Context, c, remoteClient client.Client,
 	}
 
 	// Get ClusterSummary
-	clusterSummaryName, ok := rs.Labels[libsveltosv1alpha1.ClusterSummaryLabelName]
+	clusterSummaryName, ok := rs.Labels[libsveltosv1alpha1.ClusterSummaryNameLabel]
 	if !ok {
 		logger.V(logs.LogInfo).Info("clusterSummary name label not set. Cannot process it")
 		return nil
 	}
 
 	var clusterSummaryNamespace string
-	clusterSummaryNamespace, ok = rs.Labels[libsveltosv1alpha1.ClusterSummaryLabelNamespace]
+	clusterSummaryNamespace, ok = rs.Labels[libsveltosv1alpha1.ClusterSummaryNamespaceLabel]
 	if !ok {
 		logger.V(logs.LogInfo).Info("clusterSummaryspace name label not set. Cannot process it")
 		return nil

--- a/controllers/resourcesummary_collection_test.go
+++ b/controllers/resourcesummary_collection_test.go
@@ -91,8 +91,8 @@ var _ = Describe("ResourceSummary Collection", func() {
 
 		resourceSummary := getResourceSummary(nil, nil)
 		resourceSummary.Labels = map[string]string{
-			libsveltosv1alpha1.ClusterSummaryLabelName:      clusterSummary.Name,
-			libsveltosv1alpha1.ClusterSummaryLabelNamespace: clusterSummary.Namespace,
+			libsveltosv1alpha1.ClusterSummaryNameLabel:      clusterSummary.Name,
+			libsveltosv1alpha1.ClusterSummaryNamespaceLabel: clusterSummary.Namespace,
 		}
 		Expect(testEnv.Create(context.TODO(), resourceSummary)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv.Client, resourceSummary)).To(Succeed())

--- a/controllers/resourcesummary_test.go
+++ b/controllers/resourcesummary_test.go
@@ -86,11 +86,11 @@ var _ = Describe("ResourceSummary Deployer", func() {
 			},
 			currentResourceSummary)).To(Succeed())
 		Expect(currentResourceSummary.Labels).ToNot(BeNil())
-		v, ok := currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryLabelName]
+		v, ok := currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryNameLabel]
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal(clusterSummaryName))
 
-		v, ok = currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryLabelNamespace]
+		v, ok = currentResourceSummary.Labels[libsveltosv1alpha1.ClusterSummaryNamespaceLabel]
 		Expect(ok).To(BeTrue())
 		Expect(v).To(Equal(clusterNamespace))
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -77,15 +77,24 @@ func InitScheme() (*runtime.Scheme, error) {
 	return s, nil
 }
 
+func getPrefix(clusterType libsveltosv1alpha1.ClusterType) string {
+	prefix := "capi"
+	if clusterType == libsveltosv1alpha1.ClusterTypeSveltos {
+		prefix = "sveltos"
+	}
+	return prefix
+}
+
 // GetClusterSummaryName returns the ClusterSummary name given a ClusterProfile name and
 // CAPI cluster Namespace/Name.
 // This method does not guarantee that name is not already in use. Caller of this method needs
 // to handle that scenario
 func GetClusterSummaryName(clusterProfileName, clusterName string, isSveltosCluster bool) string {
-	prefix := "capi"
+	clusterType := libsveltosv1alpha1.ClusterTypeCapi
 	if isSveltosCluster {
-		prefix = "sveltos"
+		clusterType = libsveltosv1alpha1.ClusterTypeSveltos
 	}
+	prefix := getPrefix(clusterType)
 	return fmt.Sprintf("%s-%s-%s", clusterProfileName, prefix, clusterName)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.0
 	github.com/onsi/gomega v1.29.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.19.1-0.20231029140049-048f7f2b4d99
+	github.com/projectsveltos/libsveltos v0.19.1-0.20231117122544-3c508832d1a8
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -334,8 +334,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
-github.com/projectsveltos/libsveltos v0.19.1-0.20231029140049-048f7f2b4d99 h1:MRQ3WE+6xEKgGIGMZ1vdYa+4dZ5bs1ZVCfurJ9qBNls=
-github.com/projectsveltos/libsveltos v0.19.1-0.20231029140049-048f7f2b4d99/go.mod h1:Rw0WKmazMNWg16cGfN7qzE1RP5PstR44QNlAXRAh8xM=
+github.com/projectsveltos/libsveltos v0.19.1-0.20231117122544-3c508832d1a8 h1:uYTEQa0cDMFMXU1hDBXxXIvfIPyUr1Z26uJpj522l6E=
+github.com/projectsveltos/libsveltos v0.19.1-0.20231117122544-3c508832d1a8/go.mod h1:Rw0WKmazMNWg16cGfN7qzE1RP5PstR44QNlAXRAh8xM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/test/fv/onetime_test.go
+++ b/test/fv/onetime_test.go
@@ -67,7 +67,8 @@ var _ = Describe("SyncMode one time", func() {
 		Expect(k8sClient.Create(context.TODO(), ns)).To(Succeed())
 
 		Byf("Create a configMap with a Namespace")
-		configMap := createConfigMapWithPolicy(configMapNs, namePrefix+randomString(), fmt.Sprintf(oneTimeNamespace, oneTimeNamespaceName))
+		configMap := createConfigMapWithPolicy(configMapNs, namePrefix+randomString(),
+			fmt.Sprintf(oneTimeNamespace, oneTimeNamespaceName))
 
 		Expect(k8sClient.Create(context.TODO(), configMap)).To(Succeed())
 
@@ -149,7 +150,10 @@ var _ = Describe("SyncMode one time", func() {
 		Eventually(func() bool {
 			currentNamespace := &corev1.Namespace{}
 			err = workloadClient.Get(context.TODO(), types.NamespacedName{Name: oneTimeNamespaceName}, currentNamespace)
-			return apierrors.IsNotFound(err)
+			if err != nil {
+				return apierrors.IsNotFound(err)
+			}
+			return !currentNamespace.DeletionTimestamp.IsZero()
 		}, timeout, pollingInterval).Should(BeTrue())
 	})
 })


### PR DESCRIPTION
When deploying resources in the management add an extra annotation to indicate the clusterSummary instance, and so the managed cluster, for which the resource was created.

Resources deployed by Projectsveltos have ClusterProfile as OwnerReference(s). In managed cluster that is enough to identify stale resources (resources deployed by Projectsveltos which now needs to be removed). OwnerReference is not enough for resources deployed by Projectsveltos in the management cluster. For instance, a ClusterProfile:
- matching N managed clusters
- requested to create a crossplane Bucket instabce

will create N Bucket instances in the management cluster. One per matching managed cluster.

If a managed cluster stops being a match, resources deployed for the managed cluster needs to be removed. This include the Bucket instance deployed in the management cluster.

Projectsveltos logic used to:
1. query all Bucket instances deployed by Projectsveltos;
2. if the OwnerReference was the ClusterProfile, which is now cleaning, remove ClusterProfile as OwnerReference and if no other OwnerReference was present, delete the resource

Above logic though, cleaned also up all the Bucket instances for the other managed clusters.

This PR adds new annotation for resources deployed by Projectsveltos in the management cluster indicating the mananged cluster for which resource was created. This allows to fix above logic by simply adding an extra check:
- when cleaning up stale resources deployed by Projectsveltos in the management cluster for a given managed cluster, this new annotation has to match, otherwise resources are ignored.

Closes #383 