### PR TITLE
Clean ClusterSummary and ClusterReport instances

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -18,7 +18,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: controller
       labels:
         control-plane: addon-controller
     spec:

--- a/controllers/clusterprofile_predicates_test.go
+++ b/controllers/clusterprofile_predicates_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ClusterProfile Predicates: SvelotsClusterPredicates", func() {
 	var cluster *libsveltosv1alpha1.SveltosCluster
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		cluster = &libsveltosv1alpha1.SveltosCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      upstreamClusterNamePrefix + randomString(),
@@ -221,7 +221,7 @@ var _ = Describe("ClusterProfile Predicates: ClusterPredicates", func() {
 	var cluster *clusterv1.Cluster
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		cluster = &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      upstreamClusterNamePrefix + randomString(),
@@ -378,7 +378,7 @@ var _ = Describe("ClusterProfile Predicates: MachinePredicates", func() {
 	var machine *clusterv1.Machine
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		machine = &clusterv1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      upstreamMachineNamePrefix + randomString(),

--- a/controllers/clustersummary_controller_test.go
+++ b/controllers/clustersummary_controller_test.go
@@ -165,7 +165,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -182,7 +182,7 @@ var _ = Describe("ClustersummaryController", func() {
 		}
 
 		Expect(controllers.ShouldReconcile(reconciler, clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("updateChartMap updates chartMap always but in DryRun mode", func() {
@@ -202,7 +202,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -219,7 +219,7 @@ var _ = Describe("ClustersummaryController", func() {
 		}
 
 		Expect(controllers.UpdateChartMap(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), c)
 		Expect(err).To(BeNil())
@@ -270,7 +270,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -286,7 +286,7 @@ var _ = Describe("ClustersummaryController", func() {
 			PolicyMux:         sync.Mutex{},
 		}
 
-		Expect(controllers.ShouldReconcile(reconciler, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+		Expect(controllers.ShouldReconcile(reconciler, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("shouldReconcile returns true when mode is OneTime but not all helm charts are deployed", func() {
@@ -308,7 +308,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -325,7 +325,7 @@ var _ = Describe("ClustersummaryController", func() {
 		}
 
 		Expect(controllers.ShouldReconcile(reconciler, clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("shouldReconcile returns false when mode is OneTime and policies and helm charts are deployed", func() {
@@ -351,7 +351,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -368,7 +368,7 @@ var _ = Describe("ClustersummaryController", func() {
 		}
 
 		Expect(controllers.ShouldReconcile(reconciler, clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 	})
 
 	It("Adds finalizer", func() {
@@ -380,7 +380,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
@@ -426,7 +426,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
@@ -440,7 +440,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -450,7 +450,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// In SyncMode DryRun even if config is same (input for ShouldRedeploy) result is redeploy
 		Expect(controllers.ShouldRedeploy(reconciler, clusterSummaryScope, f, true,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 
 		clusterSummaryName := client.ObjectKey{
 			Name:      clusterSummary.Name,
@@ -467,7 +467,7 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope.ClusterSummary = currentClusterSummary
 		// In SyncMode != DryRun and if config is same (input for ShouldRedeploy) result is do not redeploy
 		Expect(controllers.ShouldRedeploy(reconciler, clusterSummaryScope, f, true,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 	})
 
 	It("canRemoveFinalizer in DryRun returns true when ClusterSummary and ClusterProfile are deleted", func() {
@@ -484,7 +484,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
 			Scheme:            scheme,
@@ -497,7 +497,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -505,7 +505,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// ClusterSummary not marked for deletion. So cannot remove finalizer
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 
 		// Mark ClusterSummary for deletion
 		now := metav1.NewTime(time.Now())
@@ -514,7 +514,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// ClusterProfile is not marked for deletion. So cannot remove finalizer
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 
 		// Mark ClusterProfile for deletion
 		currentClusterProfile := &configv1alpha1.ClusterProfile{}
@@ -525,7 +525,7 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope.Profile = currentClusterProfile
 
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("canRemoveFinalizer in not DryRun returns true when ClusterSummary is deleted and features removed", func() {
@@ -548,7 +548,7 @@ var _ = Describe("ClustersummaryController", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
 		deployer := fakedeployer.GetClient(context.TODO(),
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+			textlogger.NewLogger(textlogger.NewConfig()), c)
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
 			Scheme:            scheme,
@@ -561,14 +561,14 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
 		Expect(err).To(BeNil())
 
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 
 		// Mark ClusterSummary for deletion
 		now := metav1.NewTime(time.Now())
@@ -578,7 +578,7 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope.ClusterSummary = clusterSummary
 
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 
 		// Mark all features as removed
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -589,7 +589,7 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope.ClusterSummary = clusterSummary
 
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("canRemoveFinalizer returns true when Cluster is gone", func() {
@@ -610,7 +610,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
 			Scheme:            scheme,
@@ -623,7 +623,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -631,7 +631,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// Since ClusterSummary is not yet marked for deletion, finalizer cannot be removed
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeFalse())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
 
 		// Mark ClusterSummary for deletion
 		now := metav1.NewTime(time.Now())
@@ -640,7 +640,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// Because CAPI cluster does not exist and ClusterSummary is marked for deletion, finalizer can be removed
 		Expect(controllers.CanRemoveFinalizer(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeTrue())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
 	It("getCurrentReferences collects all ClusterSummary referenced objects", func() {
@@ -656,7 +656,7 @@ var _ = Describe("ClustersummaryController", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		clusterSummaryScope := getClusterSummaryScope(c,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), clusterProfile, clusterSummary)
+			textlogger.NewLogger(textlogger.NewConfig()), clusterProfile, clusterSummary)
 		reconciler := getClusterSummaryReconciler(nil, nil)
 		set := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
 		Expect(set.Len()).To(Equal(1))
@@ -672,7 +672,7 @@ var _ = Describe("ClustersummaryController", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		clusterSummaryScope := getClusterSummaryScope(c,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), clusterProfile, clusterSummary)
+			textlogger.NewLogger(textlogger.NewConfig()), clusterProfile, clusterSummary)
 		reconciler := getClusterSummaryReconciler(nil, nil)
 		set := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
 		Expect(set.Len()).To(Equal(1))
@@ -700,12 +700,12 @@ var _ = Describe("ClustersummaryController", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		clusterSummaryReconciler := getClusterSummaryReconciler(c, dep)
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -713,7 +713,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		var result reconcile.Result
 		result, err = controllers.ReconcileDelete(clusterSummaryReconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(result.Requeue).To(BeFalse())
 	})
@@ -797,7 +797,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		addOwnerReference(context.TODO(), c, clusterSummary, clusterProfile)
 
-		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		deployer := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		reconciler := &controllers.ClusterSummaryReconciler{
 			Client:            c,
 			Scheme:            scheme,
@@ -810,7 +810,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -818,7 +818,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// because dependencies are not provisioned
 		deployed, _, err := controllers.AreDependenciesDeployed(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(deployed).To(BeFalse())
 
@@ -836,7 +836,7 @@ var _ = Describe("ClustersummaryController", func() {
 
 		// because dependencies are not all provisioned
 		deployed, _, err = controllers.AreDependenciesDeployed(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(deployed).To(BeFalse())
 
@@ -857,7 +857,7 @@ var _ = Describe("ClustersummaryController", func() {
 		Expect(c.Status().Update(context.TODO(), clusterSummaryB)).To(Succeed())
 		// because dependencies are  all provisioned
 		deployed, _, err = controllers.AreDependenciesDeployed(reconciler, context.TODO(), clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(deployed).To(BeTrue())
 	})
@@ -995,7 +995,7 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 			Namespace: referencingClusterSummary.Namespace,
 		}
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Client)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), testEnv.Client)
 		Expect(dep.RegisterFeatureID(string(configv1alpha1.FeatureResources))).To(Succeed())
 		clusterSummaryReconciler := getClusterSummaryReconciler(testEnv.Client, dep)
 
@@ -1053,7 +1053,7 @@ var _ = Describe("ClusterSummaryReconciler: requeue methods", func() {
 			Namespace: referencingClusterSummary.Namespace,
 		}
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Client)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), testEnv.Client)
 		Expect(dep.RegisterFeatureID(string(configv1alpha1.FeatureResources))).To(Succeed())
 		clusterSummaryReconciler := getClusterSummaryReconciler(testEnv.Client, dep)
 

--- a/controllers/clustersummary_deployer_test.go
+++ b/controllers/clustersummary_deployer_test.go
@@ -35,11 +35,11 @@ var _ = Describe("ClustersummaryDeployer", func() {
 	var clusterName string
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 
 		namespace = randomString()
 
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 
 		clusterProfile = &configv1alpha1.ClusterProfile{
 			ObjectMeta: metav1.ObjectMeta{
@@ -184,7 +184,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		status := configv1alpha1.FeatureStatusFailed
 		statusErr := fmt.Errorf("failed to deploy")
 		controllers.UpdateFeatureStatus(reconciler, clusterSummaryScope, configv1alpha1.FeatureResources, &status,
-			hash, statusErr, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			hash, statusErr, textlogger.NewLogger(textlogger.NewConfig()))
 
 		Expect(len(clusterSummary.Status.FeatureSummaries)).To(Equal(1))
 		Expect(clusterSummary.Status.FeatureSummaries[0].FeatureID).To(Equal(configv1alpha1.FeatureResources))
@@ -194,7 +194,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		status = configv1alpha1.FeatureStatusProvisioned
 		controllers.UpdateFeatureStatus(reconciler, clusterSummaryScope, configv1alpha1.FeatureResources, &status,
-			hash, nil, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			hash, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(clusterSummary.Status.FeatureSummaries[0].FeatureID).To(Equal(configv1alpha1.FeatureResources))
 		Expect(clusterSummary.Status.FeatureSummaries[0].Status).To(Equal(configv1alpha1.FeatureStatusProvisioned))
 		Expect(clusterSummary.Status.FeatureSummaries[0].FailureMessage).To(BeNil())
@@ -231,7 +231,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(c, logger, clusterProfile, clusterSummary)
 
-		ResourcesHash, err := controllers.ResourcesHash(ctx, c, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		ResourcesHash, err := controllers.ResourcesHash(ctx, c, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -244,7 +244,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		Expect(c.Status().Update(context.TODO(), clusterSummary)).To(Succeed())
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 
 		reconciler := getClusterSummaryReconciler(c, dep)
 
@@ -255,7 +255,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		// DeployeFeature is supposed to return before calling dep.Deploy (fake deployer Deploy once called simply
 		// adds key to InProgress).
 		// So run DeployFeature then validate key is not added to InProgress
-		err = controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err = controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
@@ -292,7 +292,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(testEnv.Client, logger, clusterProfile, clusterSummary)
 
-		ResourcesHash, err := controllers.ResourcesHash(ctx, testEnv.Client, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		ResourcesHash, err := controllers.ResourcesHash(ctx, testEnv.Client, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
 			{
@@ -318,7 +318,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 			return reflect.DeepEqual(configMap.Data, clusterConfigMap.Data)
 		}, timeout, pollingInterval).Should(BeTrue())
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Client)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), testEnv.Client)
 
 		reconciler := getClusterSummaryReconciler(testEnv.Client, dep)
 
@@ -328,7 +328,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		// does not match anymore the hash of all referenced ResourceRefs). In such situation, DeployFeature calls dep.Deploy.
 		// fake deployer Deploy simply adds key to InProgress.
 		// So run DeployFeature then validate key is added to InProgress
-		err = controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err = controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(Equal("request is queued"))
 
@@ -367,7 +367,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(testEnv.Client, logger, clusterProfile, clusterSummary)
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Client)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), testEnv.Client)
 
 		reconciler := getClusterSummaryReconciler(testEnv.Client, dep)
 
@@ -376,7 +376,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		// The feature is not marked as deployed in ClusterSummary Status. In such situation, DeployFeature calls dep.Deploy.
 		// fake deployer Deploy simply adds key to InProgress.
 		// So run DeployFeature then validate key is added to InProgress
-		err := controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err := controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(Equal("request is queued"))
 
@@ -405,7 +405,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		Expect(c.Status().Update(context.TODO(), clusterSummary)).To(Succeed())
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 
 		reconciler := getClusterSummaryReconciler(c, dep)
 
@@ -415,7 +415,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		// UndeployFeature is supposed to return before calling dep.Deploy (fake deployer Deploy once called simply
 		// adds key to InProgress).
 		// So run UndeployFeature then validate key is not added to InProgress
-		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		key := deployer.GetKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
@@ -442,7 +442,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(c, logger, clusterProfile, clusterSummary)
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 
 		reconciler := getClusterSummaryReconciler(c, dep)
 
@@ -451,7 +451,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 		// The feature is not marked as removed in ClusterSummary Status. In such situation, UndeployFeature calls dep.Deploy.
 		// fake deployer Deploy simply adds key to InProgress.
 		// So run UndeployFeature then validate key is added to InProgress
-		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(Equal("cleanup request is queued"))
 
@@ -479,7 +479,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(c, logger, clusterProfile, clusterSummary)
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		dep.StoreInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
 			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, true)
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -490,7 +490,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		f := controllers.GetHandlersForFeature(configv1alpha1.FeatureResources)
 
-		err := controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err := controllers.DeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(Equal("cleanup of Resources still in progress. Wait before redeploying"))
 	})
@@ -514,7 +514,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		clusterSummaryScope := getClusterSummaryScope(c, logger, clusterProfile, clusterSummary)
 
-		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), c)
+		dep := fakedeployer.GetClient(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), c)
 		dep.StoreInProgress(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
 			clusterSummary.Name, string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, false)
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -525,7 +525,7 @@ var _ = Describe("ClustersummaryDeployer", func() {
 
 		f := controllers.GetHandlersForFeature(configv1alpha1.FeatureResources)
 
-		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err := controllers.UndeployFeature(reconciler, context.TODO(), clusterSummaryScope, f, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error()).To(Equal("deploying Resources still in progress. Wait before cleanup"))
 	})

--- a/controllers/clustersummary_predicates_test.go
+++ b/controllers/clustersummary_predicates_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Clustersummary Predicates: ConfigMapPredicates", func() {
 	var configMap *corev1.ConfigMap
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		configMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
@@ -176,7 +176,7 @@ var _ = Describe("Clustersummary Predicates: SecretPredicates", func() {
 	var secret *corev1.Secret
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: randomString(),
@@ -272,7 +272,7 @@ var _ = Describe("ClusterProfile Predicates: FluxSourcePredicates", func() {
 	var gitRepository *sourcev1.GitRepository
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1)))
+		logger = textlogger.NewLogger(textlogger.NewConfig())
 		gitRepository = &sourcev1.GitRepository{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      upstreamClusterNamePrefix + randomString(),

--- a/controllers/clustersummary_transformations.go
+++ b/controllers/clustersummary_transformations.go
@@ -37,7 +37,7 @@ func (r *ClusterSummaryReconciler) requeueClusterSummaryForFluxSource(
 	ctx context.Context, o client.Object,
 ) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
 		"objectMapper",
 		"requeueClusterSummaryForFluxSources",
 		"reference",
@@ -104,7 +104,7 @@ func (r *ClusterSummaryReconciler) requeueClusterSummaryForReference(
 	ctx context.Context, o client.Object,
 ) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
 		"objectMapper",
 		"requeueClusterSummaryForConfigMap",
 		"reference",
@@ -167,7 +167,7 @@ func (r *ClusterSummaryReconciler) requeueClusterSummaryForCluster(
 ) []reconcile.Request {
 
 	cluster := o
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
 		"objectMapper",
 		"requeueClusterSummaryForCluster",
 		"namespace",

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -134,9 +134,9 @@ var _ = BeforeSuite(func() {
 	// Sometimes we otherwise get "no matches for kind "AddonCompliance" in version "lib.projectsveltos.io/v1alpha1"
 	time.Sleep(2 * time.Second)
 
-	controllers.InitializeManager(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+	controllers.InitializeManager(textlogger.NewLogger(textlogger.NewConfig()),
 		testEnv.Config, testEnv.GetClient())
-	compliances.InitializeManager(ctx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+	compliances.InitializeManager(ctx, textlogger.NewLogger(textlogger.NewConfig()),
 		testEnv.Config, testEnv.Client, 1)
 
 	Eventually(func() bool {
@@ -150,7 +150,7 @@ var _ = BeforeSuite(func() {
 
 	// Do this read so library is initialized with CAPI present
 	_, err = clusterproxy.GetListOfClusters(context.TODO(), testEnv.Client, "",
-		textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		textlogger.NewLogger(textlogger.NewConfig()))
 	Expect(err).To(BeNil())
 })
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -20,12 +20,12 @@ var (
 	UpdateClusterSummaries                = updateClusterSummaries
 	CreateClusterSummary                  = createClusterSummary
 	UpdateClusterSummary                  = updateClusterSummary
-	DeleteClusterSummary                  = deleteClusterSummary
 	UpdateClusterConfigurationWithProfile = updateClusterConfigurationWithProfile
 	CleanClusterConfiguration             = cleanClusterConfiguration
 	CleanClusterReports                   = cleanClusterReports
-	UpdateClusterReports                  = updateClusterReports
+	CleanClusterSummaries                 = cleanClusterSummaries
 	UpdateClusterSummarySyncMode          = updateClusterSummarySyncMode
+	UpdateClusterReports                  = updateClusterReports
 	GetMatchingClusters                   = getMatchingClusters
 	GetMaxUpdate                          = getMaxUpdate
 	ReviseUpdatedAndUpdatingClusters      = reviseUpdatedAndUpdatingClusters

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -339,7 +339,7 @@ var _ = Describe("HandlersHelm", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
 		Expect(controllers.UpdateChartsInClusterConfiguration(context.TODO(), c, clusterSummary,
-			chartDeployed, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			chartDeployed, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		currentClusterConfiguration := &configv1alpha1.ClusterConfiguration{}
 		Expect(c.Get(context.TODO(),
@@ -387,7 +387,7 @@ var _ = Describe("HandlersHelm", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
 		report, err := controllers.CreateReportForUnmanagedHelmRelease(context.TODO(), c, clusterSummary,
-			helmChart, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			helmChart, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(report).ToNot(BeNil())
 		Expect(report.Action).To(Equal(string(configv1alpha1.InstallHelmAction)))
@@ -505,14 +505,14 @@ var _ = Describe("HandlersHelm", func() {
 
 		Expect(waitForObject(context.TODO(), testEnv.Client, clusterReport)).To(Succeed())
 
-		kubeconfig, err := clusterproxy.CreateKubeconfig(textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Kubeconfig)
+		kubeconfig, err := clusterproxy.CreateKubeconfig(textlogger.NewLogger(textlogger.NewConfig()), testEnv.Kubeconfig)
 		Expect(err).To(BeNil())
 
 		// ClusterSummary in DryRun mode. Nothing registered with chartManager with respect to the two referenced
 		// helm chart. So expect action for Install will be install, and the action for Uninstall will be no action as
 		// such release has never been installed.
 		err = controllers.HandleCharts(context.TODO(), clusterSummary, testEnv.Client, testEnv.Client, kubeconfig,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 
 		var druRunError *configv1alpha1.DryRunReconciliationError
@@ -604,7 +604,7 @@ var _ = Describe("Hash methods", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -619,7 +619,7 @@ var _ = Describe("Hash methods", func() {
 		expectHash := h.Sum(nil)
 
 		hash, err := controllers.HelmHash(context.TODO(), c, clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(reflect.DeepEqual(hash, expectHash)).To(BeTrue())
 	})

--- a/controllers/handlers_kustomize_test.go
+++ b/controllers/handlers_kustomize_test.go
@@ -175,7 +175,7 @@ var _ = Describe("KustomizeRefs", func() {
 
 		Expect(controllers.GenericUndeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
 			string(configv1alpha1.FeatureKustomize), libsveltosv1alpha1.ClusterTypeCapi, deployer.Options{},
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// undeployKustomizeRefs finds all policies deployed because of a clusterSummary and deletes those.
 		// Expect ServiceAccount and ClusterRole to be deleted. ConfigMap should remain as Labels are not set on it
@@ -292,7 +292,7 @@ var _ = Describe("Hash methods", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -309,7 +309,7 @@ var _ = Describe("Hash methods", func() {
 		expectHash := h.Sum(nil)
 
 		hash, err := controllers.KustomizationHash(context.TODO(), c, clusterSummaryScope,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(reflect.DeepEqual(hash, expectHash)).To(BeTrue())
 	})

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -134,7 +134,7 @@ var _ = Describe("HandlersResource", func() {
 		Eventually(func() error {
 			return controllers.GenericDeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
 				string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, deployer.Options{},
-				textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+				textlogger.NewLogger(textlogger.NewConfig()))
 		}, timeout, pollingInterval).Should(BeNil())
 
 		// Eventual loop so testEnv Cache is synced
@@ -219,7 +219,7 @@ var _ = Describe("HandlersResource", func() {
 
 		Expect(controllers.GenericUndeploy(ctx, testEnv.Client, cluster.Namespace, cluster.Name, clusterSummary.Name,
 			string(configv1alpha1.FeatureResources), libsveltosv1alpha1.ClusterTypeCapi, deployer.Options{},
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// UnDeployResources finds all policies deployed because of a clusterSummary and deletes those.
 		// Expect role0 and cluster0 to be deleted. role1 should remain as ConfigLabelName is not set on it
@@ -274,7 +274,7 @@ var _ = Describe("HandlersResource", func() {
 		}
 
 		Expect(controllers.UpdateDeployedGroupVersionKind(context.TODO(), clusterSummary, configv1alpha1.FeatureResources,
-			localReports, remoteReports, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			localReports, remoteReports, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// wait for cache to sync
 		Eventually(func() bool {
@@ -360,7 +360,7 @@ var _ = Describe("Hash methods", func() {
 
 		clusterSummaryScope, err := scope.NewClusterSummaryScope(&scope.ClusterSummaryScopeParams{
 			Client:         c,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 			ClusterSummary: clusterSummary,
 			ControllerName: "clustersummary",
 		})
@@ -374,7 +374,7 @@ var _ = Describe("Hash methods", func() {
 		h.Write([]byte(config))
 		expectHash := h.Sum(nil)
 
-		hash, err := controllers.ResourcesHash(context.TODO(), c, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		hash, err := controllers.ResourcesHash(context.TODO(), c, clusterSummaryScope, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(reflect.DeepEqual(hash, expectHash)).To(BeTrue())
 	})

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -286,7 +286,7 @@ var _ = Describe("HandlersUtils", func() {
 		resourceReports, err := controllers.DeployContent(context.TODO(), false,
 			testEnv.Config, testEnv.Client,
 			secret, map[string]string{"service": services}, clusterSummary, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		By("Validating action for all resourceReports is Create")
 		validateResourceReports(resourceReports, 2, 0, 0, 0)
@@ -315,7 +315,7 @@ var _ = Describe("HandlersUtils", func() {
 		resourceReports, err = controllers.DeployContent(context.TODO(), false,
 			testEnv.Config, testEnv.Client,
 			secret, map[string]string{"service": services}, clusterSummary, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		By("Validating action for all resourceReports is NoAction")
 		validateResourceReports(resourceReports, 0, 0, 2, 0)
@@ -347,7 +347,7 @@ var _ = Describe("HandlersUtils", func() {
 		resourceReports, err = controllers.DeployContent(context.TODO(), false,
 			testEnv.Config, testEnv.Client,
 			secret, map[string]string{"service": newContent}, clusterSummary, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		By("Validating action for all resourceReports is Update")
 		validateResourceReports(resourceReports, 0, 2, 0, 0)
@@ -357,7 +357,7 @@ var _ = Describe("HandlersUtils", func() {
 		tmpSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: randomString(), Name: randomString()}}
 		resourceReports, err = controllers.DeployContent(context.TODO(), false,
 			testEnv.Config, testEnv.Client, tmpSecret, map[string]string{"service": services},
-			clusterSummary, nil, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			clusterSummary, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		By("Validating action for all resourceReports is Conflict")
 		validateResourceReports(resourceReports, 0, 0, 0, 2)
@@ -398,7 +398,7 @@ var _ = Describe("HandlersUtils", func() {
 
 		resourceReports, err := controllers.DeployContentOfSecret(context.TODO(), false,
 			testEnv.Config, testEnv.Client, secret, clusterSummary, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(len(resourceReports)).To(Equal(3))
 	})
@@ -417,7 +417,7 @@ var _ = Describe("HandlersUtils", func() {
 
 		resourceReports, err := controllers.DeployContentOfConfigMap(context.TODO(), false,
 			testEnv.Config, testEnv.Client, configMap, clusterSummary, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(len(resourceReports)).To(Equal(3))
 	})
@@ -482,7 +482,7 @@ var _ = Describe("HandlersUtils", func() {
 		// pretending it was created by this ClusterSummary instance, UndeployStaleResources will remove no instance as
 		// syncMode is dryRun and will report one instance (ClusterRole created above) would be undeployed
 		undeploy, err := controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
-			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, nil, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(len(undeploy)).To(Equal(1))
 
@@ -600,7 +600,7 @@ var _ = Describe("HandlersUtils", func() {
 		// removes the stale ones.
 		_, err := controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
 			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, currentClusterRoles,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		// Consistently loop so testEnv Cache is synced
@@ -625,7 +625,7 @@ var _ = Describe("HandlersUtils", func() {
 
 		_, err = controllers.UndeployStaleResources(context.TODO(), false, testEnv.Config, testEnv.Client,
 			configv1alpha1.FeatureResources, currentClusterSummary, deployedGKVs, currentClusterRoles,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		// Eventual loop so testEnv Cache is synced
@@ -698,7 +698,7 @@ var _ = Describe("HandlersUtils", func() {
 			currentClusterSummary)).To(Succeed())
 
 		Expect(controllers.HandleResourceDelete(ctx, c, depl, currentClusterSummary,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		currentDepl := &appsv1.Deployment{}
 		Expect(c.Get(context.TODO(), types.NamespacedName{Namespace: depl.Namespace, Name: depl.Name}, currentDepl)).To(Succeed())
@@ -739,7 +739,7 @@ subjects:
 `
 		data := map[string]string{"policy.yaml": content}
 		u, err := controllers.CollectContent(context.TODO(), clusterSummary, nil, data, false,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(len(u)).To(Equal(1))
 		Expect(u[0].GetName()).To(Equal("contour-gateway-provisioner"))
@@ -798,7 +798,7 @@ subjects:
 `
 		data := map[string]string{"policy.yaml": content}
 		u, err := controllers.CollectContent(context.TODO(), clusterSummary, nil, data, false,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(len(u)).To(Equal(3))
 	})

--- a/controllers/lua_validations_test.go
+++ b/controllers/lua_validations_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Lua validations", func() {
 		Expect(err).To(BeNil())
 
 		Expect(controllers.LuaValidation(context.TODO(), []byte(deploymentName),
-			[]*unstructured.Unstructured{u}, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeNil())
+			[]*unstructured.Unstructured{u}, textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 	})
 
 	It("luaValidation returns an error when resources do not satisfy a given lua validation. Single resource.", func() {
@@ -170,7 +170,7 @@ var _ = Describe("Lua validations", func() {
 		Expect(err).To(BeNil())
 
 		Expect(controllers.LuaValidation(context.TODO(), []byte(deploymentName),
-			[]*unstructured.Unstructured{u}, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).ToNot(BeNil())
+			[]*unstructured.Unstructured{u}, textlogger.NewLogger(textlogger.NewConfig()))).ToNot(BeNil())
 	})
 	It("luaValidation returns no error when resources do not satisfy a given lua validation. Multiple resource.", func() {
 		service := `apiVersion: v1
@@ -213,7 +213,7 @@ spec:
 		Expect(err).To(BeNil())
 
 		Expect(controllers.LuaValidation(context.TODO(), []byte(deploymentAndService),
-			[]*unstructured.Unstructured{deplUnstructured, serviceUnstructured}, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeNil())
+			[]*unstructured.Unstructured{deplUnstructured, serviceUnstructured}, textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 	})
 	It("luaValidation returns no error when resources do not satisfy a given lua validation. Multiple resource.", func() {
 		pod := `apiVersion: v1
@@ -233,7 +233,7 @@ spec:
 		Expect(err).To(BeNil())
 
 		Expect(controllers.LuaValidation(context.TODO(), []byte(deploymentAndService),
-			[]*unstructured.Unstructured{deplUnstructured, podUnstructured}, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).ToNot(BeNil())
+			[]*unstructured.Unstructured{deplUnstructured, podUnstructured}, textlogger.NewLogger(textlogger.NewConfig()))).ToNot(BeNil())
 	})
 })
 
@@ -296,7 +296,7 @@ func verifyLuaPolicy(dirName string) {
 	} else {
 		By("Verifying valid resource")
 		spec := map[string][]byte{randomString(): luaPolicy}
-		err = controllers.RunLuaValidations(context.TODO(), spec, validResources, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err = controllers.RunLuaValidations(context.TODO(), spec, validResources, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 	}
 
@@ -306,7 +306,7 @@ func verifyLuaPolicy(dirName string) {
 	} else {
 		By("Verifying non-matching content")
 		spec := map[string][]byte{randomString(): luaPolicy}
-		err = controllers.RunLuaValidations(context.TODO(), spec, invalidResources, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		err = controllers.RunLuaValidations(context.TODO(), spec, invalidResources, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 	}
 }

--- a/controllers/profile_transformation_common.go
+++ b/controllers/profile_transformation_common.go
@@ -37,7 +37,7 @@ func requeueForCluster(cluster client.Object,
 	clusterLabels map[corev1.ObjectReference]map[string]string,
 	clusterMap map[corev1.ObjectReference]*libsveltosset.Set) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
 		"cluster", fmt.Sprintf("%s/%s", cluster.GetNamespace(), cluster.GetName()))
 
 	logger.V(logs.LogDebug).Info("reacting to Cluster change")
@@ -89,7 +89,7 @@ func requeueClusterProfileForMachine(machine client.Object,
 	clusterMap map[corev1.ObjectReference]*libsveltosset.Set,
 ) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
 		"machine", fmt.Sprintf("%s/%s", machine.GetNamespace(), machine.GetName()))
 
 	logger.V(logs.LogDebug).Info("reacting to CAPI Machine change")

--- a/controllers/reloader_utils.go
+++ b/controllers/reloader_utils.go
@@ -38,7 +38,7 @@ func removeReloaderInstance(ctx context.Context, remoteClient client.Client,
 	clusterProfileName string, feature configv1alpha1.FeatureID, logger logr.Logger) error {
 
 	reloader, err := getReloaderInstance(ctx, remoteClient, clusterProfileName,
-		feature, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		feature, textlogger.NewLogger(textlogger.NewConfig()))
 	if err != nil {
 		return err
 	}

--- a/controllers/reloader_utils_test.go
+++ b/controllers/reloader_utils_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Reloader utils", func() {
 		clusterProfileName := randomString()
 		feature := configv1alpha1.FeatureHelm
 		Expect(controllers.DeployReloaderInstance(context.TODO(), c,
-			clusterProfileName, feature, resources, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			clusterProfileName, feature, resources, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		reloaders := &libsveltosv1alpha1.ReloaderList{}
 		Expect(c.List(context.TODO(), reloaders)).To(Succeed())
@@ -127,7 +127,7 @@ var _ = Describe("Reloader utils", func() {
 
 		// Reloader Spec.ReloaderInfo is updated now
 		Expect(controllers.DeployReloaderInstance(context.TODO(), c,
-			clusterProfileName, feature, resources, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			clusterProfileName, feature, resources, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		Expect(c.List(context.TODO(), reloaders)).To(Succeed())
 		Expect(len(reloaders.Items)).To(Equal(1))
@@ -149,7 +149,7 @@ var _ = Describe("Reloader utils", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		Expect(controllers.RemoveReloaderInstance(context.TODO(), c, randomString(),
-			configv1alpha1.FeatureKustomize, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeNil())
+			configv1alpha1.FeatureKustomize, textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 	})
 
 	It("removeReloaderInstance removes Reloader instance", func() {
@@ -165,7 +165,7 @@ var _ = Describe("Reloader utils", func() {
 		Expect(len(reloaders.Items)).To(Equal(1))
 
 		Expect(controllers.RemoveReloaderInstance(context.TODO(), c, clusterProfileName,
-			feature, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(BeNil())
+			feature, textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 
 		Expect(c.List(context.TODO(), reloaders)).To(Succeed())
 		Expect(len(reloaders.Items)).To(Equal(0))
@@ -213,7 +213,7 @@ var _ = Describe("Reloader utils", func() {
 		}
 
 		Expect(controllers.UpdateReloaderWithDeployedResources(context.TODO(), testEnv.Client, clusterProfileOwner,
-			configv1alpha1.FeatureResources, resources, clusterSummary, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			configv1alpha1.FeatureResources, resources, clusterSummary, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		reloaders := &libsveltosv1alpha1.ReloaderList{}
 
@@ -237,7 +237,7 @@ var _ = Describe("Reloader utils", func() {
 		clusterSummary.Spec.ClusterProfileSpec.Reloader = false
 
 		Expect(controllers.UpdateReloaderWithDeployedResources(context.TODO(), testEnv.Client, clusterProfileOwner,
-			configv1alpha1.FeatureResources, nil, clusterSummary, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			configv1alpha1.FeatureResources, nil, clusterSummary, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		Eventually(func() bool {
 			err := testEnv.Client.List(context.TODO(), reloaders)

--- a/controllers/resourcesummary_collection_test.go
+++ b/controllers/resourcesummary_collection_test.go
@@ -123,7 +123,7 @@ var _ = Describe("ResourceSummary Collection", func() {
 		// - reset ClusterSummary.Status.FeatureSummaries hash for helm (indicating new reconciliation is needed)
 		// - reset ResourceSummary.Status
 		Expect(controllers.CollectResourceSummariesFromCluster(context.TODO(), testEnv.Client, getClusterRef(cluster),
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
 		Eventually(func() bool {

--- a/controllers/resourcesummary_test.go
+++ b/controllers/resourcesummary_test.go
@@ -41,7 +41,7 @@ import (
 var _ = Describe("ResourceSummary Deployer", func() {
 	It("deployDebuggingConfigurationCRD deploys DebuggingConfiguration CRD", func() {
 		Expect(controllers.DeployDebuggingConfigurationCRD(context.TODO(), testEnv.Config,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
 		Eventually(func() error {
@@ -53,7 +53,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 
 	It("deployResourceSummaryCRD deploys ResourceSummary CRD", func() {
 		Expect(controllers.DeployResourceSummaryCRD(context.TODO(), testEnv.Config,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
 		Eventually(func() error {
@@ -78,7 +78,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		clusterNamespace := randomString()
 		clusterSummaryName := randomString()
 		Expect(controllers.DeployResourceSummaryInstance(ctx, c, resources, nil, nil,
-			clusterNamespace, clusterSummaryName, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			clusterNamespace, clusterSummaryName, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		currentResourceSummary := &libsveltosv1alpha1.ResourceSummary{}
 		Expect(c.Get(context.TODO(),
@@ -120,7 +120,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		// classifier is expected in the management cluster, above line is required
 		Expect(controllers.DeployResourceSummaryInCluster(context.TODO(), testEnv.Client, cluster.Namespace, cluster.Name,
 			clusterSummaryName, libsveltosv1alpha1.ClusterTypeCapi, nil, nil, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced
 		Eventually(func() error {
@@ -137,7 +137,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 
 		Expect(controllers.DeployDriftDetectionManagerInManagementCluster(context.TODO(), testEnv.Config,
 			clusterNamespace, clusterName, "", clusterType,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		expectedLabels := controllers.GetDriftDetectionManagerLabels(clusterNamespace, clusterName, clusterType)
 
@@ -165,7 +165,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		}, timeout, pollingInterval).Should(BeTrue())
 
 		Expect(controllers.RemoveDriftDetectionManagerFromManagementCluster(context.TODO(), clusterNamespace, clusterName,
-			clusterType, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))).To(Succeed())
+			clusterType, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Verify resources are gone
 		Eventually(func() bool {

--- a/controllers/template_instantiation_test.go
+++ b/controllers/template_instantiation_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Template instantiation", func() {
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
 			libsveltosv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(fmt.Sprintf("%s-test", cluster.Name)))
 	})
@@ -99,7 +99,7 @@ var _ = Describe("Template instantiation", func() {
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
 			libsveltosv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values, nil,
-			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(fmt.Sprintf("%s-test", cluster.Name)))
 		Expect(result).To(ContainSubstring(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0]))
@@ -145,7 +145,7 @@ valuesTemplate: |
 
 		result, err := controllers.InstantiateTemplateValues(context.TODO(), testEnv.Config, testEnv.GetClient(),
 			libsveltosv1alpha1.ClusterTypeCapi, cluster.Namespace, cluster.Name, randomString(), values,
-			mgmtResources, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			mgmtResources, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(pwd))
 	})

--- a/controllers/validate_health_test.go
+++ b/controllers/validate_health_test.go
@@ -162,7 +162,7 @@ func verifyHealthLuaPolicy(dirName string) {
 		By("Verifying valid resource")
 		for i := range validResources {
 			resource := validResources[i]
-			healthy, _, err := controllers.IsHealthy(resource, string(luaPolicy), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			healthy, _, err := controllers.IsHealthy(resource, string(luaPolicy), textlogger.NewLogger(textlogger.NewConfig()))
 			Expect(err).To(BeNil())
 			Expect(healthy).To(BeTrue())
 		}
@@ -175,7 +175,7 @@ func verifyHealthLuaPolicy(dirName string) {
 		By("Verifying non-matching content")
 		for i := range invalidResources {
 			resource := invalidResources[i]
-			healthy, _, err := controllers.IsHealthy(resource, string(luaPolicy), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+			healthy, _, err := controllers.IsHealthy(resource, string(luaPolicy), textlogger.NewLogger(textlogger.NewConfig()))
 			Expect(err).To(BeNil())
 			Expect(healthy).To(BeFalse())
 		}

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -13,7 +13,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: controller
       labels:
         control-plane: addon-controller
     spec:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -3006,7 +3006,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-container: manager
+        kubectl.kubernetes.io/default-container: controller
       labels:
         control-plane: addon-controller
     spec:

--- a/pkg/compliances/addonconstraint_watcher_test.go
+++ b/pkg/compliances/addonconstraint_watcher_test.go
@@ -37,7 +37,7 @@ var _ = Describe("AddonCompliance watcher", func() {
 	BeforeEach(func() {
 		compliances.Reset()
 		watcherCtx, cancel = context.WithCancel(context.Background())
-		compliances.InitializeManagerWithSkip(watcherCtx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Config, testEnv.Client, 10)
+		compliances.InitializeManagerWithSkip(watcherCtx, textlogger.NewLogger(textlogger.NewConfig()), testEnv.Config, testEnv.Client, 10)
 	})
 
 	AfterEach(func() {
@@ -57,7 +57,7 @@ var _ = Describe("AddonCompliance watcher", func() {
 		manager := compliances.GetManager()
 		manager.SetReEvaluate(false)
 
-		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig()))
 
 		addonCompliance := &libsveltosv1alpha1.AddonCompliance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -77,7 +77,7 @@ var _ = Describe("AddonCompliance watcher", func() {
 	})
 
 	It("watchAddonCompliance starts watcher which reacts to AddonCompliance update events (labels change)", func() {
-		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig()))
 
 		addonCompliance := &libsveltosv1alpha1.AddonCompliance{
 			ObjectMeta: metav1.ObjectMeta{
@@ -118,7 +118,7 @@ var _ = Describe("AddonCompliance watcher", func() {
 	})
 
 	It("watchAddonCompliance starts watcher which reacts to AddonCompliance update events (spec change)", func() {
-		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))))
+		go compliances.WatchAddonCompliance(watcherCtx, testEnv.Config, textlogger.NewLogger(textlogger.NewConfig()))
 
 		addonCompliance := &libsveltosv1alpha1.AddonCompliance{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/compliances/manager_test.go
+++ b/pkg/compliances/manager_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Constraints", func() {
 		Expect(testEnv.Create(context.TODO(), addonCompliance2)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv.Client, addonCompliance2)).To(Succeed())
 
-		compliances.InitializeManagerWithSkip(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Config, testEnv.Client, 10)
+		compliances.InitializeManagerWithSkip(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), testEnv.Config, testEnv.Client, 10)
 		manager := compliances.GetManager()
 
 		clusterType := libsveltosv1alpha1.ClusterTypeSveltos
@@ -161,7 +161,7 @@ var _ = Describe("Constraints", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		compliances.InitializeManagerWithSkip(context.TODO(), textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), nil, c, 10)
+		compliances.InitializeManagerWithSkip(context.TODO(), textlogger.NewLogger(textlogger.NewConfig()), nil, c, 10)
 		manager := compliances.GetManager()
 		compliances.ReEvaluateClusters(manager, context.TODO())
 

--- a/pkg/scope/clusterprofile_test.go
+++ b/pkg/scope/clusterprofile_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 	It("Return nil,error if Profile/ClusterProfile is not specified", func() {
 		cpParams := scope.ProfileScopeParams{
 			Client: c,
-			Logger: textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger: textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		cpScope, err := scope.NewProfileScope(cpParams)
@@ -76,7 +76,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 	It("Return nil,error if client is not specified", func() {
 		cpParams := scope.ProfileScopeParams{
 			Profile: clusterProfile,
-			Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		cpScope, err := scope.NewProfileScope(cpParams)
@@ -87,7 +87,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 	It("Return nil,error if any resource but Profile/ClusterProfile is passed", func() {
 		cpParams := scope.ProfileScopeParams{
 			Client:  c,
-			Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			Profile: &corev1.Node{},
 		}
 
@@ -105,7 +105,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -125,7 +125,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -145,7 +145,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -162,7 +162,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -182,7 +182,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -205,7 +205,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -224,7 +224,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -261,7 +261,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -278,7 +278,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -297,7 +297,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -314,7 +314,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -334,7 +334,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)
@@ -352,7 +352,7 @@ var _ = Describe("ProfileScope/ClusterProfileScope", func() {
 			params := scope.ProfileScopeParams{
 				Client:  c,
 				Profile: objects[i],
-				Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+				Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			}
 
 			scope, err := scope.NewProfileScope(params)

--- a/pkg/scope/clustersummary_test.go
+++ b/pkg/scope/clustersummary_test.go
@@ -65,7 +65,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 	It("Return nil,error if ClusterSummary is not specified", func() {
 		params := &scope.ClusterSummaryScopeParams{
 			Client:  c,
-			Logger:  textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:  textlogger.NewLogger(textlogger.NewConfig()),
 			Profile: clusterProfile,
 		}
 
@@ -78,7 +78,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 		params := &scope.ClusterSummaryScopeParams{
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -91,7 +91,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -106,7 +106,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -122,13 +122,12 @@ var _ = Describe("ClusterSummaryScope", func() {
 		Expect(clusterSummary.Status.FeatureSummaries[0].Status).To(Equal(configv1alpha1.FeatureStatusProvisioned))
 	})
 
-	//nolint: dupl // better readibility of test
 	It("SetFailureMessage updates ClusterSummary Status FeatureSummary when not nil", func() {
 		params := &scope.ClusterSummaryScopeParams{
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -160,7 +159,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -181,7 +180,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -212,7 +211,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -236,7 +235,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -250,13 +249,13 @@ var _ = Describe("ClusterSummaryScope", func() {
 		Expect(clusterSummary.Status.FeatureSummaries[0].FeatureID).To(Equal(configv1alpha1.FeatureHelm))
 		Expect(clusterSummary.Status.FeatureSummaries[0].Status).To(Equal(configv1alpha1.FeatureStatusProvisioning))
 	})
-	//nolint: dupl // better readibility of test
+
 	It("SetFailureReason updates ClusterSummary Status FeatureSummary when not nil", func() {
 		params := &scope.ClusterSummaryScopeParams{
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		clusterSummary.Status.FeatureSummaries = []configv1alpha1.FeatureSummary{
@@ -288,7 +287,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -309,7 +308,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -339,7 +338,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -365,7 +364,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -389,7 +388,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -411,7 +410,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -433,7 +432,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)
@@ -453,7 +452,7 @@ var _ = Describe("ClusterSummaryScope", func() {
 			Client:         c,
 			Profile:        clusterProfile,
 			ClusterSummary: clusterSummary,
-			Logger:         textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
+			Logger:         textlogger.NewLogger(textlogger.NewConfig()),
 		}
 
 		scope, err := scope.NewClusterSummaryScope(params)


### PR DESCRIPTION
When removing instances created by a Profile, limit search to Profile namespace.

Part of #396 