### PR TITLE
Fix issue requeuing Profiles when cluster changes

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -332,14 +332,20 @@ func capiWatchers(ctx context.Context, mgr ctrl.Manager,
 			} else {
 				setupLog.V(logsettings.LogInfo).Info("CAPI present.")
 				if clusterProfileReconciler != nil {
+					setupLog.V(logsettings.LogInfo).Info("start clusterProfile CAPI watcher.")
 					err = clusterProfileReconciler.WatchForCAPI(mgr, clusterProfileController)
 					if err != nil {
+						setupLog.V(logsettings.LogInfo).Info(
+							fmt.Sprintf("failed to start clusterProfile CAPI watcher: %v", err))
 						continue
 					}
 				}
 				if profileReconciler != nil {
+					setupLog.V(logsettings.LogInfo).Info("start profile CAPI watcher.")
 					err = profileReconciler.WatchForCAPI(mgr, profileController)
 					if err != nil {
+						setupLog.V(logsettings.LogInfo).Info(
+							fmt.Sprintf("failed to start profile CAPI watcher: %v", err))
 						continue
 					}
 				}

--- a/controllers/clusterprofile_transformations.go
+++ b/controllers/clusterprofile_transformations.go
@@ -49,5 +49,5 @@ func (r *ClusterProfileReconciler) requeueClusterProfileForMachine(
 	r.Mux.Lock()
 	defer r.Mux.Unlock()
 
-	return requeueClusterProfileForMachine(machine, r.ClusterProfiles, r.ClusterLabels, r.ClusterMap)
+	return requeueForMachine(machine, r.ClusterProfiles, r.ClusterLabels, r.ClusterMap)
 }

--- a/controllers/profile_transformation_common.go
+++ b/controllers/profile_transformation_common.go
@@ -37,9 +37,8 @@ func requeueForCluster(cluster client.Object,
 	clusterLabels map[corev1.ObjectReference]map[string]string,
 	clusterMap map[corev1.ObjectReference]*libsveltosset.Set) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(logs.LogInfo))).WithValues(
 		"cluster", fmt.Sprintf("%s/%s", cluster.GetNamespace(), cluster.GetName()))
-
 	logger.V(logs.LogDebug).Info("reacting to Cluster change")
 
 	apiVersion, kind := cluster.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
@@ -74,7 +73,8 @@ func requeueForCluster(cluster client.Object,
 			l.V(logs.LogDebug).Info("queuing profile")
 			requests = append(requests, ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name: k.Name,
+					Name:      k.Name,
+					Namespace: k.Namespace,
 				},
 			})
 		}
@@ -83,13 +83,12 @@ func requeueForCluster(cluster client.Object,
 	return requests
 }
 
-func requeueClusterProfileForMachine(machine client.Object,
+func requeueForMachine(machine client.Object,
 	profileSelectors map[corev1.ObjectReference]libsveltosv1alpha1.Selector,
 	clusterLabels map[corev1.ObjectReference]map[string]string,
-	clusterMap map[corev1.ObjectReference]*libsveltosset.Set,
-) []reconcile.Request {
+	clusterMap map[corev1.ObjectReference]*libsveltosset.Set) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(logs.LogInfo))).WithValues(
 		"machine", fmt.Sprintf("%s/%s", machine.GetNamespace(), machine.GetName()))
 
 	logger.V(logs.LogDebug).Info("reacting to CAPI Machine change")
@@ -135,7 +134,8 @@ func requeueClusterProfileForMachine(machine client.Object,
 				l.V(logs.LogDebug).Info("queuing profile")
 				requests = append(requests, ctrl.Request{
 					NamespacedName: client.ObjectKey{
-						Name: k.Name,
+						Name:      k.Name,
+						Namespace: k.Namespace,
 					},
 				})
 			}

--- a/controllers/profile_transformations.go
+++ b/controllers/profile_transformations.go
@@ -49,5 +49,5 @@ func (r *ProfileReconciler) requeueProfileForMachine(
 	r.Mux.Lock()
 	defer r.Mux.Unlock()
 
-	return requeueClusterProfileForMachine(machine, r.Profiles, r.ClusterLabels, r.ClusterMap)
+	return requeueForMachine(machine, r.Profiles, r.ClusterLabels, r.ClusterMap)
 }

--- a/controllers/profile_transformations_test.go
+++ b/controllers/profile_transformations_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Profile Transformations", func() {
 		namespace = randomString()
 	})
 
-	It("requeueProfileForCluster returns matching Profiles", func() {
+	It("requeueProfileForCluster returns matching ClusterProfiles", func() {
 		key := randomString()
 		value := randomString()
 
@@ -88,6 +88,120 @@ var _ = Describe("Profile Transformations", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
+		reconciler := &controllers.ClusterProfileReconciler{
+			Client:            c,
+			Scheme:            scheme,
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
+			Mux:               sync.Mutex{},
+		}
+
+		By("Setting ProfileReconciler internal structures")
+		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: configv1alpha1.ClusterProfileKind, Name: matchingProfile.Name}
+		reconciler.ClusterProfiles[matchingInfo] = matchingProfile.Spec.ClusterSelector
+
+		nonMatchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingProfile.Name}
+		reconciler.ClusterProfiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+
+		// ClusterMap contains, per ClusterName, list of ClusterProfiles matching it.
+		clusterProfileSet := &libsveltosset.Set{}
+		clusterProfileSet.Insert(&matchingInfo)
+		clusterInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: cluster.Kind, Namespace: cluster.Namespace, Name: cluster.Name}
+		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+
+		// ProfileMap contains, per Profile, list of matched Clusters.
+		clusterSet1 := &libsveltosset.Set{}
+		reconciler.ClusterProfileMap[nonMatchingInfo] = clusterSet1
+
+		clusterSet2 := &libsveltosset.Set{}
+		clusterSet2.Insert(&clusterInfo)
+		reconciler.ClusterProfileMap[matchingInfo] = clusterSet2
+
+		By("Expect only matchingProfile to be requeued")
+		requests := controllers.RequeueClusterProfileForCluster(reconciler, context.TODO(), cluster)
+		expected := reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+
+		By("Changing Profile ClusterSelector again to have two ClusterProfiles match")
+		nonMatchingProfile.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		Expect(c.Update(context.TODO(), nonMatchingProfile)).To(Succeed())
+
+		reconciler.ClusterProfiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+
+		clusterSet1.Insert(&clusterInfo)
+		reconciler.ClusterProfileMap[nonMatchingInfo] = clusterSet1
+
+		clusterProfileSet.Insert(&nonMatchingInfo)
+		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+
+		requests = controllers.RequeueClusterProfileForCluster(reconciler, context.TODO(), cluster)
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: nonMatchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+	})
+
+	It("requeueProfileForCluster returns matching Profiles", func() {
+		key := randomString()
+		value := randomString()
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      upstreamClusterNamePrefix + randomString(),
+				Namespace: namespace,
+				Labels: map[string]string{
+					key: value,
+				},
+			},
+		}
+
+		matchingProfile := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: cluster.Namespace,
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", key, value)),
+			},
+		}
+
+		nonMatchingProfile1 := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: cluster.Namespace,
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", randomString(), value)),
+			},
+		}
+
+		nonMatchingProfile2 := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: randomString(),
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", key, value)),
+			},
+		}
+
+		initObjects := []client.Object{
+			matchingProfile,
+			nonMatchingProfile1,
+			nonMatchingProfile2,
+			cluster,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
 		reconciler := &controllers.ProfileReconciler{
 			Client:        c,
 			Scheme:        scheme,
@@ -99,24 +213,29 @@ var _ = Describe("Profile Transformations", func() {
 		}
 
 		By("Setting ProfileReconciler internal structures")
-		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
-			Kind: configv1alpha1.ClusterProfileKind, Name: matchingProfile.Name}
+		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}
 		reconciler.Profiles[matchingInfo] = matchingProfile.Spec.ClusterSelector
 
-		nonMatchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
-			Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingProfile.Name}
-		reconciler.Profiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+		nonMatchingInfo1 := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: nonMatchingProfile1.Namespace, Name: nonMatchingProfile1.Name}
+		reconciler.Profiles[nonMatchingInfo1] = nonMatchingProfile1.Spec.ClusterSelector
 
-		// ClusterMap contains, per ClusterName, list of ClusterProfiles matching it.
-		clusterProfileSet := &libsveltosset.Set{}
-		clusterProfileSet.Insert(&matchingInfo)
+		nonMatchingInfo2 := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: nonMatchingProfile2.Namespace, Name: nonMatchingProfile2.Name}
+		reconciler.Profiles[nonMatchingInfo2] = nonMatchingProfile2.Spec.ClusterSelector
+
+		// ClusterMap contains, per ClusterName, list of Profiles matching it.
+		profileSet := &libsveltosset.Set{}
+		profileSet.Insert(&matchingInfo)
 		clusterInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
 			Kind: cluster.Kind, Namespace: cluster.Namespace, Name: cluster.Name}
-		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+		reconciler.ClusterMap[clusterInfo] = profileSet
 
 		// ProfileMap contains, per Profile, list of matched Clusters.
 		clusterSet1 := &libsveltosset.Set{}
-		reconciler.ProfileMap[nonMatchingInfo] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo1] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo2] = clusterSet1
 
 		clusterSet2 := &libsveltosset.Set{}
 		clusterSet2.Insert(&clusterInfo)
@@ -124,25 +243,32 @@ var _ = Describe("Profile Transformations", func() {
 
 		By("Expect only matchingProfile to be requeued")
 		requests := controllers.RequeueProfileForCluster(reconciler, context.TODO(), cluster)
-		expected := reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		expected := reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}}
 		Expect(requests).To(ContainElement(expected))
 
 		By("Changing Profile ClusterSelector again to have two ClusterProfiles match")
-		nonMatchingProfile.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
-		Expect(c.Update(context.TODO(), nonMatchingProfile)).To(Succeed())
+		nonMatchingProfile1.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		// Even though selector is a match, namespace is not for nonMatchingProfile2
+		nonMatchingProfile2.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		Expect(c.Update(context.TODO(), nonMatchingProfile1)).To(Succeed())
+		Expect(c.Update(context.TODO(), nonMatchingProfile2)).To(Succeed())
 
-		reconciler.Profiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+		reconciler.Profiles[nonMatchingInfo1] = nonMatchingProfile1.Spec.ClusterSelector
+		reconciler.Profiles[nonMatchingInfo2] = nonMatchingProfile2.Spec.ClusterSelector
 
 		clusterSet1.Insert(&clusterInfo)
-		reconciler.ProfileMap[nonMatchingInfo] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo1] = clusterSet1
 
-		clusterProfileSet.Insert(&nonMatchingInfo)
-		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+		profileSet.Insert(&nonMatchingInfo1)
+		reconciler.ClusterMap[clusterInfo] = profileSet
 
 		requests = controllers.RequeueProfileForCluster(reconciler, context.TODO(), cluster)
-		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}}
 		Expect(requests).To(ContainElement(expected))
-		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: nonMatchingProfile.Name}}
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: nonMatchingProfile1.Namespace, Name: nonMatchingProfile1.Name}}
 		Expect(requests).To(ContainElement(expected))
 	})
 


### PR DESCRIPTION
Due to this bug, following sequence did not work:
1. Create Profile
2. Create cluster matching Profile instance created in #1

In other words, code was correctly identifying the Profile to requeue for reconciliation when a Cluster or Machine changed. Instead of returning Profile Namespace,Name simple Name was returned so nothing was reconciled. 
This PR fixes this issue by returning Profile Namespace and Name.

Fixes #415  #416 