### PR TITLE
Fix requeue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v0.21.0
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -332,14 +332,20 @@ func capiWatchers(ctx context.Context, mgr ctrl.Manager,
 			} else {
 				setupLog.V(logsettings.LogInfo).Info("CAPI present.")
 				if clusterProfileReconciler != nil {
+					setupLog.V(logsettings.LogInfo).Info("start clusterProfile CAPI watcher.")
 					err = clusterProfileReconciler.WatchForCAPI(mgr, clusterProfileController)
 					if err != nil {
+						setupLog.V(logsettings.LogInfo).Info(
+							fmt.Sprintf("failed to start clusterProfile CAPI watcher: %v", err))
 						continue
 					}
 				}
 				if profileReconciler != nil {
+					setupLog.V(logsettings.LogInfo).Info("start profile CAPI watcher.")
 					err = profileReconciler.WatchForCAPI(mgr, profileController)
 					if err != nil {
+						setupLog.V(logsettings.LogInfo).Info(
+							fmt.Sprintf("failed to start profile CAPI watcher: %v", err))
 						continue
 					}
 				}

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller-amd64:v0.21.0
+      - image: projectsveltos/addon-controller-amd64:main
         name: controller

--- a/controllers/clusterprofile_transformations.go
+++ b/controllers/clusterprofile_transformations.go
@@ -49,5 +49,5 @@ func (r *ClusterProfileReconciler) requeueClusterProfileForMachine(
 	r.Mux.Lock()
 	defer r.Mux.Unlock()
 
-	return requeueClusterProfileForMachine(machine, r.ClusterProfiles, r.ClusterLabels, r.ClusterMap)
+	return requeueForMachine(machine, r.ClusterProfiles, r.ClusterLabels, r.ClusterMap)
 }

--- a/controllers/profile_transformation_common.go
+++ b/controllers/profile_transformation_common.go
@@ -37,9 +37,8 @@ func requeueForCluster(cluster client.Object,
 	clusterLabels map[corev1.ObjectReference]map[string]string,
 	clusterMap map[corev1.ObjectReference]*libsveltosset.Set) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(logs.LogInfo))).WithValues(
 		"cluster", fmt.Sprintf("%s/%s", cluster.GetNamespace(), cluster.GetName()))
-
 	logger.V(logs.LogDebug).Info("reacting to Cluster change")
 
 	apiVersion, kind := cluster.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
@@ -74,7 +73,8 @@ func requeueForCluster(cluster client.Object,
 			l.V(logs.LogDebug).Info("queuing profile")
 			requests = append(requests, ctrl.Request{
 				NamespacedName: client.ObjectKey{
-					Name: k.Name,
+					Name:      k.Name,
+					Namespace: k.Namespace,
 				},
 			})
 		}
@@ -83,13 +83,12 @@ func requeueForCluster(cluster client.Object,
 	return requests
 }
 
-func requeueClusterProfileForMachine(machine client.Object,
+func requeueForMachine(machine client.Object,
 	profileSelectors map[corev1.ObjectReference]libsveltosv1alpha1.Selector,
 	clusterLabels map[corev1.ObjectReference]map[string]string,
-	clusterMap map[corev1.ObjectReference]*libsveltosset.Set,
-) []reconcile.Request {
+	clusterMap map[corev1.ObjectReference]*libsveltosset.Set) []reconcile.Request {
 
-	logger := textlogger.NewLogger(textlogger.NewConfig()).WithValues(
+	logger := textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(logs.LogInfo))).WithValues(
 		"machine", fmt.Sprintf("%s/%s", machine.GetNamespace(), machine.GetName()))
 
 	logger.V(logs.LogDebug).Info("reacting to CAPI Machine change")
@@ -135,7 +134,8 @@ func requeueClusterProfileForMachine(machine client.Object,
 				l.V(logs.LogDebug).Info("queuing profile")
 				requests = append(requests, ctrl.Request{
 					NamespacedName: client.ObjectKey{
-						Name: k.Name,
+						Name:      k.Name,
+						Namespace: k.Namespace,
 					},
 				})
 			}

--- a/controllers/profile_transformations.go
+++ b/controllers/profile_transformations.go
@@ -49,5 +49,5 @@ func (r *ProfileReconciler) requeueProfileForMachine(
 	r.Mux.Lock()
 	defer r.Mux.Unlock()
 
-	return requeueClusterProfileForMachine(machine, r.Profiles, r.ClusterLabels, r.ClusterMap)
+	return requeueForMachine(machine, r.Profiles, r.ClusterLabels, r.ClusterMap)
 }

--- a/controllers/profile_transformations_test.go
+++ b/controllers/profile_transformations_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Profile Transformations", func() {
 		namespace = randomString()
 	})
 
-	It("requeueProfileForCluster returns matching Profiles", func() {
+	It("requeueProfileForCluster returns matching ClusterProfiles", func() {
 		key := randomString()
 		value := randomString()
 
@@ -88,6 +88,120 @@ var _ = Describe("Profile Transformations", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
+		reconciler := &controllers.ClusterProfileReconciler{
+			Client:            c,
+			Scheme:            scheme,
+			ClusterMap:        make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfileMap: make(map[corev1.ObjectReference]*libsveltosset.Set),
+			ClusterProfiles:   make(map[corev1.ObjectReference]libsveltosv1alpha1.Selector),
+			ClusterLabels:     make(map[corev1.ObjectReference]map[string]string),
+			Mux:               sync.Mutex{},
+		}
+
+		By("Setting ProfileReconciler internal structures")
+		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: configv1alpha1.ClusterProfileKind, Name: matchingProfile.Name}
+		reconciler.ClusterProfiles[matchingInfo] = matchingProfile.Spec.ClusterSelector
+
+		nonMatchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingProfile.Name}
+		reconciler.ClusterProfiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+
+		// ClusterMap contains, per ClusterName, list of ClusterProfiles matching it.
+		clusterProfileSet := &libsveltosset.Set{}
+		clusterProfileSet.Insert(&matchingInfo)
+		clusterInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
+			Kind: cluster.Kind, Namespace: cluster.Namespace, Name: cluster.Name}
+		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+
+		// ProfileMap contains, per Profile, list of matched Clusters.
+		clusterSet1 := &libsveltosset.Set{}
+		reconciler.ClusterProfileMap[nonMatchingInfo] = clusterSet1
+
+		clusterSet2 := &libsveltosset.Set{}
+		clusterSet2.Insert(&clusterInfo)
+		reconciler.ClusterProfileMap[matchingInfo] = clusterSet2
+
+		By("Expect only matchingProfile to be requeued")
+		requests := controllers.RequeueClusterProfileForCluster(reconciler, context.TODO(), cluster)
+		expected := reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+
+		By("Changing Profile ClusterSelector again to have two ClusterProfiles match")
+		nonMatchingProfile.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		Expect(c.Update(context.TODO(), nonMatchingProfile)).To(Succeed())
+
+		reconciler.ClusterProfiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+
+		clusterSet1.Insert(&clusterInfo)
+		reconciler.ClusterProfileMap[nonMatchingInfo] = clusterSet1
+
+		clusterProfileSet.Insert(&nonMatchingInfo)
+		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+
+		requests = controllers.RequeueClusterProfileForCluster(reconciler, context.TODO(), cluster)
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: nonMatchingProfile.Name}}
+		Expect(requests).To(ContainElement(expected))
+	})
+
+	It("requeueProfileForCluster returns matching Profiles", func() {
+		key := randomString()
+		value := randomString()
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      upstreamClusterNamePrefix + randomString(),
+				Namespace: namespace,
+				Labels: map[string]string{
+					key: value,
+				},
+			},
+		}
+
+		matchingProfile := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: cluster.Namespace,
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", key, value)),
+			},
+		}
+
+		nonMatchingProfile1 := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: cluster.Namespace,
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", randomString(), value)),
+			},
+		}
+
+		nonMatchingProfile2 := &configv1alpha1.Profile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterProfileNamePrefix + randomString(),
+				Namespace: randomString(),
+			},
+			Spec: configv1alpha1.Spec{
+				ClusterSelector: libsveltosv1alpha1.Selector(
+					fmt.Sprintf("%s=%s", key, value)),
+			},
+		}
+
+		initObjects := []client.Object{
+			matchingProfile,
+			nonMatchingProfile1,
+			nonMatchingProfile2,
+			cluster,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
 		reconciler := &controllers.ProfileReconciler{
 			Client:        c,
 			Scheme:        scheme,
@@ -99,24 +213,29 @@ var _ = Describe("Profile Transformations", func() {
 		}
 
 		By("Setting ProfileReconciler internal structures")
-		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
-			Kind: configv1alpha1.ClusterProfileKind, Name: matchingProfile.Name}
+		matchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}
 		reconciler.Profiles[matchingInfo] = matchingProfile.Spec.ClusterSelector
 
-		nonMatchingInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
-			Kind: configv1alpha1.ClusterProfileKind, Name: nonMatchingProfile.Name}
-		reconciler.Profiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+		nonMatchingInfo1 := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: nonMatchingProfile1.Namespace, Name: nonMatchingProfile1.Name}
+		reconciler.Profiles[nonMatchingInfo1] = nonMatchingProfile1.Spec.ClusterSelector
 
-		// ClusterMap contains, per ClusterName, list of ClusterProfiles matching it.
-		clusterProfileSet := &libsveltosset.Set{}
-		clusterProfileSet.Insert(&matchingInfo)
+		nonMatchingInfo2 := corev1.ObjectReference{APIVersion: cluster.APIVersion, Kind: configv1alpha1.ProfileKind,
+			Namespace: nonMatchingProfile2.Namespace, Name: nonMatchingProfile2.Name}
+		reconciler.Profiles[nonMatchingInfo2] = nonMatchingProfile2.Spec.ClusterSelector
+
+		// ClusterMap contains, per ClusterName, list of Profiles matching it.
+		profileSet := &libsveltosset.Set{}
+		profileSet.Insert(&matchingInfo)
 		clusterInfo := corev1.ObjectReference{APIVersion: cluster.APIVersion,
 			Kind: cluster.Kind, Namespace: cluster.Namespace, Name: cluster.Name}
-		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+		reconciler.ClusterMap[clusterInfo] = profileSet
 
 		// ProfileMap contains, per Profile, list of matched Clusters.
 		clusterSet1 := &libsveltosset.Set{}
-		reconciler.ProfileMap[nonMatchingInfo] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo1] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo2] = clusterSet1
 
 		clusterSet2 := &libsveltosset.Set{}
 		clusterSet2.Insert(&clusterInfo)
@@ -124,25 +243,32 @@ var _ = Describe("Profile Transformations", func() {
 
 		By("Expect only matchingProfile to be requeued")
 		requests := controllers.RequeueProfileForCluster(reconciler, context.TODO(), cluster)
-		expected := reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		expected := reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}}
 		Expect(requests).To(ContainElement(expected))
 
 		By("Changing Profile ClusterSelector again to have two ClusterProfiles match")
-		nonMatchingProfile.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
-		Expect(c.Update(context.TODO(), nonMatchingProfile)).To(Succeed())
+		nonMatchingProfile1.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		// Even though selector is a match, namespace is not for nonMatchingProfile2
+		nonMatchingProfile2.Spec.ClusterSelector = matchingProfile.Spec.ClusterSelector
+		Expect(c.Update(context.TODO(), nonMatchingProfile1)).To(Succeed())
+		Expect(c.Update(context.TODO(), nonMatchingProfile2)).To(Succeed())
 
-		reconciler.Profiles[nonMatchingInfo] = nonMatchingProfile.Spec.ClusterSelector
+		reconciler.Profiles[nonMatchingInfo1] = nonMatchingProfile1.Spec.ClusterSelector
+		reconciler.Profiles[nonMatchingInfo2] = nonMatchingProfile2.Spec.ClusterSelector
 
 		clusterSet1.Insert(&clusterInfo)
-		reconciler.ProfileMap[nonMatchingInfo] = clusterSet1
+		reconciler.ProfileMap[nonMatchingInfo1] = clusterSet1
 
-		clusterProfileSet.Insert(&nonMatchingInfo)
-		reconciler.ClusterMap[clusterInfo] = clusterProfileSet
+		profileSet.Insert(&nonMatchingInfo1)
+		reconciler.ClusterMap[clusterInfo] = profileSet
 
 		requests = controllers.RequeueProfileForCluster(reconciler, context.TODO(), cluster)
-		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: matchingProfile.Name}}
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: matchingProfile.Namespace, Name: matchingProfile.Name}}
 		Expect(requests).To(ContainElement(expected))
-		expected = reconcile.Request{NamespacedName: types.NamespacedName{Name: nonMatchingProfile.Name}}
+		expected = reconcile.Request{NamespacedName: types.NamespacedName{
+			Namespace: nonMatchingProfile1.Namespace, Name: nonMatchingProfile1.Name}}
 		Expect(requests).To(ContainElement(expected))
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.2
 	github.com/onsi/gomega v1.30.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.21.0
+	github.com/projectsveltos/libsveltos v0.21.1-0.20240104154531-101b29f82445
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.21.0 h1:NkkGiDbQJyp0WuPkioS4pHzmRwy8XtomNC4dJrZ4mW8=
-github.com/projectsveltos/libsveltos v0.21.0/go.mod h1:HnXXTWK9BqzoN4aAQs0kdjK7wpsaSz0nNemN4rMruV4=
+github.com/projectsveltos/libsveltos v0.21.1-0.20240104154531-101b29f82445 h1:BRQmPXAGVKTWq5GdlvPPZmAe4D5bmR8Bum1pqPCEd8w=
+github.com/projectsveltos/libsveltos v0.21.1-0.20240104154531-101b29f82445/go.mod h1:HnXXTWK9BqzoN4aAQs0kdjK7wpsaSz0nNemN4rMruV4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:v0.21.0
+        image: projectsveltos/addon-controller-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -3019,7 +3019,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:v0.21.0
+        image: projectsveltos/addon-controller-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -63,7 +63,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:v0.21.0
+        image: projectsveltos/drift-detection-manager-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -45,7 +45,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:v0.21.0
+        image: projectsveltos/drift-detection-manager-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -176,7 +176,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:v0.21.0
+        image: projectsveltos/drift-detection-manager-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -158,7 +158,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:v0.21.0
+        image: projectsveltos/drift-detection-manager-amd64:main
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Due to this bug, following sequence did not work:
- Create Profile
- Create cluster matching Profile instance created in https://github.com/projectsveltos/addon-controller/pull/1

In other words, code was correctly identifying the Profile to requeue for reconciliation when a Cluster or Machine changed. Instead of returning Profile Namespace,Name simple Name was returned so nothing was reconciled.
This PR fixes this issue by returning Profile Namespace and Name.

Fixes https://github.com/projectsveltos/addon-controller/issues/415 https://github.com/projectsveltos/addon-controller/issues/416