### PR TITLE
Drift-detection logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller-amd64:main
+      - image: projectsveltos/addon-controller-amd64:dev
         name: controller

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -105,6 +105,16 @@ func deployHelmCharts(ctx context.Context, c client.Client,
 		if err != nil {
 			return err
 		}
+
+		// Since we are updating resources to watch for drift, remove helm section in ResourceSummary to eliminate
+		// un-needed reconciliation (Sveltos is updating those resources so we don't want drift-detection to think
+		// a configuration drift is happening)
+		err = deployResourceSummaryInCluster(ctx, c, clusterNamespace, clusterName, clusterSummary.Name,
+			clusterType, nil, nil, []libsveltosv1alpha1.HelmResources{}, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to remove ResourceSummary.")
+			return err
+		}
 	}
 
 	adminNamespace, adminName := getClusterSummaryAdmin(clusterSummary)

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -171,6 +171,16 @@ func handleDriftDetectionManagerDeployment(ctx context.Context, clusterSummary *
 		if err != nil {
 			return err
 		}
+
+		// Since we are updating resources to watch for drift, remove resource section in ResourceSummary to eliminate
+		// un-needed reconciliation (Sveltos is updating those resources so we don't want drift-detection to think
+		// a configuration drift is happening)
+		err = handleResourceSummaryDeployment(ctx, clusterSummary, clusterNamespace, clusterName,
+			clusterType, []configv1alpha1.Resource{}, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to remove ResourceSummary.")
+			return err
+		}
 	}
 
 	return nil

--- a/controllers/reloader_utils_test.go
+++ b/controllers/reloader_utils_test.go
@@ -26,6 +26,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -33,6 +34,8 @@ import (
 	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	libsveltoscrd "github.com/projectsveltos/libsveltos/lib/crd"
+	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var _ = Describe("Reloader utils", func() {
@@ -157,6 +160,11 @@ var _ = Describe("Reloader utils", func() {
 		feature := configv1alpha1.FeatureKustomize
 
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		var reloaderCRD *unstructured.Unstructured
+		reloaderCRD, err := utils.GetUnstructured(libsveltoscrd.GetReloaderCRDYAML())
+		Expect(err).To(BeNil())
+		Expect(c.Create(context.TODO(), reloaderCRD)).To(Succeed())
 
 		Expect(controllers.CreateReloaderInstance(context.TODO(), c,
 			clusterProfileName, feature, nil)).To(Succeed())

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:main
+        image: projectsveltos/addon-controller-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -3019,7 +3019,7 @@ spec:
         - --v=5
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:main
+        image: projectsveltos/addon-controller-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -63,7 +63,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -45,7 +45,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -176,7 +176,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -158,7 +158,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: projectsveltos/drift-detection-manager-amd64:main
+        image: projectsveltos/drift-detection-manager-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/scope/clustersummary.go
+++ b/pkg/scope/clustersummary.go
@@ -192,6 +192,11 @@ func (s *ClusterSummaryScope) SetLastAppliedTime(featureID configv1alpha1.Featur
 	)
 }
 
+// IsContinuousWithDriftDetection returns true if ClusterProfile is set to SyncModeContinuousWithDriftDetection
+func (s *ClusterSummaryScope) IsContinuousWithDriftDetection() bool {
+	return s.ClusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeContinuousWithDriftDetection
+}
+
 // IsContinuousSync returns true if ClusterProfile is set to keep updating workload cluster
 func (s *ClusterSummaryScope) IsContinuousSync() bool {
 	return s.ClusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeContinuous ||

--- a/test/fv/utils_test.go
+++ b/test/fv/utils_test.go
@@ -146,7 +146,8 @@ func verifyFeatureStatusIsProvisioned(clusterSummaryNamespace, clusterSummaryNam
 		}
 		for i := range currentClusterSummary.Status.FeatureSummaries {
 			if currentClusterSummary.Status.FeatureSummaries[i].FeatureID == featureID &&
-				currentClusterSummary.Status.FeatureSummaries[i].Status == configv1alpha1.FeatureStatusProvisioned {
+				currentClusterSummary.Status.FeatureSummaries[i].Status == configv1alpha1.FeatureStatusProvisioned &&
+				currentClusterSummary.Status.FeatureSummaries[i].FailureMessage == nil {
 
 				return true
 			}


### PR DESCRIPTION
When ClusterSummary in mode ContinuousWithDriftDetection is about to deploy resources, stop drift detection for such resources. This means:

- for helm resource, set Spec.ChartResources to empty
- for raw YAML/JSON, set Spec.Resources to empty
- for kustomize, set Spec.KustomizeResources to empty

This is done to avoid un-necessary reconciliation. If Sveltos is about to redeploy those resources, very likely some of those will be modified. By updating ResourceSummary instance before re-deploying those resources, we avoid drift-detection from considering such updates (done by Sveltos) as configuration drift.

Code already re-updates ResourceSummary after resources are re-deployed.

This PR also fix an issue where Sveltos reports an issue when no ReloaderReport or ResourceSummary are present in the managed cluster. That is not an error if those CRDs were not installed. Those CRDs are only installed in a cluster when there is at least one matching ClusterProfile with Spec.Reloader field set to true or mode set to ContinuousWithDriftDetection respectively.

Fixes #420 
Fixes #419 