### PR TITLE
Add support for getting YAML from Flux sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/api/v1alpha1/spec.go
+++ b/api/v1alpha1/spec.go
@@ -308,9 +308,17 @@ type PolicyRef struct {
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name"`
 
-	// Kind of the resource. Supported kinds are: Secrets and ConfigMaps.
-	// +kubebuilder:validation:Enum=Secret;ConfigMap
+	// Kind of the resource. Supported kinds are:
+	// - ConfigMap/Secret
+	// - flux GitRepository;OCIRepository;Bucket
+	// +kubebuilder:validation:Enum=GitRepository;OCIRepository;Bucket;ConfigMap;Secret
 	Kind string `json:"kind"`
+
+	// Path to the directory containing the YAML files.
+	// Defaults to 'None', which translates to the root path of the SourceRef.
+	// Used only for GitRepository;OCIRepository;Bucket
+	// +optional
+	Path string `json:"path,omitempty"`
 
 	// DeploymentType indicates whether resources need to be deployed
 	// into the management cluster (local) or the managed cluster (remote)

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -309,11 +309,14 @@ spec:
                       - Remote
                       type: string
                     kind:
-                      description: 'Kind of the resource. Supported kinds are: Secrets
-                        and ConfigMaps.'
+                      description: 'Kind of the resource. Supported kinds are: - ConfigMap/Secret
+                        - flux GitRepository;OCIRepository;Bucket'
                       enum:
-                      - Secret
+                      - GitRepository
+                      - OCIRepository
+                      - Bucket
                       - ConfigMap
+                      - Secret
                       type: string
                     name:
                       description: Name of the referenced resource.
@@ -324,6 +327,11 @@ spec:
                         namespace can be left empty. In such a case, namespace will
                         be implicit set to cluster's namespace. For Profile namespace
                         must be left empty. Profile namespace will be used.
+                      type: string
+                    path:
+                      description: Path to the directory containing the YAML files.
+                        Defaults to 'None', which translates to the root path of the
+                        SourceRef. Used only for GitRepository;OCIRepository;Bucket
                       type: string
                   required:
                   - kind

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -329,10 +329,13 @@ spec:
                           type: string
                         kind:
                           description: 'Kind of the resource. Supported kinds are:
-                            Secrets and ConfigMaps.'
+                            - ConfigMap/Secret - flux GitRepository;OCIRepository;Bucket'
                           enum:
-                          - Secret
+                          - GitRepository
+                          - OCIRepository
+                          - Bucket
                           - ConfigMap
+                          - Secret
                           type: string
                         name:
                           description: Name of the referenced resource.
@@ -344,6 +347,11 @@ spec:
                             will be implicit set to cluster's namespace. For Profile
                             namespace must be left empty. Profile namespace will be
                             used.
+                          type: string
+                        path:
+                          description: Path to the directory containing the YAML files.
+                            Defaults to 'None', which translates to the root path
+                            of the SourceRef. Used only for GitRepository;OCIRepository;Bucket
                           type: string
                       required:
                       - kind

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -309,11 +309,14 @@ spec:
                       - Remote
                       type: string
                     kind:
-                      description: 'Kind of the resource. Supported kinds are: Secrets
-                        and ConfigMaps.'
+                      description: 'Kind of the resource. Supported kinds are: - ConfigMap/Secret
+                        - flux GitRepository;OCIRepository;Bucket'
                       enum:
-                      - Secret
+                      - GitRepository
+                      - OCIRepository
+                      - Bucket
                       - ConfigMap
+                      - Secret
                       type: string
                     name:
                       description: Name of the referenced resource.
@@ -324,6 +327,11 @@ spec:
                         namespace can be left empty. In such a case, namespace will
                         be implicit set to cluster's namespace. For Profile namespace
                         must be left empty. Profile namespace will be used.
+                      type: string
+                    path:
+                      description: Path to the directory containing the YAML files.
+                        Defaults to 'None', which translates to the root path of the
+                        SourceRef. Used only for GitRepository;OCIRepository;Bucket
                       type: string
                   required:
                   - kind

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -39,4 +39,4 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller-amd64:main
+      - image: projectsveltos/addon-controller-amd64:dev
         name: controller

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -88,6 +88,7 @@ var (
 	HandleResourceDelete          = handleResourceDelete
 	GetSecret                     = getSecret
 	GetReferenceResourceNamespace = getReferenceResourceNamespace
+	ReadFiles                     = readFiles
 
 	ResourcesHash   = resourcesHash
 	GetResourceRefs = getResourceRefs

--- a/controllers/flux_source.go
+++ b/controllers/flux_source.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/fluxcd/pkg/http/fetch"
+	"github.com/fluxcd/pkg/tar"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func prepareFileSystemWithFluxSource(source sourcev1.Source, logger logr.Logger) (string, error) {
+	if source.GetArtifact() == nil {
+		msg := "Source is not ready, artifact not found"
+		logger.V(logs.LogInfo).Info(msg)
+		return "", fmt.Errorf("%s", msg)
+	}
+
+	// Update status with the reconciliation progress.
+	// revision := source.GetArtifact().Revision
+
+	// Create tmp dir.
+	tmpDir, err := os.MkdirTemp("", fmt.Sprintf("kustomization-%s", source.GetArtifact().Revision))
+	if err != nil {
+		err = fmt.Errorf("tmp dir error: %w", err)
+		return "", err
+	}
+
+	artifactFetcher := fetch.NewArchiveFetcher(
+		1,
+		tar.UnlimitedUntarSize,
+		tar.UnlimitedUntarSize,
+		os.Getenv("SOURCE_CONTROLLER_LOCALHOST"),
+	)
+
+	// Download artifact and extract files to the tmp dir.
+	err = artifactFetcher.Fetch(source.GetArtifact().URL, source.GetArtifact().Digest, tmpDir)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpDir, nil
+}
+
+func getSource(ctx context.Context, c client.Client, namespace, sourceName, sourceKind string,
+) (client.Object, error) {
+
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      sourceName,
+	}
+
+	switch sourceKind {
+	case sourcev1.GitRepositoryKind:
+		var repository sourcev1.GitRepository
+		err := c.Get(ctx, namespacedName, &repository)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("unable to get source '%s': %w", namespacedName, err)
+		}
+		return &repository, nil
+	case sourcev1b2.OCIRepositoryKind:
+		var repository sourcev1b2.OCIRepository
+		err := c.Get(ctx, namespacedName, &repository)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("unable to get source '%s': %w", namespacedName, err)
+		}
+		return &repository, nil
+	case sourcev1b2.BucketKind:
+		var bucket sourcev1b2.Bucket
+		err := c.Get(ctx, namespacedName, &bucket)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("unable to get source '%s': %w", namespacedName, err)
+		}
+		return &bucket, nil
+	default:
+		return nil, fmt.Errorf("source `%s` kind '%s' not supported",
+			sourceName, sourceKind)
+	}
+}

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,10 +24,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:main
+        image: projectsveltos/addon-controller-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -677,11 +677,14 @@ spec:
                       - Remote
                       type: string
                     kind:
-                      description: 'Kind of the resource. Supported kinds are: Secrets
-                        and ConfigMaps.'
+                      description: 'Kind of the resource. Supported kinds are: - ConfigMap/Secret
+                        - flux GitRepository;OCIRepository;Bucket'
                       enum:
-                      - Secret
+                      - GitRepository
+                      - OCIRepository
+                      - Bucket
                       - ConfigMap
+                      - Secret
                       type: string
                     name:
                       description: Name of the referenced resource.
@@ -692,6 +695,11 @@ spec:
                         namespace can be left empty. In such a case, namespace will
                         be implicit set to cluster's namespace. For Profile namespace
                         must be left empty. Profile namespace will be used.
+                      type: string
+                    path:
+                      description: Path to the directory containing the YAML files.
+                        Defaults to 'None', which translates to the root path of the
+                        SourceRef. Used only for GitRepository;OCIRepository;Bucket
                       type: string
                   required:
                   - kind
@@ -1718,10 +1726,13 @@ spec:
                           type: string
                         kind:
                           description: 'Kind of the resource. Supported kinds are:
-                            Secrets and ConfigMaps.'
+                            - ConfigMap/Secret - flux GitRepository;OCIRepository;Bucket'
                           enum:
-                          - Secret
+                          - GitRepository
+                          - OCIRepository
+                          - Bucket
                           - ConfigMap
+                          - Secret
                           type: string
                         name:
                           description: Name of the referenced resource.
@@ -1733,6 +1744,11 @@ spec:
                             will be implicit set to cluster's namespace. For Profile
                             namespace must be left empty. Profile namespace will be
                             used.
+                          type: string
+                        path:
+                          description: Path to the directory containing the YAML files.
+                            Defaults to 'None', which translates to the root path
+                            of the SourceRef. Used only for GitRepository;OCIRepository;Bucket
                           type: string
                       required:
                       - kind
@@ -2329,11 +2345,14 @@ spec:
                       - Remote
                       type: string
                     kind:
-                      description: 'Kind of the resource. Supported kinds are: Secrets
-                        and ConfigMaps.'
+                      description: 'Kind of the resource. Supported kinds are: - ConfigMap/Secret
+                        - flux GitRepository;OCIRepository;Bucket'
                       enum:
-                      - Secret
+                      - GitRepository
+                      - OCIRepository
+                      - Bucket
                       - ConfigMap
+                      - Secret
                       type: string
                     name:
                       description: Name of the referenced resource.
@@ -2344,6 +2363,11 @@ spec:
                         namespace can be left empty. In such a case, namespace will
                         be implicit set to cluster's namespace. For Profile namespace
                         must be left empty. Profile namespace will be used.
+                      type: string
+                    path:
+                      description: Path to the directory containing the YAML files.
+                        Defaults to 'None', which translates to the root path of the
+                        SourceRef. Used only for GitRepository;OCIRepository;Bucket
                       type: string
                   required:
                   - kind
@@ -3189,10 +3213,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller-amd64:main
+        image: projectsveltos/addon-controller-amd64:dev
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Following ClusterProfile get YAMLs from a git repository, synced in the management cluster with Flux

```yaml
apiVersion: config.projectsveltos.io/v1alpha1
kind: ClusterProfile
metadata:
  name: deploy-kyverno-resources
spec:
  clusterSelector: env=fv
  policyRefs:
  - name: flux-system
    namespace: flux-system
    path: kyverno
    kind: GitRepository
```

This is referenced flux GitRepository instance

```yaml
- apiVersion: source.toolkit.fluxcd.io/v1
  kind: GitRepository
  metadata:
    creationTimestamp: "2024-02-07T13:53:12Z"
    finalizers:
    - finalizers.fluxcd.io
    generation: 1
    labels:
      kustomize.toolkit.fluxcd.io/name: flux-system
      kustomize.toolkit.fluxcd.io/namespace: flux-system
    name: flux-system
    namespace: flux-system
  spec:
    interval: 1m0s
    ref:
      branch: main
    secretRef:
      name: flux-system
    timeout: 60s
    url: https://github.com/gianlucam76/yaml_flux.git
```

Fixes #428 