### PR TITLE
Set namespace to default when not set

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -114,6 +114,7 @@ var (
 	InstantiateTemplateValues = instantiateTemplateValues
 
 	IsCluterSummaryProvisioned = isCluterSummaryProvisioned
+	IsNamespaced               = isNamespaced
 )
 
 type (

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -32,12 +32,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -405,4 +410,26 @@ func getSortedKeys(m map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func isNamespaced(r *unstructured.Unstructured, config *rest.Config) (bool, error) {
+	gvk := schema.GroupVersionKind{
+		Group:   r.GroupVersionKind().Group,
+		Kind:    r.GetKind(),
+		Version: r.GroupVersionKind().Version,
+	}
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return false, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	var mapping *meta.RESTMapping
+	mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, err
+	}
+	return mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -38,6 +38,7 @@ import (
 	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 const (
@@ -287,6 +288,20 @@ var _ = Describe("getClusterProfileOwner ", func() {
 		value, err := controllers.GetMgmtResourceName(clusterSummary, ref)
 		Expect(err).To(BeNil())
 		Expect(value).To(Equal(cluster.Namespace + "-" + cluster.Name))
+	})
+
+	It("isNamespaced returns true for namespaced resources", func() {
+		clusterRole, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
+		Expect(err).To(BeNil())
+		isNamespaced, err := controllers.IsNamespaced(clusterRole, testEnv.Config)
+		Expect(err).To(BeNil())
+		Expect(isNamespaced).To(BeFalse())
+
+		deployment, err := utils.GetUnstructured([]byte(fmt.Sprintf(deplTemplate, randomString())))
+		Expect(err).To(BeNil())
+		isNamespaced, err = controllers.IsNamespaced(deployment, testEnv.Config)
+		Expect(err).To(BeNil())
+		Expect(isNamespaced).To(BeTrue())
 	})
 
 	It("isClusterProvisioned returns true when all Features are marked Provisioned", func() {

--- a/test/fv/resource_test.go
+++ b/test/fv/resource_test.go
@@ -67,7 +67,6 @@ rules:
 kind: Pod
 metadata:
   name: %s
-  namespace: default
   labels:
     environment: production
     app: nginx


### PR DESCRIPTION
For namespaced resources deployed by Sveltos via YAML/JSON/Kustomize when namespace is not set, set it to "default"