### PR TITLE
Print memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ create-control-cluster: $(KIND) $(CLUSTERCTL) $(KUBECTL)
 	sed -e "s/K8S_VERSION/$(K8S_VERSION)/g"  test/$(KIND_CONFIG) > test/$(KIND_CONFIG).tmp
 	$(KIND) create cluster --name=$(CONTROL_CLUSTER_NAME) --config test/$(KIND_CONFIG).tmp
 	@echo "Create control cluster with docker as infrastructure provider"
-	CLUSTER_TOPOLOGY=true $(CLUSTERCTL) init --infrastructure docker
+	CLUSTER_TOPOLOGY=true $(CLUSTERCTL) init --core cluster-api --bootstrap kubeadm --control-plane kubeadm --infrastructure docker
 
 	@echo wait for capd-system pod
 	$(KUBECTL) wait --for=condition=Available deployment/capd-controller-manager -n capd-system --timeout=$(TIMEOUT)

--- a/api/v1alpha1/spec.go
+++ b/api/v1alpha1/spec.go
@@ -189,6 +189,11 @@ type HelmOptions struct {
 	// Labels that would be added to release metadata.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
+
+	// EnableClientCache is a flag to enable Helm client cache. If it is not specified, it will be set to false.
+	// +kubebuilder:default=false
+	// +optional
+	EnableClientCache bool `json:"enableClientCache,omitempty"`
 }
 
 type HelmChart struct {

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -187,6 +187,12 @@ spec:
                             if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                             Default to false
                           type: boolean
+                        enableClientCache:
+                          default: false
+                          description: EnableClientCache is a flag to enable Helm
+                            client cache. If it is not specified, it will be set to
+                            false.
+                          type: boolean
                         labels:
                           additionalProperties:
                             type: string

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -203,6 +203,12 @@ spec:
                                 if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                                 Default to false
                               type: boolean
+                            enableClientCache:
+                              default: false
+                              description: EnableClientCache is a flag to enable Helm
+                                client cache. If it is not specified, it will be set
+                                to false.
+                              type: boolean
                             labels:
                               additionalProperties:
                                 type: string

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -187,6 +187,12 @@ spec:
                             if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                             Default to false
                           type: boolean
+                        enableClientCache:
+                          default: false
+                          description: EnableClientCache is a flag to enable Helm
+                            client cache. If it is not specified, it will be set to
+                            false.
+                          type: boolean
                         labels:
                           additionalProperties:
                             type: string

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,7 +69,10 @@ spec:
           periodSeconds: 10
         volumeMounts:
         - mountPath: /tmp
-          name: tmp            
+          name: tmp
+        resources:
+          requests:
+            memory: 256Mi
       serviceAccountName: controller
       terminationGracePeriodSeconds: 10
       volumes:

--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -367,7 +367,7 @@ func (m *instance) getClusterSummaryKey(clusterSummaryName string) string {
 	return clusterSummaryName
 }
 
-// getReleaseInfoFromKey returns helm release given a key
+// getReleaseInfoFromKey returns helm release for given a key
 func getReleaseInfoFromKey(releaseKey string) *HelmReleaseInfo {
 	info := strings.Split(releaseKey, keySeparator)
 	return &HelmReleaseInfo{

--- a/controllers/profile_transformation_common.go
+++ b/controllers/profile_transformation_common.go
@@ -48,8 +48,6 @@ func requeueForCluster(cluster client.Object,
 
 	profileCurrentlyMatching := getConsumersForEntry(clusterMap, &clusterInfo)
 
-	logger.V(logs.LogInfo).Info(fmt.Sprintf("MGIANLUC %d", profileCurrentlyMatching.Len()))
-
 	clusterLabels[clusterInfo] = cluster.GetLabels()
 
 	// Get all (Cluster)Profiles previously matching this cluster and reconcile those

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -51,6 +51,9 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
+        resources:
+          requests:
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -51,6 +51,9 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
+        resources:
+          requests:
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -564,6 +564,12 @@ spec:
                             if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                             Default to false
                           type: boolean
+                        enableClientCache:
+                          default: false
+                          description: EnableClientCache is a flag to enable Helm
+                            client cache. If it is not specified, it will be set to
+                            false.
+                          type: boolean
                         labels:
                           additionalProperties:
                             type: string
@@ -1690,6 +1696,12 @@ spec:
                                 if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                                 Default to false
                               type: boolean
+                            enableClientCache:
+                              default: false
+                              description: EnableClientCache is a flag to enable Helm
+                                client cache. If it is not specified, it will be set
+                                to false.
+                              type: boolean
                             labels:
                               additionalProperties:
                                 type: string
@@ -2373,6 +2385,12 @@ spec:
                           description: |-
                             if set, the installation process will not validate rendered templates against the Kubernetes OpenAPI Schema
                             Default to false
+                          type: boolean
+                        enableClientCache:
+                          default: false
+                          description: EnableClientCache is a flag to enable Helm
+                            client cache. If it is not specified, it will be set to
+                            false.
                           type: boolean
                         labels:
                           additionalProperties:
@@ -3454,6 +3472,9 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           periodSeconds: 10
+        resources:
+          requests:
+            memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/test/kind-cluster.yaml
+++ b/test/kind-cluster.yaml
@@ -24,3 +24,10 @@ nodes:
       containerPath: /var/run/docker.sock
     - hostPath: /usr/share/zoneinfo
       containerPath: /usr/share/zoneinfo
+- role: worker
+  image: kindest/node:K8S_VERSION
+  extraMounts:
+    - hostPath: /var/run/docker.sock
+      containerPath: /var/run/docker.sock
+    - hostPath: /usr/share/zoneinfo
+      containerPath: /usr/share/zoneinfo


### PR DESCRIPTION
Add EnableClientCache to Helm options. That is a flag to enable Helm client cache (false by default).
