### PR TITLE
Allow KustomizationRef.Path and PolicyRef.Path to be template

### DIFF
--- a/controllers/handlers_kustomize.go
+++ b/controllers/handlers_kustomize.go
@@ -434,8 +434,18 @@ func deployKustomizeRef(ctx context.Context, c client.Client, remoteRestConfig *
 
 	defer os.RemoveAll(tmpDir)
 
+	// Path can be expressed as a template and instantiate using Cluster fields.
+	instantiatedPath, err := instantiateTemplateValues(ctx, getManagementClusterConfig(), getManagementClusterClient(),
+		clusterSummary.Spec.ClusterType, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.GetName(), kustomizationRef.Path, nil, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("using path %s", instantiatedPath))
+
 	// check build path exists
-	dirPath := filepath.Join(tmpDir, kustomizationRef.Path)
+	dirPath := filepath.Join(tmpDir, instantiatedPath)
 	_, err = os.Stat(dirPath)
 	if err != nil {
 		err = fmt.Errorf("kustomization path not found: %w", err)

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -145,8 +145,18 @@ func deployContentOfSource(ctx context.Context, deployingToMgmtCluster bool, des
 
 	defer os.RemoveAll(tmpDir)
 
+	// Path can be expressed as a template and instantiate using Cluster fields.
+	instantiatedPath, err := instantiateTemplateValues(ctx, getManagementClusterConfig(), getManagementClusterClient(),
+		clusterSummary.Spec.ClusterType, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		clusterSummary.GetName(), path, nil, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("using path %s", instantiatedPath))
+
 	// check build path exists
-	dirPath := filepath.Join(tmpDir, path)
+	dirPath := filepath.Join(tmpDir, instantiatedPath)
 	_, err = os.Stat(dirPath)
 	if err != nil {
 		logger.Error(err, "source path not found")


### PR DESCRIPTION
This allow Sveltos to decide which path to use at run-time.

For instance, this repo https://github.com/gianlucam76/kustomize has two directories with kustomize files:

1. production
2. pre-production

The only difference between the two is that Deployment in production/helloWorld has replicas set to 3, while the Deployment in pre-production/helloWorld has replicase set to 1.

By creating this ClusterProfile:

```yaml
apiVersion: config.projectsveltos.io/v1alpha1
kind: ClusterProfile
metadata:
  name: flux-system
spec:
  clusterSelector: region=west
  syncMode: Continuous
  kustomizationRefs:
  - namespace: flux-system
    name: flux-system
    kind: GitRepository
    path: '{{ index .Cluster.metadata.annotations "environment" }}/helloWorld'
    targetNamespace: eng
```

For every matching cluster, Sveltos will first instantiate the __path__ so:

1. picking production/helloWorld path if cluster has annotation ```environment: production```
2. picking pre-production/helloWorld path if cluster has annotation ```environment: pre-production```

Closes #532 
Closes [278](https://github.com/projectsveltos/sveltos/issues/278)
