### PR TITLE
Use custom split

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -1571,7 +1571,7 @@ func collectResourcesFromManagedHelmCharts(ctx context.Context, c client.Client,
 func collectHelmContent(manifest string, logger logr.Logger) ([]*unstructured.Unstructured, error) {
 	resources := make([]*unstructured.Unstructured, 0)
 
-	elements := strings.Split(manifest, separator)
+	elements := customSplit(manifest)
 	for i := range elements {
 		section := removeCommentsAndEmptyLines(elements[i])
 		if section == "" {

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -464,6 +464,19 @@ func removeCommentsAndEmptyLines(text string) string {
 	return result
 }
 
+func customSplit(text string) []string {
+	var result []string
+	start := 0
+	for i := range text {
+		if i > 0 && text[i-1] != ' ' && strings.HasPrefix(text[i:], separator) { // Check for "---" not preceded by space
+			result = append(result, text[start:i])
+			start = i + 3
+		}
+	}
+	result = append(result, text[start:])
+	return result
+}
+
 // collectContent collect policies contained in a ConfigMap/Secret.
 // ConfigMap/Secret Data might have one or more keys. Each key might contain a single policy
 // or multiple policies separated by '---'
@@ -476,7 +489,7 @@ func collectContent(ctx context.Context, clusterSummary *configv1alpha1.ClusterS
 	policies := make([]*unstructured.Unstructured, 0)
 
 	for k := range data {
-		elements := strings.Split(data[k], separator)
+		elements := customSplit(data[k])
 		for i := range elements {
 			section := removeCommentsAndEmptyLines(elements[i])
 			if section == "" {
@@ -516,7 +529,7 @@ func collectContent(ctx context.Context, clusterSummary *configv1alpha1.ClusterS
 
 func getUnstructured(section []byte, logger logr.Logger) ([]*unstructured.Unstructured, error) {
 	policies := make([]*unstructured.Unstructured, 0)
-	elements := strings.Split(string(section), separator)
+	elements := customSplit(string(section))
 
 	for i := range elements {
 		section := removeCommentsAndEmptyLines(elements[i])

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -259,8 +259,7 @@ func deployDriftDetectionManagerInManagementCluster(ctx context.Context, restCon
 func deployDriftDetectionManagerResources(ctx context.Context, restConfig *rest.Config,
 	driftDetectionManagerYAML string, lbls map[string]string, logger logr.Logger) error {
 
-	const separator = "---"
-	elements := strings.Split(driftDetectionManagerYAML, separator)
+	elements := customSplit(driftDetectionManagerYAML)
 	for i := range elements {
 		policy, err := utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {
@@ -502,8 +501,7 @@ func removeDriftDetectionManagerFromManagementCluster(ctx context.Context,
 
 	restConfig := getManagementClusterConfig()
 
-	const separator = "---"
-	elements := strings.Split(driftDetectionManagerYAML, separator)
+	elements := customSplit(driftDetectionManagerYAML)
 	for i := range elements {
 		policy, err := utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {


### PR DESCRIPTION
Sveltos expects content of ConfigMap can contain multiple resources separated by "---"

Sometime those resources might contain ConfigMap which in turn contains "---"

Replace strings.Split with customSplit that splits only if line is "---"