### PR TITLE
PolicyRefs: referenced ConfigMap/Secret with multiple resources

### DIFF
--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -333,7 +333,7 @@ func deployUnstructured(ctx context.Context, deployingToMgmtCluster bool, destCo
 				reports = append(reports, *conflictResourceReport)
 				continue
 			}
-			return nil, err
+			return reports, err
 		}
 
 		deployer.AddOwnerReference(policy, profile)
@@ -353,7 +353,7 @@ func deployUnstructured(ctx context.Context, deployingToMgmtCluster bool, destCo
 
 		err = updateResource(ctx, dr, clusterSummary, policy, logger)
 		if err != nil {
-			return nil, err
+			return reports, err
 		}
 
 		resource.LastAppliedTime = &metav1.Time{Time: time.Now()}
@@ -769,10 +769,13 @@ func deployObjects(ctx context.Context, deployingToMgmtCluster bool, destClient 
 					clusterSummary, mgmtResources, logger)
 		}
 
-		if err != nil {
-			return nil, err
+		if tmpResourceReports != nil {
+			reports = append(reports, tmpResourceReports...)
 		}
-		reports = append(reports, tmpResourceReports...)
+
+		if err != nil {
+			return reports, err
+		}
 	}
 
 	return reports, nil


### PR DESCRIPTION
When ClusterProfile/Profile references a ConfigMap or a Secret whose data section contains multiple resources, Sveltos tries to deploy each one of them.

Before this PR, if a ConfigMap contained an entry in its Data section with following resources:

1. deployment
2. service
3. secret

If deploying the deployment succeeded, but deploying service failed, Sveltos did not update the
ClusterSummary.Status.featureSummaries.deployedGroupVersionKind

that field is used by Sveltos to understand which resources to cleanup when a cleanup is needed.

So if in this state, ClusterProfile was deleted or the cluster stopped being a match, the deployed Deployment instance was never removed from the managed cluster.

This PR fixes that by always reporting the GVKs of the resources deployed even an error happens mid way.