### PR TITLE
Set resource version when updating an object

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.29.2-0.20240514105451-8d864115aeb3
+	github.com/projectsveltos/libsveltos v0.29.2-0.20240515110222-363f6838ddc0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.29.2-0.20240514105451-8d864115aeb3 h1:ELFLrYMhMHAgkl4HrDy9iwFJkL93HRUAvYH/jfm0+R4=
-github.com/projectsveltos/libsveltos v0.29.2-0.20240514105451-8d864115aeb3/go.mod h1:hCFMjAjY3d/h3Nw2ZBREFqDenhqYyZl2lJlybpEcuzM=
+github.com/projectsveltos/libsveltos v0.29.2-0.20240515110222-363f6838ddc0 h1:xz2LXv5tiMeVQrc5kGT8sgwOowYIP3mRLX4me8kOO5w=
+github.com/projectsveltos/libsveltos v0.29.2-0.20240515110222-363f6838ddc0/go.mod h1:hCFMjAjY3d/h3Nw2ZBREFqDenhqYyZl2lJlybpEcuzM=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=


### PR DESCRIPTION
The canDeployResource function validates if objects can be deployed. It achieves this by fetching the object from the managed cluster and using its metadata to detect and potentially resolve conflicts. If a conflict is detected, and the decision favors current clusterSummary instance, the policy is updated.

However, it's crucial to ensure that between the time canDeployResource runs and the policy update, no other modifications occur to the object. This includes updates from other ClusterSummary instances. To guarantee consistency, we leverage the object's resourceVersion obtained by canDeployResource when fetching the object. Setting the resource version during policy update acts as an optimistic locking mechanism. If the object has been modified since the canDeployResource call, setting the resource version will fail, invalidating previous conflict call and preventing unintended overwrites.

This approach ensures that conflict resolution decisions made by canDeployResource remain valid during the policy update.