### PR TITLE
Addon-controller with git

### DIFF
--- a/Dockerfile_WithGit
+++ b/Dockerfile_WithGit
@@ -1,0 +1,32 @@
+# Build the manager binary
+FROM golang:1.22 as builder
+
+ARG BUILDOS
+ARG TARGETARCH
+
+WORKDIR /workspace
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY cmd/main.go cmd/main.go
+COPY api/ api/
+COPY controllers/ controllers/
+COPY pkg/ pkg/
+COPY internal/ internal/
+
+# Build
+RUN CGO_ENABLED=0 GOOS=$BUILDOS GOARCH=$TARGETARCH go build -a -o manager cmd/main.go
+
+# This is needed to support kustomization that points to a oci/git repo that utilizes remote kustomization references.
+FROM alpine
+RUN apk add --no-cache git
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build
@@ -362,6 +362,7 @@ docker-push: ## Push docker image with the manager.
 .PHONY: docker-buildx
 docker-buildx: ## docker build for multiple arch and push to docker hub
 	docker buildx build --push --platform linux/amd64,linux/arm64 -t $(CONTROLLER_IMG):$(TAG) .
+	docker buildx build --push --platform linux/amd64,linux/arm64 -t $(CONTROLLER_IMG)-git:$(TAG) -f Dockerfile_WithGit .
 
 .PHONY: load-image
 load-image: docker-build $(KIND)

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,4 +15,4 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller:main
+      - image: projectsveltos/addon-controller:dev
         name: controller

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --agent-in-mgmt-cluster
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -4054,10 +4054,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Kustomization file can reference resources from a Kustomization directory in another Git repository.
Kustomize supports fetching resources from remote repositories using URLs.

In order for that to work __git__ is required.

This PR allows building another image for addon-controller that contains git:

```
kubectl exec -it -n projectsveltos                      addon-controller-68988cc5c6-6fk6j   -- sh
~ $ ls /usr/bin/git
/usr/bin/git
~ $ /usr/bin/git version
git version 2.43.0
~ $ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```

Fixes #515 