### PR TITLE
Watch resources listed in TemplateResourceRefs 

### DIFF
--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -296,12 +296,10 @@ func genericUndeploy(ctx context.Context, c client.Client,
 func (r *ClusterSummaryReconciler) isFeatureStatusPresent(clusterSummary *configv1alpha1.ClusterSummary,
 	featureID configv1alpha1.FeatureID) bool {
 
-	for i := range clusterSummary.Status.FeatureSummaries {
-		fs := clusterSummary.Status.FeatureSummaries[i]
-		if fs.FeatureID == featureID {
-			return true
-		}
+	if fs := getFeatureSummaryForFeatureID(clusterSummary, featureID); fs != nil {
+		return true
 	}
+
 	return false
 }
 
@@ -310,14 +308,11 @@ func (r *ClusterSummaryReconciler) isFeatureStatusPresent(clusterSummary *config
 func (r *ClusterSummaryReconciler) isFeatureDeployed(clusterSummary *configv1alpha1.ClusterSummary,
 	featureID configv1alpha1.FeatureID) bool {
 
-	for i := range clusterSummary.Status.FeatureSummaries {
-		fs := clusterSummary.Status.FeatureSummaries[i]
-		if fs.FeatureID == featureID {
-			if fs.Status == configv1alpha1.FeatureStatusProvisioned {
-				return true
-			}
-		}
+	fs := getFeatureSummaryForFeatureID(clusterSummary, featureID)
+	if fs != nil && fs.Status == configv1alpha1.FeatureStatusProvisioned {
+		return true
 	}
+
 	return false
 }
 
@@ -325,14 +320,11 @@ func (r *ClusterSummaryReconciler) isFeatureDeployed(clusterSummary *configv1alp
 func (r *ClusterSummaryReconciler) isFeatureFailedWithNonRetriableError(clusterSummary *configv1alpha1.ClusterSummary,
 	featureID configv1alpha1.FeatureID) bool {
 
-	for i := range clusterSummary.Status.FeatureSummaries {
-		fs := clusterSummary.Status.FeatureSummaries[i]
-		if fs.FeatureID == featureID {
-			if fs.Status == configv1alpha1.FeatureStatusFailedNonRetriable {
-				return true
-			}
-		}
+	fs := getFeatureSummaryForFeatureID(clusterSummary, featureID)
+	if fs != nil && fs.Status == configv1alpha1.FeatureStatusFailedNonRetriable {
+		return true
 	}
+
 	return false
 }
 
@@ -341,14 +333,11 @@ func (r *ClusterSummaryReconciler) isFeatureFailedWithNonRetriableError(clusterS
 func (r *ClusterSummaryReconciler) isFeatureRemoved(clusterSummary *configv1alpha1.ClusterSummary,
 	featureID configv1alpha1.FeatureID) bool {
 
-	for i := range clusterSummary.Status.FeatureSummaries {
-		fs := clusterSummary.Status.FeatureSummaries[i]
-		if fs.FeatureID == featureID {
-			if fs.Status == configv1alpha1.FeatureStatusRemoved {
-				return true
-			}
-		}
+	fs := getFeatureSummaryForFeatureID(clusterSummary, featureID)
+	if fs != nil && fs.Status == configv1alpha1.FeatureStatusRemoved {
+		return true
 	}
+
 	return false
 }
 
@@ -359,12 +348,10 @@ func (r *ClusterSummaryReconciler) getHash(clusterSummaryScope *scope.ClusterSum
 
 	clusterSummary := clusterSummaryScope.ClusterSummary
 
-	for i := range clusterSummary.Status.FeatureSummaries {
-		fs := clusterSummary.Status.FeatureSummaries[i]
-		if fs.FeatureID == featureID {
-			return fs.Hash
-		}
+	if fs := getFeatureSummaryForFeatureID(clusterSummary, featureID); fs != nil {
+		return fs.Hash
 	}
+
 	return nil
 }
 

--- a/controllers/clustersummary_watchers.go
+++ b/controllers/clustersummary_watchers.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
@@ -58,7 +59,23 @@ type manager struct {
 	watchers map[schema.GroupVersionKind]context.CancelFunc
 
 	// List of ClusterSummary requesting a watcher for a given GVK
-	requestor map[schema.GroupVersionKind]*libsveltosset.Set
+	// Those are resources deployed in the management cluster. ClusterSummaries
+	// need to watch those resources and reconcile when those resources are modified
+	// if mode is ContinuousWithDriftDetection.
+	requestorForMgmtResourcesKustomizeRef map[schema.GroupVersionKind]*libsveltosset.Set
+	requestorForMgmtResourcesPolicyRef    map[schema.GroupVersionKind]*libsveltosset.Set
+
+	// key: resource being watched, value: list of ClusterSummary interested in this resource
+	mgmtResourcesWatchedKustomizeRef map[corev1.ObjectReference]*libsveltosset.Set
+	mgmtResourcesWatchedPolicyRef    map[corev1.ObjectReference]*libsveltosset.Set
+
+	// List of ClusterSummary requesting a watcher for a given GVK
+	// TemplateResourceRefs is a list of resource to collect from the management cluster.
+	// Those resources' values will be used to instantiate templates contained in referenced
+	requestorForTemplateResourceRefs map[schema.GroupVersionKind]*libsveltosset.Set
+
+	// key: resource being watched, value: list of ClusterSummary interested in this resource
+	templateResourceRefsWatched map[corev1.ObjectReference]*libsveltosset.Set
 }
 
 // initializeManager initializes a manager implementing the Watchers
@@ -71,7 +88,12 @@ func initializeManager(l logr.Logger, config *rest.Config, c client.Client) {
 			managerInstance = &manager{log: l, Client: c, config: config}
 			managerInstance.watchMu = &sync.RWMutex{}
 			managerInstance.watchers = make(map[schema.GroupVersionKind]context.CancelFunc)
-			managerInstance.requestor = make(map[schema.GroupVersionKind]*libsveltosset.Set)
+			managerInstance.requestorForMgmtResourcesKustomizeRef = make(map[schema.GroupVersionKind]*libsveltosset.Set)
+			managerInstance.requestorForMgmtResourcesPolicyRef = make(map[schema.GroupVersionKind]*libsveltosset.Set)
+			managerInstance.requestorForTemplateResourceRefs = make(map[schema.GroupVersionKind]*libsveltosset.Set)
+			managerInstance.mgmtResourcesWatchedKustomizeRef = make(map[corev1.ObjectReference]*libsveltosset.Set)
+			managerInstance.mgmtResourcesWatchedPolicyRef = make(map[corev1.ObjectReference]*libsveltosset.Set)
+			managerInstance.templateResourceRefsWatched = make(map[corev1.ObjectReference]*libsveltosset.Set)
 		}
 	}
 }
@@ -81,61 +103,203 @@ func getManager() *manager {
 	return managerInstance
 }
 
-// WatchGVK starts a watcher if one does not exist already
-func (m *manager) watchGVK(ctx context.Context, gvk schema.GroupVersionKind,
-	clusterSummary *configv1alpha1.ClusterSummary) error {
+// startWatcherForMgmtResource starts a watcher if one does not exist already.
+// ClusterSummary is listed as one of the consumer for this watcher.
+// ClusterSummary will only receive updates when the specific resource itself changes, not when other resources of the same type change.
+func (m *manager) startWatcherForMgmtResource(ctx context.Context, gvk schema.GroupVersionKind,
+	resource *corev1.ObjectReference, clusterSummary *configv1alpha1.ClusterSummary, fID configv1alpha1.FeatureID) error {
+
+	consumer := &corev1.ObjectReference{
+		APIVersion: configv1alpha1.GroupVersion.Group,
+		Kind:       configv1alpha1.ClusterSummaryKind,
+		Namespace:  clusterSummary.Namespace,
+		Name:       clusterSummary.Name,
+	}
 
 	m.watchMu.Lock()
 	defer m.watchMu.Unlock()
 
-	m.log.V(logs.LogDebug).Info(fmt.Sprintf("request to watch %s from %s/%s",
-		gvk.String(), clusterSummary.Namespace, clusterSummary.Name))
+	m.log.V(logs.LogDebug).Info(fmt.Sprintf("request to watch %s %s/%s from %s/%s",
+		gvk.String(),
+		resource.Namespace, resource.Name,
+		clusterSummary.Namespace, clusterSummary.Name))
 
 	err := m.startWatcher(ctx, &gvk)
 	if err != nil {
 		return err
 	}
-	if _, ok := m.requestor[gvk]; !ok {
-		s := &libsveltosset.Set{}
-		m.requestor[gvk] = s
-	}
 
-	m.requestor[gvk].Insert(&corev1.ObjectReference{
+	gvkSet := m.getGVKMapEntryForFeatureID(gvk, fID)
+	gvkSet.Insert(consumer)
+
+	resourceSet := m.getResourceMapEntryForFeatureID(resource, fID)
+	resourceSet.Insert(consumer)
+	return nil
+}
+
+// startWatcherForTemplateResourceRef starts a watcher if one does not exist already
+// ClusterSummary is listed as one of the consumer for this watcher.
+// ClusterSummary will only receive updates when the specific resource itself changes, not when other resources of the same type change.
+func (m *manager) startWatcherForTemplateResourceRef(ctx context.Context, gvk schema.GroupVersionKind,
+	resource *corev1.ObjectReference, clusterSummary *configv1alpha1.ClusterSummary) error {
+
+	consumer := &corev1.ObjectReference{
 		APIVersion: configv1alpha1.GroupVersion.Group,
 		Kind:       configv1alpha1.ClusterSummaryKind,
 		Namespace:  clusterSummary.Namespace,
 		Name:       clusterSummary.Name,
-	})
-	return nil
-}
-
-func (m *manager) stopStaleWatch(currentGVKs map[schema.GroupVersionKind]bool,
-	clusterSummary *configv1alpha1.ClusterSummary) {
+	}
 
 	m.watchMu.Lock()
 	defer m.watchMu.Unlock()
 
-	for gvk := range m.requestor {
-		if currentGVKs != nil && currentGVKs[gvk] {
+	m.log.V(logs.LogDebug).Info(fmt.Sprintf("request to watch %s %s/%s from %s/%s",
+		gvk.String(),
+		resource.Namespace, resource.Name,
+		clusterSummary.Namespace, clusterSummary.Name))
+
+	err := m.startWatcher(ctx, &gvk)
+	if err != nil {
+		return err
+	}
+	if _, ok := m.requestorForTemplateResourceRefs[gvk]; !ok {
+		s := &libsveltosset.Set{}
+		m.requestorForTemplateResourceRefs[gvk] = s
+	}
+
+	m.requestorForTemplateResourceRefs[gvk].Insert(consumer)
+
+	if _, ok := m.templateResourceRefsWatched[*resource]; !ok {
+		s := &libsveltosset.Set{}
+		m.templateResourceRefsWatched[*resource] = s
+	}
+
+	m.templateResourceRefsWatched[*resource].Insert(consumer)
+
+	return nil
+}
+
+// This function identifies resources that the ClusterSummary object is no longer interested in.
+// It then stops any watchers that were previously set up to deliver notifications about those specific
+// resources to ClusterSummary.
+// Resources that are still included in the currentResources map will continue to be watched.
+func (m *manager) stopStaleWatchForMgmtResource(currentResources map[corev1.ObjectReference]bool,
+	clusterSummary *configv1alpha1.ClusterSummary, fId configv1alpha1.FeatureID) {
+
+	consumer := &corev1.ObjectReference{
+		APIVersion: configv1alpha1.GroupVersion.Group,
+		Kind:       configv1alpha1.ClusterSummaryKind,
+		Namespace:  clusterSummary.Namespace,
+		Name:       clusterSummary.Name,
+	}
+
+	currentGVKs := make(map[schema.GroupVersionKind]bool)
+	for resource := range currentResources {
+		gvk := schema.GroupVersionKind{
+			Kind:    resource.Kind,
+			Group:   resource.GroupVersionKind().Group,
+			Version: resource.GroupVersionKind().Version,
+		}
+		currentGVKs[gvk] = true
+	}
+
+	m.watchMu.Lock()
+	defer m.watchMu.Unlock()
+
+	gvkMap := m.getGVKMapForFeatureID(fId)
+
+	for gvk := range gvkMap {
+		if currentGVKs[gvk] {
 			// ClusterSummary still wants a watcher for this GVK
 			continue
 		}
 
-		requestors := m.requestor[gvk]
-		requestors.Erase(&corev1.ObjectReference{
-			APIVersion: configv1alpha1.GroupVersion.Group,
-			Kind:       configv1alpha1.ClusterSummaryKind,
-			Namespace:  clusterSummary.Namespace,
-			Name:       clusterSummary.Name,
-		})
-		m.requestor[gvk] = requestors
+		s := m.getGVKMapEntryForFeatureID(gvk, fId)
+		s.Erase(consumer)
+		m.setGVKMapEntryForFeatureID(gvk, fId, s)
 
-		// If no ClusterSummary wants to watch this gvk, stop watcher
-		if requestors.Len() == 0 {
+		if m.canStopWatcher(gvk) {
 			if cancel, ok := m.watchers[gvk]; ok {
 				m.log.V(logs.LogInfo).Info(fmt.Sprintf("stop watching gvk: %s", gvk.String()))
 				cancel()
 				delete(m.watchers, gvk)
+			}
+		}
+	}
+
+	resourceMap := m.getResourceMapForFeatureID(fId)
+
+	for resource := range resourceMap {
+		if _, ok := currentResources[resource]; !ok {
+			s := m.getResourceMapEntryForFeatureID(&resource, fId)
+			s.Erase(consumer)
+			m.setResourceMapEntryForFeatureID(&resource, fId, s)
+		}
+	}
+}
+
+// This function identifies resources that the ClusterSummary object is no longer interested in.
+// It then stops any watchers that were previously set up to deliver notifications about those specific
+// resources to ClusterSummary.
+// Resources that are still included in the currentResources map will continue to be watched.
+func (m *manager) stopStaleWatchForTemplateResourceRef(clusterSummary *configv1alpha1.ClusterSummary,
+	removeAll bool) {
+
+	consumer := &corev1.ObjectReference{
+		APIVersion: configv1alpha1.GroupVersion.Group,
+		Kind:       configv1alpha1.ClusterSummaryKind,
+		Namespace:  clusterSummary.Namespace,
+		Name:       clusterSummary.Name,
+	}
+
+	currentGVKs := make(map[schema.GroupVersionKind]bool)
+	currentResources := make(map[corev1.ObjectReference]bool)
+	if !removeAll {
+		for i := range clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs {
+			resource := &clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs[i].Resource
+			resource.Namespace = getTemplateResourceNamespace(clusterSummary,
+				&clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs[i])
+			resource.Name, _ = getTemplateResourceName(clusterSummary,
+				&clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs[i])
+
+			currentResources[*resource] = true
+
+			gvk := schema.GroupVersionKind{
+				Kind:    resource.Kind,
+				Group:   resource.GroupVersionKind().Group,
+				Version: resource.GroupVersionKind().Version,
+			}
+			currentGVKs[gvk] = true
+		}
+	}
+
+	m.watchMu.Lock()
+	defer m.watchMu.Unlock()
+
+	for gvk := range m.requestorForTemplateResourceRefs {
+		if currentGVKs[gvk] {
+			// ClusterSummary still wants a watcher for this GVK
+			continue
+		}
+
+		requestors := m.requestorForTemplateResourceRefs[gvk]
+		requestors.Erase(consumer)
+		m.requestorForTemplateResourceRefs[gvk] = requestors
+
+		if m.canStopWatcher(gvk) {
+			if cancel, ok := m.watchers[gvk]; ok {
+				m.log.V(logs.LogInfo).Info(fmt.Sprintf("stop watching gvk: %s", gvk.String()))
+				cancel()
+				delete(m.watchers, gvk)
+			}
+		}
+	}
+
+	for resource := range m.templateResourceRefsWatched {
+		if _, ok := currentResources[resource]; !ok {
+			m.templateResourceRefsWatched[resource].Erase(consumer)
+			if m.templateResourceRefsWatched[resource].Len() == 0 {
+				delete(m.templateResourceRefsWatched, resource)
 			}
 		}
 	}
@@ -159,7 +323,7 @@ func (m *manager) startWatcher(ctx context.Context, gvk *schema.GroupVersionKind
 
 	watcherCtx, cancel := context.WithCancel(ctx)
 	m.watchers[*gvk] = cancel
-	go m.runInformer(watcherCtx.Done(), dcinformer.Informer(), gvk, logger)
+	go m.runInformer(watcherCtx.Done(), dcinformer.Informer(), logger)
 	return nil
 }
 
@@ -202,20 +366,17 @@ func (m *manager) getDynamicInformer(gvk *schema.GroupVersionKind) (informers.Ge
 }
 
 func (m *manager) runInformer(stopCh <-chan struct{}, s cache.SharedIndexInformer,
-	gvk *schema.GroupVersionKind, logger logr.Logger) {
+	logger logr.Logger) {
 
 	handlers := cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
-			logger.V(logsettings.LogDebug).Info("got add notification")
-			// Nothing to do
+			m.react(obj.(client.Object), logger)
 		},
 		DeleteFunc: func(obj interface{}) {
-			logger.V(logsettings.LogDebug).Info("got delete notification")
-			// Nothing to do
+			m.react(obj.(client.Object), logger)
 		},
 		UpdateFunc: func(oldObj, newObj interface{}) {
-			logger.V(logsettings.LogDebug).Info("got update notification")
-			m.react(gvk)
+			m.react(newObj.(client.Object), logger)
 		},
 	}
 	_, err := s.AddEventHandler(handlers)
@@ -226,33 +387,209 @@ func (m *manager) runInformer(stopCh <-chan struct{}, s cache.SharedIndexInforme
 }
 
 // react gets called when an instance of passed in gvk has been modified.
-// This method queues all Classifier currently using that gvk to be evaluated.
-func (m *manager) react(gvk *schema.GroupVersionKind) {
+func (m *manager) react(obj client.Object, logger logr.Logger) {
 	m.watchMu.RLock()
 	defer m.watchMu.RUnlock()
 
-	if gvk == nil {
-		return
+	ref := corev1.ObjectReference{
+		Kind:       obj.GetObjectKind().GroupVersionKind().Kind,
+		APIVersion: obj.GetObjectKind().GroupVersionKind().GroupVersion().String(),
+		Namespace:  obj.GetNamespace(),
+		Name:       obj.GetName(),
 	}
 
-	if v, ok := m.requestor[*gvk]; ok {
-		requestors := v.Items()
-		for i := range requestors {
-			currentRequestor := &configv1alpha1.ClusterSummary{}
-			err := m.Get(context.TODO(),
-				types.NamespacedName{Namespace: requestors[i].Namespace, Name: requestors[i].Name},
-				currentRequestor)
-			if err != nil {
-				m.log.V(logs.LogInfo).Info(fmt.Sprintf("failed to fetch ClusterSummary %v", err))
-				continue
-			}
-			m.log.V(logs.LogInfo).Info(fmt.Sprintf("requeuing ClusterSummary %s/%s",
-				currentRequestor.Namespace, currentRequestor.Name))
-			err = m.Update(context.TODO(), currentRequestor)
-			if err != nil {
-				m.log.V(logs.LogInfo).Info(fmt.Sprintf("requeuing ClusterSummary %s/%s",
-					currentRequestor.Namespace, currentRequestor.Name))
-			}
+	// finds all ClusterSummary objects that want to be informed about updates to this specific resource.
+	// It takes into account registrations made through KustomizationRefs
+	if v, ok := m.mgmtResourcesWatchedKustomizeRef[ref]; ok {
+		m.notify(v, logger)
+	}
+
+	// finds all ClusterSummary objects that want to be informed about updates to this specific resource.
+	// It takes into account registrations made through PolicyRefs
+	if v, ok := m.mgmtResourcesWatchedPolicyRef[ref]; ok {
+		m.notify(v, logger)
+	}
+
+	// finds all ClusterSummary objects that want to be informed about updates to this specific resource.
+	// It takes into account registrations made through TemplateResourceRefs
+	if v, ok := m.templateResourceRefsWatched[ref]; ok {
+		m.notify(v, logger)
+	}
+}
+
+func (m *manager) notify(consumers *libsveltosset.Set, logger logr.Logger) {
+	requestors := consumers.Items()
+	for i := range requestors {
+		logger.V(logsettings.LogDebug).Info("got change notification. Notifying %s/%s",
+			requestors[i].Namespace, requestors[i].Name)
+		m.notifyConsumer(&requestors[i])
+	}
+}
+
+func (m *manager) notifyConsumer(consumer *corev1.ObjectReference) {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentRequestor := &configv1alpha1.ClusterSummary{}
+		err := m.Get(context.TODO(),
+			types.NamespacedName{Namespace: consumer.Namespace, Name: consumer.Name},
+			currentRequestor)
+		if err != nil {
+			m.log.V(logs.LogInfo).Info(fmt.Sprintf("failed to fetch ClusterSummary %v", err))
+			return err
 		}
+
+		m.log.V(logs.LogInfo).Info(fmt.Sprintf("requeuing ClusterSummary %s/%s",
+			currentRequestor.Namespace, currentRequestor.Name))
+		// reset hash
+		for i := range currentRequestor.Status.FeatureSummaries {
+			currentRequestor.Status.FeatureSummaries[i].Hash = nil
+		}
+		return m.Status().Update(context.TODO(), currentRequestor)
+	})
+	if err != nil {
+		// TODO: if this fails, there is no way to reconcile the ClusterSummary
+		m.log.V(logs.LogInfo).Info(fmt.Sprintf("requeuing ClusterSummary %s/%s",
+			consumer.Namespace, consumer.Name))
+	}
+}
+
+func (m *manager) canStopWatcher(gvk schema.GroupVersionKind) bool {
+	requestors, ok := m.requestorForMgmtResourcesKustomizeRef[gvk]
+	if ok {
+		if requestors.Len() != 0 {
+			return false
+		}
+	}
+
+	requestors, ok = m.requestorForMgmtResourcesPolicyRef[gvk]
+	if ok {
+		if requestors.Len() != 0 {
+			return false
+		}
+	}
+
+	requestors, ok = m.requestorForTemplateResourceRefs[gvk]
+	if ok {
+		if requestors.Len() != 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (m *manager) getGVKMapForFeatureID(fID configv1alpha1.FeatureID) map[schema.GroupVersionKind]*libsveltosset.Set {
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		return m.requestorForMgmtResourcesKustomizeRef
+	case configv1alpha1.FeatureResources:
+		return m.requestorForMgmtResourcesPolicyRef
+	case configv1alpha1.FeatureHelm:
+		panic(1)
+	}
+
+	return nil
+}
+
+func (m *manager) getGVKMapEntryForFeatureID(gvk schema.GroupVersionKind, fID configv1alpha1.FeatureID) *libsveltosset.Set {
+	var s *libsveltosset.Set
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		s = m.requestorForMgmtResourcesKustomizeRef[gvk]
+		if s == nil {
+			s := &libsveltosset.Set{}
+			m.requestorForMgmtResourcesKustomizeRef[gvk] = s
+		}
+	case configv1alpha1.FeatureResources:
+		s := m.requestorForMgmtResourcesPolicyRef[gvk]
+		if s == nil {
+			s := &libsveltosset.Set{}
+			m.requestorForMgmtResourcesPolicyRef[gvk] = s
+		}
+	case configv1alpha1.FeatureHelm:
+		// No resources can be deployed in the management cluster because of helm
+		panic(1)
+	}
+
+	return s
+}
+
+func (m *manager) setGVKMapEntryForFeatureID(gvk schema.GroupVersionKind, fID configv1alpha1.FeatureID,
+	currentSet *libsveltosset.Set) {
+
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		if currentSet.Len() != 0 {
+			m.requestorForMgmtResourcesKustomizeRef[gvk] = currentSet
+		} else {
+			delete(m.requestorForMgmtResourcesKustomizeRef, gvk)
+		}
+	case configv1alpha1.FeatureResources:
+		if currentSet.Len() != 0 {
+			m.requestorForMgmtResourcesPolicyRef[gvk] = currentSet
+		} else {
+			delete(m.requestorForMgmtResourcesKustomizeRef, gvk)
+		}
+	case configv1alpha1.FeatureHelm:
+		// No resources can be deployed in the management cluster because of helm
+		panic(1)
+	}
+}
+
+func (m *manager) getResourceMapForFeatureID(fID configv1alpha1.FeatureID) map[corev1.ObjectReference]*libsveltosset.Set {
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		return m.mgmtResourcesWatchedKustomizeRef
+	case configv1alpha1.FeatureResources:
+		return m.mgmtResourcesWatchedPolicyRef
+	case configv1alpha1.FeatureHelm:
+		// No resources can be deployed in the management cluster because of helm
+		panic(1)
+	}
+
+	return nil
+}
+
+func (m *manager) getResourceMapEntryForFeatureID(resource *corev1.ObjectReference, fID configv1alpha1.FeatureID) *libsveltosset.Set {
+	var s *libsveltosset.Set
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		s = m.mgmtResourcesWatchedKustomizeRef[*resource]
+		if s == nil {
+			s := &libsveltosset.Set{}
+			m.mgmtResourcesWatchedKustomizeRef[*resource] = s
+		}
+	case configv1alpha1.FeatureResources:
+		s := m.mgmtResourcesWatchedPolicyRef[*resource]
+		if s == nil {
+			s := &libsveltosset.Set{}
+			m.mgmtResourcesWatchedPolicyRef[*resource] = s
+		}
+	case configv1alpha1.FeatureHelm:
+		// No resources can be deployed in the management cluster because of helm
+		panic(1)
+	}
+
+	return s
+}
+
+func (m *manager) setResourceMapEntryForFeatureID(resource *corev1.ObjectReference, fID configv1alpha1.FeatureID,
+	currentSet *libsveltosset.Set) {
+
+	switch fID {
+	case configv1alpha1.FeatureKustomize:
+		if currentSet.Len() != 0 {
+			m.mgmtResourcesWatchedKustomizeRef[*resource] = currentSet
+		} else {
+			delete(m.mgmtResourcesWatchedKustomizeRef, *resource)
+		}
+	case configv1alpha1.FeatureResources:
+		if currentSet.Len() != 0 {
+			m.mgmtResourcesWatchedPolicyRef[*resource] = currentSet
+		} else {
+			delete(m.mgmtResourcesWatchedPolicyRef, *resource)
+		}
+	case configv1alpha1.FeatureHelm:
+		// No resources can be deployed in the management cluster because of helm
+		panic(1)
 	}
 }

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -188,7 +188,8 @@ var (
 )
 
 var (
-	GetMgmtResourceName = getMgmtResourceName
+	GetTemplateResourceName      = getTemplateResourceName
+	GetTemplateResourceNamespace = getTemplateResourceNamespace
 )
 
 var (

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -394,6 +394,14 @@ func helmHash(ctx context.Context, c client.Client, clusterSummaryScope *scope.C
 		config += getVersion()
 	}
 
+	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummaryScope.ClusterSummary)
+	if err != nil {
+		return nil, err
+	}
+	for i := range mgmtResources {
+		config += render.AsCode(mgmtResources[i])
+	}
+
 	h.Write([]byte(config))
 	return h.Sum(nil), nil
 }
@@ -478,7 +486,7 @@ func handleCharts(ctx context.Context, clusterSummary *configv1alpha1.ClusterSum
 func walkChartsAndDeploy(ctx context.Context, c client.Client, clusterSummary *configv1alpha1.ClusterSummary,
 	kubeconfig string, logger logr.Logger) ([]configv1alpha1.ReleaseReport, []configv1alpha1.Chart, error) {
 
-	mgmtResources, err := collectMgmtResources(ctx, clusterSummary)
+	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -106,7 +106,7 @@ func deployResources(ctx context.Context, c client.Client,
 	}
 	remoteResourceReports = append(remoteResourceReports, undeployed...)
 
-	err = handleWatchers(ctx, clusterSummary, localResourceReports)
+	err = handleWatchers(ctx, clusterSummary, localResourceReports, featureHandler)
 	if err != nil {
 		return err
 	}
@@ -201,25 +201,39 @@ func handleResourceSummaryDeployment(ctx context.Context, clusterSummary *config
 }
 
 func handleWatchers(ctx context.Context, clusterSummary *configv1alpha1.ClusterSummary,
-	localResourceReports []configv1alpha1.ResourceReport) error {
+	localResourceReports []configv1alpha1.ResourceReport, featureHandler feature) error {
 
-	currentGVKs := make(map[schema.GroupVersionKind]bool)
 	manager := getManager()
-	for i := range localResourceReports {
-		gvk := schema.GroupVersionKind{
-			Group:   localResourceReports[i].Resource.Group,
-			Kind:    localResourceReports[i].Resource.Kind,
-			Version: localResourceReports[i].Resource.Version,
-		}
+	currentResources := make(map[corev1.ObjectReference]bool)
 
-		if err := manager.watchGVK(ctx, gvk, clusterSummary); err != nil {
-			return err
-		}
+	// Only if mode is SyncModeContinuousWithDriftDetection starts those watcher.
+	// A watcher for TemplateResourceRefs is started as part of ClusterSummary reconciler
+	if clusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1alpha1.SyncModeContinuousWithDriftDetection {
+		for i := range localResourceReports {
+			gvk := schema.GroupVersionKind{
+				Group:   localResourceReports[i].Resource.Group,
+				Kind:    localResourceReports[i].Resource.Kind,
+				Version: localResourceReports[i].Resource.Version,
+			}
 
-		currentGVKs[gvk] = true
+			apiVersion, kind := gvk.ToAPIVersionAndKind()
+
+			ref := &corev1.ObjectReference{
+				Kind:       kind,
+				APIVersion: apiVersion,
+				Namespace:  localResourceReports[i].Resource.Namespace,
+				Name:       localResourceReports[i].Resource.Name,
+			}
+
+			if err := manager.startWatcherForMgmtResource(ctx, gvk, ref, clusterSummary, featureHandler.id); err != nil {
+				return err
+			}
+
+			currentResources[*ref] = true
+		}
 	}
 
-	manager.stopStaleWatch(currentGVKs, clusterSummary)
+	manager.stopStaleWatchForMgmtResource(currentResources, clusterSummary, featureHandler.id)
 	return nil
 }
 
@@ -320,7 +334,7 @@ func undeployResources(ctx context.Context, c client.Client,
 	}
 
 	manager := getManager()
-	manager.stopStaleWatch(nil, clusterSummary)
+	manager.stopStaleWatchForMgmtResource(nil, clusterSummary, configv1alpha1.FeatureResources)
 
 	return nil
 }
@@ -402,6 +416,14 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummaryScope *sc
 		// Use the version. This will cause drift-detection, Sveltos CRDs
 		// to be redeployed on upgrade
 		config += getVersion()
+	}
+
+	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
+	if err != nil {
+		return nil, err
+	}
+	for i := range mgmtResources {
+		config += render.AsCode(mgmtResources[i])
 	}
 
 	h.Write([]byte(config))

--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
+	"github.com/projectsveltos/libsveltos/lib/utils"
+)
+
+// The TemplateResource namespace can be specified or it will inherit the cluster namespace
+func getTemplateResourceNamespace(clusterSummary *configv1alpha1.ClusterSummary,
+	ref *configv1alpha1.TemplateResourceRef) string {
+
+	namespace := ref.Resource.Namespace
+	if namespace == "" {
+		// Use cluster namespace
+		namespace = clusterSummary.Spec.ClusterNamespace
+	}
+
+	return namespace
+}
+
+// Resources referenced in the management cluster can have their name expressed in function
+// of cluster information (clusterNamespace, clusterName, clusterType)
+func getTemplateResourceName(clusterSummary *configv1alpha1.ClusterSummary,
+	ref *configv1alpha1.TemplateResourceRef) (string, error) {
+
+	// Accept name that are templates
+	templateName := getTemplateName(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+		string(clusterSummary.Spec.ClusterType))
+	tmpl, err := template.New(templateName).Option("missingkey=error").Funcs(sprig.FuncMap()).Parse(ref.Resource.Name)
+	if err != nil {
+		return "", err
+	}
+
+	var buffer bytes.Buffer
+
+	if err := tmpl.Execute(&buffer,
+		struct{ ClusterNamespace, ClusterName string }{
+			ClusterNamespace: clusterSummary.Spec.ClusterNamespace,
+			ClusterName:      clusterSummary.Spec.ClusterName}); err != nil {
+		return "", errors.Wrapf(err, "error executing template")
+	}
+	return buffer.String(), nil
+}
+
+// collectTemplateResourceRefs collects clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs
+// from management cluster
+func collectTemplateResourceRefs(ctx context.Context, clusterSummary *configv1alpha1.ClusterSummary,
+) (map[string]*unstructured.Unstructured, error) {
+
+	if clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs == nil {
+		return nil, nil
+	}
+
+	restConfig := getManagementClusterConfig()
+
+	result := make(map[string]*unstructured.Unstructured)
+	for i := range clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs {
+		ref := clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs[i]
+		ref.Resource.Namespace = getTemplateResourceNamespace(clusterSummary, &ref)
+		var err error
+		ref.Resource.Name, err = getTemplateResourceName(clusterSummary, &ref)
+		if err != nil {
+			return nil, err
+		}
+
+		dr, err := utils.GetDynamicResourceInterface(restConfig, ref.Resource.GroupVersionKind(), ref.Resource.Namespace)
+		if err != nil {
+			return nil, err
+		}
+
+		var u *unstructured.Unstructured
+		u, err = dr.Get(ctx, ref.Resource.Name, metav1.GetOptions{})
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, err
+		}
+
+		result[ref.Identifier] = u
+	}
+
+	return result, nil
+}

--- a/controllers/templateresourcedef_utils_test.go
+++ b/controllers/templateresourcedef_utils_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
+	"github.com/projectsveltos/addon-controller/controllers"
+	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
+)
+
+var _ = Describe("TemplateResourceDef utils ", func() {
+	var cluster *clusterv1.Cluster
+	var namespace string
+
+	BeforeEach(func() {
+		var err error
+		scheme, err = setupScheme()
+		Expect(err).ToNot(HaveOccurred())
+
+		namespace = randomString()
+
+		cluster = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      upstreamClusterNamePrefix + randomString(),
+				Namespace: namespace,
+				Labels: map[string]string{
+					randomString(): randomString(),
+				},
+			},
+		}
+	})
+
+	It("GetTemplateResourceName returns the correct name", func() {
+		ref := &configv1alpha1.TemplateResourceRef{
+			Resource: corev1.ObjectReference{
+				Name: "{{ .ClusterNamespace }}-{{ .ClusterName }}",
+			},
+			Identifier: randomString(),
+		}
+
+		clusterSummary := &configv1alpha1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+			Spec: configv1alpha1.ClusterSummarySpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
+			},
+		}
+
+		value, err := controllers.GetTemplateResourceName(clusterSummary, ref)
+		Expect(err).To(BeNil())
+		Expect(value).To(Equal(cluster.Namespace + "-" + cluster.Name))
+	})
+
+	It("GetTemplateResourceNamespace returns the correct namespace", func() {
+		ref := &configv1alpha1.TemplateResourceRef{
+			Resource: corev1.ObjectReference{
+				Name: randomString(),
+			},
+			Identifier: randomString(),
+		}
+
+		clusterSummary := &configv1alpha1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+			Spec: configv1alpha1.ClusterSummarySpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
+			},
+		}
+
+		value := controllers.GetTemplateResourceNamespace(clusterSummary, ref)
+		Expect(value).To(Equal(cluster.Namespace))
+
+		ref.Resource.Namespace = randomString()
+		value = controllers.GetTemplateResourceNamespace(clusterSummary, ref)
+		Expect(value).To(Equal(ref.Resource.Namespace))
+	})
+
+})

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -17,24 +17,19 @@ limitations under the License.
 package controllers
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
 	"strings"
-	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	sourcev1b2 "github.com/fluxcd/source-controller/api/v1beta2"
 	"github.com/gdexlab/go-render/render"
-	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -50,7 +45,6 @@ import (
 	configv1alpha1 "github.com/projectsveltos/addon-controller/api/v1alpha1"
 	libsveltosv1alpha1 "github.com/projectsveltos/libsveltos/api/v1alpha1"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 //+kubebuilder:rbac:groups=extension.projectsveltos.io,resources=yttsources,verbs=get;list;watch
@@ -236,74 +230,6 @@ func addTypeInformationToObject(scheme *runtime.Scheme, obj client.Object) {
 	}
 }
 
-// collectMgmtResources collects clusterSummary.Spec.ClusterProfileSpec.MgmtClusterResources
-// from management cluster
-func collectMgmtResources(ctx context.Context, clusterSummary *configv1alpha1.ClusterSummary,
-) (map[string]*unstructured.Unstructured, error) {
-
-	if clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs == nil {
-		return nil, nil
-	}
-
-	restConfig := getManagementClusterConfig()
-
-	result := make(map[string]*unstructured.Unstructured)
-	for i := range clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs {
-		ref := &clusterSummary.Spec.ClusterProfileSpec.TemplateResourceRefs[i]
-		// If namespace is not defined, default to cluster namespace
-		namespace := ref.Resource.Namespace
-		if namespace == "" {
-			namespace = clusterSummary.Namespace
-		}
-		dr, err := utils.GetDynamicResourceInterface(restConfig, ref.Resource.GroupVersionKind(), namespace)
-		if err != nil {
-			return nil, err
-		}
-
-		instantiatedName, err := getMgmtResourceName(clusterSummary, ref)
-		if err != nil {
-			return nil, err
-		}
-
-		var u *unstructured.Unstructured
-		u, err = dr.Get(ctx, instantiatedName, metav1.GetOptions{})
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-			return nil, err
-		}
-
-		result[ref.Identifier] = u
-	}
-
-	return result, nil
-}
-
-// Resources referenced in the management cluster can have their name expressed in function
-// of cluster information (clusterNamespace, clusterName, clusterType)
-func getMgmtResourceName(clusterSummary *configv1alpha1.ClusterSummary,
-	ref *configv1alpha1.TemplateResourceRef) (string, error) {
-
-	// Accept name that are templates
-	templateName := getTemplateName(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-		string(clusterSummary.Spec.ClusterType))
-	tmpl, err := template.New(templateName).Option("missingkey=error").Funcs(sprig.FuncMap()).Parse(ref.Resource.Name)
-	if err != nil {
-		return "", err
-	}
-
-	var buffer bytes.Buffer
-
-	if err := tmpl.Execute(&buffer,
-		struct{ ClusterNamespace, ClusterName string }{
-			ClusterNamespace: clusterSummary.Spec.ClusterNamespace,
-			ClusterName:      clusterSummary.Spec.ClusterName}); err != nil {
-		return "", errors.Wrapf(err, "error executing template")
-	}
-	return buffer.String(), nil
-}
-
 // isCluterSummaryProvisioned returns true if ClusterSummary is currently fully deployed.
 func isCluterSummaryProvisioned(clusterSumary *configv1alpha1.ClusterSummary) bool {
 	hasHelmCharts := false
@@ -484,4 +410,17 @@ func unique[T comparable](input []T) []T {
 	}
 
 	return unique
+}
+
+// Return FeatureSummaries for featureID
+func getFeatureSummaryForFeatureID(clusterSummay *configv1alpha1.ClusterSummary, fID configv1alpha1.FeatureID,
+) *configv1alpha1.FeatureSummary {
+
+	for i := range clusterSummay.Status.FeatureSummaries {
+		if clusterSummay.Status.FeatureSummaries[i].FeatureID == fID {
+			return &clusterSummay.Status.FeatureSummaries[i]
+		}
+	}
+
+	return nil
 }

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -296,30 +296,6 @@ var _ = Describe("getClusterProfileOwner ", func() {
 		Expect(currentClusterSummary.Name).To(Equal(clusterSummary.Name))
 	})
 
-	It("getMgmtResourceName returns the correct name", func() {
-		ref := &configv1alpha1.TemplateResourceRef{
-			Resource: corev1.ObjectReference{
-				Name: "{{ .ClusterNamespace }}-{{ .ClusterName }}",
-			},
-			Identifier: randomString(),
-		}
-
-		clusterSummary := &configv1alpha1.ClusterSummary{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: randomString(),
-			},
-			Spec: configv1alpha1.ClusterSummarySpec{
-				ClusterNamespace: cluster.Namespace,
-				ClusterName:      cluster.Name,
-				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
-			},
-		}
-
-		value, err := controllers.GetMgmtResourceName(clusterSummary, ref)
-		Expect(err).To(BeNil())
-		Expect(value).To(Equal(cluster.Namespace + "-" + cluster.Name))
-	})
-
 	It("isNamespaced returns true for namespaced resources", func() {
 		clusterRole, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Profiles can use resources in the management cluster to instantiate the templates representing the add-ons/applications to deploy in the matching managed clusters.

Those resources are listed in the TemplateResourceRefs.

When one of those resources change, corresponding ClusterSummary instances need to be requeued again. Templates need to be re-instantiated again.

This PR starts and stop watchers for TemplateResourceRefs.

Closes #93 