### PR TITLE
Fix identification of stale resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= amd64
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,4 +15,4 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller:main
+      - image: projectsveltos/addon-controller:dev
         name: controller

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -98,6 +98,7 @@ var (
 
 	AddExtraLabels      = addExtraLabels
 	AddExtraAnnotations = addExtraAnnotations
+	AdjustNamespace     = adjustNamespace
 
 	ResourcesHash   = resourcesHash
 	GetResourceRefs = getResourceRefs

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --agent-in-mgmt-cluster
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -4095,10 +4095,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When Sveltos is referencing a ConfigMap/Secret, Sveltos takes the content stored in the Data section and deploys it.

Configuration in Data is one ore more Kubernetes resources. Sveltos needs to identify two situations:

1. A namespace resource (like a Deployment) is in the Data section, but the namespace is not set. Sveltos handles that by setting namespace to "default". This was Sveltos behavior event before this PR.
2. A cluster wide resource (like ClusterIssuer) is in the Data section, and the namespace is set. Sveltos handles that by resetting the namespace to empty.

Adding in Sveltos the capabilities to correctly handle cluster wide resources with (incorrectly) namespace set, allows Sveltos to properly identify stale resources later on.

```
I0612 08:37:57.989753       1 handlers_utils.go:316] "deploying resource ClusterIssuer /cloudflare (deploy to management cluster: false)" logger="deployer" worker="2" key="default:::clusterapi-workload:::Capi:::clusterissuer-capi-clusterapi-workload:::Resources:::false" cluster="default/clusterapi-workload" clusterSummary="clusterissuer-capi-clusterapi-workload" admin="/" configMapNamespace="default" configMapName="clusterissuer"
```

Fixes #582 