### PR TITLE
Fix typo in quickstart make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ quickstart:  ## start kind cluster; install all cluster api components; create a
 	@echo "Start projectsveltos"
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/$(TAG)/manifest/manifest.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/$(TAG)/manifest/default-classifier.yaml
-	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/main/manifest/sveltosctl_manifest.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/sveltos/$(TAG)/manifest/sveltosctl_manifest.yaml
 
 	sleep 5
 


### PR DESCRIPTION
Use sveltosctl manifest from the right tag/branch instead of main.