### PR TITLE
TemplateResourceRefs: name

### DIFF
--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -58,8 +58,19 @@ func getTemplateResourceName(clusterSummary *configv1alpha1.ClusterSummary,
 
 	var buffer bytes.Buffer
 
+	// Cluster namespace and name can be used to instantiate the name of the resource that
+	// needs to be fetched from the management cluster. Defined an unstructured with namespace and name set
+	u := &unstructured.Unstructured{}
+	u.SetNamespace(clusterSummary.Spec.ClusterNamespace)
+	u.SetName(clusterSummary.Spec.ClusterName)
+
 	if err := tmpl.Execute(&buffer,
-		struct{ ClusterNamespace, ClusterName string }{
+		struct {
+			Cluster map[string]interface{}
+			// deprecated. This used to be original format which was different than rest of templating
+			ClusterNamespace, ClusterName string
+		}{
+			Cluster:          u.UnstructuredContent(),
 			ClusterNamespace: clusterSummary.Spec.ClusterNamespace,
 			ClusterName:      clusterSummary.Spec.ClusterName}); err != nil {
 		return "", errors.Wrapf(err, "error executing template")

--- a/controllers/templateresourcedef_utils_test.go
+++ b/controllers/templateresourcedef_utils_test.go
@@ -51,10 +51,34 @@ var _ = Describe("TemplateResourceDef utils ", func() {
 		}
 	})
 
-	It("GetTemplateResourceName returns the correct name", func() {
+	It("GetTemplateResourceName returns the correct name (uses ClusterNamespace and ClusterName)", func() {
 		ref := &configv1alpha1.TemplateResourceRef{
 			Resource: corev1.ObjectReference{
 				Name: "{{ .ClusterNamespace }}-{{ .ClusterName }}",
+			},
+			Identifier: randomString(),
+		}
+
+		clusterSummary := &configv1alpha1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+			Spec: configv1alpha1.ClusterSummarySpec{
+				ClusterNamespace: cluster.Namespace,
+				ClusterName:      cluster.Name,
+				ClusterType:      libsveltosv1alpha1.ClusterTypeCapi,
+			},
+		}
+
+		value, err := controllers.GetTemplateResourceName(clusterSummary, ref)
+		Expect(err).To(BeNil())
+		Expect(value).To(Equal(cluster.Namespace + "-" + cluster.Name))
+	})
+
+	It("GetTemplateResourceNamespace returns the correct namespace (uses Cluster)", func() {
+		ref := &configv1alpha1.TemplateResourceRef{
+			Resource: corev1.ObjectReference{
+				Name: "{{ .Cluster.metadata.namespace }}-{{ .Cluster.metadata.name }}",
 			},
 			Identifier: randomString(),
 		}


### PR DESCRIPTION
TemplateResourceRefs can be expressed as a template and instantiated at run-time using matching cluster namespace/name.

Before this PR:
- .ClusterNamespace represented the cluster namespace
- .ClusterName represented the cluster name

This is off with rest of templating where:
- .Cluster.metadata.namespace represents the cluster namespace
- .Cluster.metadata.name represents the cluster name

This PR allows .Cluster.metadata.namespace and .Cluster.metadata.name to be also used. This will be the documented way.

In order not to break existing deployment, .ClusterNamespace and .ClusterName can still be used.