### PR TITLE
Retrigger sanity

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -135,7 +135,7 @@ var _ = BeforeSuite(func() {
 	Expect(waitForObject(context.TODO(), testEnv.Client, projectsveltosNs)).To(Succeed())
 
 	// Wait for synchronization
-	// Sometimes we otherwise get "no matches for kind "AddonCompliance" in version "lib.projectsveltos.io/v1alpha1"
+	// Sometimes we otherwise get "no matches for kind "AddonCompliance" in version "lib.projectsveltos.io/v1beta1"
 	time.Sleep(2 * time.Second)
 
 	controllers.InitializeManager(textlogger.NewLogger(textlogger.NewConfig()),


### PR DESCRIPTION
This PR simply retrigger sanity using latest version of drift-detection-manager that uses v1beta1 resources