### PR TITLE
Referenced resource names can be expressed as templates

### DIFF
--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -1161,6 +1161,7 @@ spec:
                   deployed in a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                   `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               extraLabels:
                 additionalProperties:
@@ -1170,6 +1171,7 @@ spec:
                   a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a label with a key present in
                   `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               helmCharts:
                 description: Helm charts is a list of helm charts that need to be
@@ -1368,7 +1370,7 @@ spec:
                         Values field allows to define configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     valuesFrom:
                       description: |-
@@ -1376,7 +1378,7 @@ spec:
                         it is possible to store configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       items:
                         properties:
                           kind:
@@ -1388,7 +1390,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -1441,7 +1448,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -1456,6 +1468,9 @@ spec:
                         Path to the directory containing the kustomization.yaml file, or the
                         set of plain YAMLs a kustomization.yaml should be generated for.
                         Defaults to 'None', which translates to the root path of the SourceRef.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster)
                       type: string
                     targetNamespace:
                       description: |-
@@ -1511,7 +1526,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -1559,6 +1579,9 @@ spec:
                       description: |-
                         Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                         an array of operation objects.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     target:
                       description: Target points to the resources that the patch document
@@ -1606,8 +1629,11 @@ spec:
                 type: array
               policyRefs:
                 description: |-
-                  PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                  that need to be deployed in the matching CAPI clusters.
+                  PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                  that need to be deployed in the matching managed clusters.
+                  The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                 items:
                   properties:
                     deploymentType:
@@ -1632,7 +1658,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -1700,8 +1731,7 @@ spec:
               templateResourceRefs:
                 description: |-
                   TemplateResourceRefs is a list of resource to collect from the management cluster.
-                  Those resources' values will be used to instantiate templates contained in referenced
-                  PolicyRefs and Helm charts
+                  Those resources' values will be used to instantiate templates
                 items:
                   properties:
                     identifier:
@@ -1713,6 +1743,12 @@ spec:
                       description: |-
                         Resource references a Kubernetes instance in the management
                         cluster to fetch and use during template instantiation.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       properties:
                         apiVersion:
                           description: API version of the referent.

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -1116,6 +1116,7 @@ spec:
                       deployed in a managed cluster based on this ClusterProfile/Profile instance.
                       **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                       `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                      (Deprecated use Patches instead)
                     type: object
                   extraLabels:
                     additionalProperties:
@@ -1125,6 +1126,7 @@ spec:
                       a managed cluster based on this ClusterProfile/Profile instance.
                       **Important:** If a resource deployed by Sveltos already has a label with a key present in
                       `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                      (Deprecated use Patches instead)
                     type: object
                   helmCharts:
                     description: Helm charts is a list of helm charts that need to
@@ -1325,7 +1327,7 @@ spec:
                             Values field allows to define configuration for the Helm release.
                             These values can be static or leverage Go templates for dynamic customization.
                             When expressed as templates, the values are filled in using information from
-                            resources within the management cluster before deployment.
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           type: string
                         valuesFrom:
                           description: |-
@@ -1333,7 +1335,7 @@ spec:
                             it is possible to store configuration for the Helm release.
                             These values can be static or leverage Go templates for dynamic customization.
                             When expressed as templates, the values are filled in using information from
-                            resources within the management cluster before deployment.
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           items:
                             properties:
                               kind:
@@ -1345,7 +1347,12 @@ spec:
                                 - Secret
                                 type: string
                               name:
-                                description: Name of the referenced resource.
+                                description: |-
+                                  Name of the referenced resource.
+                                  Name can be expressed as a template and instantiate using
+                                  - cluster namespace: .Cluster.metadata.namespace
+                                  - cluster name: .Cluster.metadata.name
+                                  - cluster type: .Cluster.kind
                                 minLength: 1
                                 type: string
                               namespace:
@@ -1398,7 +1405,12 @@ spec:
                           - Secret
                           type: string
                         name:
-                          description: Name of the referenced resource.
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           minLength: 1
                           type: string
                         namespace:
@@ -1413,6 +1425,9 @@ spec:
                             Path to the directory containing the kustomization.yaml file, or the
                             set of plain YAMLs a kustomization.yaml should be generated for.
                             Defaults to 'None', which translates to the root path of the SourceRef.
+                            These values can be static or leverage Go templates for dynamic customization.
+                            When expressed as templates, the values are filled in using information from
+                            resources within the management cluster before deployment (Cluster)
                           type: string
                         targetNamespace:
                           description: |-
@@ -1468,7 +1483,12 @@ spec:
                                 - Secret
                                 type: string
                               name:
-                                description: Name of the referenced resource.
+                                description: |-
+                                  Name of the referenced resource.
+                                  Name can be expressed as a template and instantiate using
+                                  - cluster namespace: .Cluster.metadata.namespace
+                                  - cluster name: .Cluster.metadata.name
+                                  - cluster type: .Cluster.kind
                                 minLength: 1
                                 type: string
                               namespace:
@@ -1516,6 +1536,9 @@ spec:
                           description: |-
                             Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                             an array of operation objects.
+                            These values can be static or leverage Go templates for dynamic customization.
+                            When expressed as templates, the values are filled in using information from
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           type: string
                         target:
                           description: Target points to the resources that the patch
@@ -1563,8 +1586,11 @@ spec:
                     type: array
                   policyRefs:
                     description: |-
-                      PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                      that need to be deployed in the matching CAPI clusters.
+                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                      that need to be deployed in the matching managed clusters.
+                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                     items:
                       properties:
                         deploymentType:
@@ -1589,7 +1615,12 @@ spec:
                           - Secret
                           type: string
                         name:
-                          description: Name of the referenced resource.
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           minLength: 1
                           type: string
                         namespace:
@@ -1657,8 +1688,7 @@ spec:
                   templateResourceRefs:
                     description: |-
                       TemplateResourceRefs is a list of resource to collect from the management cluster.
-                      Those resources' values will be used to instantiate templates contained in referenced
-                      PolicyRefs and Helm charts
+                      Those resources' values will be used to instantiate templates
                     items:
                       properties:
                         identifier:
@@ -1670,6 +1700,12 @@ spec:
                           description: |-
                             Resource references a Kubernetes instance in the management
                             cluster to fetch and use during template instantiation.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           properties:
                             apiVersion:
                               description: API version of the referent.

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -1161,6 +1161,7 @@ spec:
                   deployed in a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                   `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               extraLabels:
                 additionalProperties:
@@ -1170,6 +1171,7 @@ spec:
                   a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a label with a key present in
                   `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               helmCharts:
                 description: Helm charts is a list of helm charts that need to be
@@ -1368,7 +1370,7 @@ spec:
                         Values field allows to define configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     valuesFrom:
                       description: |-
@@ -1376,7 +1378,7 @@ spec:
                         it is possible to store configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       items:
                         properties:
                           kind:
@@ -1388,7 +1390,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -1441,7 +1448,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -1456,6 +1468,9 @@ spec:
                         Path to the directory containing the kustomization.yaml file, or the
                         set of plain YAMLs a kustomization.yaml should be generated for.
                         Defaults to 'None', which translates to the root path of the SourceRef.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster)
                       type: string
                     targetNamespace:
                       description: |-
@@ -1511,7 +1526,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -1559,6 +1579,9 @@ spec:
                       description: |-
                         Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                         an array of operation objects.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     target:
                       description: Target points to the resources that the patch document
@@ -1606,8 +1629,11 @@ spec:
                 type: array
               policyRefs:
                 description: |-
-                  PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                  that need to be deployed in the matching CAPI clusters.
+                  PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                  that need to be deployed in the matching managed clusters.
+                  The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                 items:
                   properties:
                     deploymentType:
@@ -1632,7 +1658,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -1700,8 +1731,7 @@ spec:
               templateResourceRefs:
                 description: |-
                   TemplateResourceRefs is a list of resource to collect from the management cluster.
-                  Those resources' values will be used to instantiate templates contained in referenced
-                  PolicyRefs and Helm charts
+                  Those resources' values will be used to instantiate templates
                 items:
                   properties:
                     identifier:
@@ -1713,6 +1743,12 @@ spec:
                       description: |-
                         Resource references a Kubernetes instance in the management
                         cluster to fetch and use during template instantiation.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       properties:
                         apiVersion:
                           description: API version of the referent.

--- a/controllers/clustersummary_controller_test.go
+++ b/controllers/clustersummary_controller_test.go
@@ -870,7 +870,8 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope := getClusterSummaryScope(c,
 			textlogger.NewLogger(textlogger.NewConfig()), clusterProfile, clusterSummary)
 		reconciler := getClusterSummaryReconciler(nil, nil)
-		set := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
+		set, err := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
+		Expect(err).To(BeNil())
 		Expect(set.Len()).To(Equal(4))
 	})
 
@@ -884,7 +885,8 @@ var _ = Describe("ClustersummaryController", func() {
 		clusterSummaryScope := getClusterSummaryScope(c,
 			textlogger.NewLogger(textlogger.NewConfig()), clusterProfile, clusterSummary)
 		reconciler := getClusterSummaryReconciler(nil, nil)
-		set := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
+		set, err := controllers.GetCurrentReferences(reconciler, clusterSummaryScope)
+		Expect(err).To(BeNil())
 		Expect(set.Len()).To(Equal(1))
 		items := set.Items()
 		Expect(items[0].Namespace).To(Equal(clusterSummary.Namespace))

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -730,7 +730,7 @@ func handleUninstall(clusterSummary *configv1beta1.ClusterSummary, currentChart 
 	kubeconfig string, logger logr.Logger) (*configv1beta1.ReleaseReport, error) {
 
 	var report *configv1beta1.ReleaseReport
-	logger.V(logs.LogDebug).Info("uniinstall helm release")
+	logger.V(logs.LogDebug).Info("uninstall helm release")
 	err := doUninstallRelease(clusterSummary, currentChart, kubeconfig, logger)
 	if err != nil {
 		return nil, err

--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -44,7 +44,10 @@ func getTemplateResourceNamespace(clusterSummary *configv1beta1.ClusterSummary,
 }
 
 // Resources referenced in the management cluster can have their name expressed in function
-// of cluster information (clusterNamespace, clusterName, clusterType)
+// of cluster information:
+// clusterNamespace => .Cluster.metadata.namespace
+// clusterName => .Cluster.metadata.name
+// clusterType => .Cluster.kind
 func getTemplateResourceName(clusterSummary *configv1beta1.ClusterSummary,
 	ref *configv1beta1.TemplateResourceRef) (string, error) {
 
@@ -63,6 +66,7 @@ func getTemplateResourceName(clusterSummary *configv1beta1.ClusterSummary,
 	u := &unstructured.Unstructured{}
 	u.SetNamespace(clusterSummary.Spec.ClusterNamespace)
 	u.SetName(clusterSummary.Spec.ClusterName)
+	u.SetKind(string(clusterSummary.Spec.ClusterType))
 
 	if err := tmpl.Execute(&buffer,
 		struct {

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1918,6 +1918,7 @@ spec:
                   deployed in a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                   `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               extraLabels:
                 additionalProperties:
@@ -1927,6 +1928,7 @@ spec:
                   a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a label with a key present in
                   `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               helmCharts:
                 description: Helm charts is a list of helm charts that need to be
@@ -2125,7 +2127,7 @@ spec:
                         Values field allows to define configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     valuesFrom:
                       description: |-
@@ -2133,7 +2135,7 @@ spec:
                         it is possible to store configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       items:
                         properties:
                           kind:
@@ -2145,7 +2147,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -2198,7 +2205,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -2213,6 +2225,9 @@ spec:
                         Path to the directory containing the kustomization.yaml file, or the
                         set of plain YAMLs a kustomization.yaml should be generated for.
                         Defaults to 'None', which translates to the root path of the SourceRef.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster)
                       type: string
                     targetNamespace:
                       description: |-
@@ -2268,7 +2283,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -2316,6 +2336,9 @@ spec:
                       description: |-
                         Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                         an array of operation objects.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     target:
                       description: Target points to the resources that the patch document
@@ -2363,8 +2386,11 @@ spec:
                 type: array
               policyRefs:
                 description: |-
-                  PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                  that need to be deployed in the matching CAPI clusters.
+                  PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                  that need to be deployed in the matching managed clusters.
+                  The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                 items:
                   properties:
                     deploymentType:
@@ -2389,7 +2415,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -2457,8 +2488,7 @@ spec:
               templateResourceRefs:
                 description: |-
                   TemplateResourceRefs is a list of resource to collect from the management cluster.
-                  Those resources' values will be used to instantiate templates contained in referenced
-                  PolicyRefs and Helm charts
+                  Those resources' values will be used to instantiate templates
                 items:
                   properties:
                     identifier:
@@ -2470,6 +2500,12 @@ spec:
                       description: |-
                         Resource references a Kubernetes instance in the management
                         cluster to fetch and use during template instantiation.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       properties:
                         apiVersion:
                           description: API version of the referent.
@@ -4593,6 +4629,7 @@ spec:
                       deployed in a managed cluster based on this ClusterProfile/Profile instance.
                       **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                       `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                      (Deprecated use Patches instead)
                     type: object
                   extraLabels:
                     additionalProperties:
@@ -4602,6 +4639,7 @@ spec:
                       a managed cluster based on this ClusterProfile/Profile instance.
                       **Important:** If a resource deployed by Sveltos already has a label with a key present in
                       `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                      (Deprecated use Patches instead)
                     type: object
                   helmCharts:
                     description: Helm charts is a list of helm charts that need to
@@ -4802,7 +4840,7 @@ spec:
                             Values field allows to define configuration for the Helm release.
                             These values can be static or leverage Go templates for dynamic customization.
                             When expressed as templates, the values are filled in using information from
-                            resources within the management cluster before deployment.
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           type: string
                         valuesFrom:
                           description: |-
@@ -4810,7 +4848,7 @@ spec:
                             it is possible to store configuration for the Helm release.
                             These values can be static or leverage Go templates for dynamic customization.
                             When expressed as templates, the values are filled in using information from
-                            resources within the management cluster before deployment.
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           items:
                             properties:
                               kind:
@@ -4822,7 +4860,12 @@ spec:
                                 - Secret
                                 type: string
                               name:
-                                description: Name of the referenced resource.
+                                description: |-
+                                  Name of the referenced resource.
+                                  Name can be expressed as a template and instantiate using
+                                  - cluster namespace: .Cluster.metadata.namespace
+                                  - cluster name: .Cluster.metadata.name
+                                  - cluster type: .Cluster.kind
                                 minLength: 1
                                 type: string
                               namespace:
@@ -4875,7 +4918,12 @@ spec:
                           - Secret
                           type: string
                         name:
-                          description: Name of the referenced resource.
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           minLength: 1
                           type: string
                         namespace:
@@ -4890,6 +4938,9 @@ spec:
                             Path to the directory containing the kustomization.yaml file, or the
                             set of plain YAMLs a kustomization.yaml should be generated for.
                             Defaults to 'None', which translates to the root path of the SourceRef.
+                            These values can be static or leverage Go templates for dynamic customization.
+                            When expressed as templates, the values are filled in using information from
+                            resources within the management cluster before deployment (Cluster)
                           type: string
                         targetNamespace:
                           description: |-
@@ -4945,7 +4996,12 @@ spec:
                                 - Secret
                                 type: string
                               name:
-                                description: Name of the referenced resource.
+                                description: |-
+                                  Name of the referenced resource.
+                                  Name can be expressed as a template and instantiate using
+                                  - cluster namespace: .Cluster.metadata.namespace
+                                  - cluster name: .Cluster.metadata.name
+                                  - cluster type: .Cluster.kind
                                 minLength: 1
                                 type: string
                               namespace:
@@ -4993,6 +5049,9 @@ spec:
                           description: |-
                             Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                             an array of operation objects.
+                            These values can be static or leverage Go templates for dynamic customization.
+                            When expressed as templates, the values are filled in using information from
+                            resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                           type: string
                         target:
                           description: Target points to the resources that the patch
@@ -5040,8 +5099,11 @@ spec:
                     type: array
                   policyRefs:
                     description: |-
-                      PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                      that need to be deployed in the matching CAPI clusters.
+                      PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                      that need to be deployed in the matching managed clusters.
+                      The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                     items:
                       properties:
                         deploymentType:
@@ -5066,7 +5128,12 @@ spec:
                           - Secret
                           type: string
                         name:
-                          description: Name of the referenced resource.
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           minLength: 1
                           type: string
                         namespace:
@@ -5134,8 +5201,7 @@ spec:
                   templateResourceRefs:
                     description: |-
                       TemplateResourceRefs is a list of resource to collect from the management cluster.
-                      Those resources' values will be used to instantiate templates contained in referenced
-                      PolicyRefs and Helm charts
+                      Those resources' values will be used to instantiate templates
                     items:
                       properties:
                         identifier:
@@ -5147,6 +5213,12 @@ spec:
                           description: |-
                             Resource references a Kubernetes instance in the management
                             cluster to fetch and use during template instantiation.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            Name can be expressed as a template and instantiate using
+                            - cluster namespace: .Cluster.metadata.namespace
+                            - cluster name: .Cluster.metadata.name
+                            - cluster type: .Cluster.kind
                           properties:
                             apiVersion:
                               description: API version of the referent.
@@ -6620,6 +6692,7 @@ spec:
                   deployed in a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a annotation with a key present in
                   `ExtraAnnotations`, the value from `ExtraAnnotations` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               extraLabels:
                 additionalProperties:
@@ -6629,6 +6702,7 @@ spec:
                   a managed cluster based on this ClusterProfile/Profile instance.
                   **Important:** If a resource deployed by Sveltos already has a label with a key present in
                   `ExtraLabels`, the value from `ExtraLabels` will override the existing value.
+                  (Deprecated use Patches instead)
                 type: object
               helmCharts:
                 description: Helm charts is a list of helm charts that need to be
@@ -6827,7 +6901,7 @@ spec:
                         Values field allows to define configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     valuesFrom:
                       description: |-
@@ -6835,7 +6909,7 @@ spec:
                         it is possible to store configuration for the Helm release.
                         These values can be static or leverage Go templates for dynamic customization.
                         When expressed as templates, the values are filled in using information from
-                        resources within the management cluster before deployment.
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       items:
                         properties:
                           kind:
@@ -6847,7 +6921,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -6900,7 +6979,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -6915,6 +6999,9 @@ spec:
                         Path to the directory containing the kustomization.yaml file, or the
                         set of plain YAMLs a kustomization.yaml should be generated for.
                         Defaults to 'None', which translates to the root path of the SourceRef.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster)
                       type: string
                     targetNamespace:
                       description: |-
@@ -6970,7 +7057,12 @@ spec:
                             - Secret
                             type: string
                           name:
-                            description: Name of the referenced resource.
+                            description: |-
+                              Name of the referenced resource.
+                              Name can be expressed as a template and instantiate using
+                              - cluster namespace: .Cluster.metadata.namespace
+                              - cluster name: .Cluster.metadata.name
+                              - cluster type: .Cluster.kind
                             minLength: 1
                             type: string
                           namespace:
@@ -7018,6 +7110,9 @@ spec:
                       description: |-
                         Patch contains an inline StrategicMerge patch or an inline JSON6902 patch with
                         an array of operation objects.
+                        These values can be static or leverage Go templates for dynamic customization.
+                        When expressed as templates, the values are filled in using information from
+                        resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                       type: string
                     target:
                       description: Target points to the resources that the patch document
@@ -7065,8 +7160,11 @@ spec:
                 type: array
               policyRefs:
                 description: |-
-                  PolicyRefs references all the ConfigMaps/Secrets containing kubernetes resources
-                  that need to be deployed in the matching CAPI clusters.
+                  PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
+                  that need to be deployed in the matching managed clusters.
+                  The values contained in those resources can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
                 items:
                   properties:
                     deploymentType:
@@ -7091,7 +7189,12 @@ spec:
                       - Secret
                       type: string
                     name:
-                      description: Name of the referenced resource.
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       minLength: 1
                       type: string
                     namespace:
@@ -7159,8 +7262,7 @@ spec:
               templateResourceRefs:
                 description: |-
                   TemplateResourceRefs is a list of resource to collect from the management cluster.
-                  Those resources' values will be used to instantiate templates contained in referenced
-                  PolicyRefs and Helm charts
+                  Those resources' values will be used to instantiate templates
                 items:
                   properties:
                     identifier:
@@ -7172,6 +7274,12 @@ spec:
                       description: |-
                         Resource references a Kubernetes instance in the management
                         cluster to fetch and use during template instantiation.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        Name can be expressed as a template and instantiate using
+                        - cluster namespace: .Cluster.metadata.namespace
+                        - cluster name: .Cluster.metadata.name
+                        - cluster type: .Cluster.kind
                       properties:
                         apiVersion:
                           description: API version of the referent.


### PR DESCRIPTION
For following fields:

- PolicyRef
- KustomizationRef
- ValueFrom

name can be expressed as a template and instantiate using

- cluster namespace: .Cluster.metadata.namespace
- cluster name: .Cluster.metadata.name
- cluster type: .Cluster.kind

It was already possible to leave namespace empty, in which case cluster namespace was used.

Sveltos will instantiate name at run-time. This allows different resources to be fetched for different cluster, all while using a single ClusterProfile/Profile