### PR TITLE
(feat) Don't track certain resources for configuration drift

### DIFF
--- a/api/v1beta1/clusterconfiguration_types.go
+++ b/api/v1beta1/clusterconfiguration_types.go
@@ -54,6 +54,11 @@ type Resource struct {
 
 	// Owner is the list of ConfigMap/Secret containing this resource.
 	Owner corev1.ObjectReference `json:"owner"`
+
+	// IgnoreForConfigurationDrift indicates to not track resource
+	// for configuration drift detection.
+	// This field has a meaning only when mode is ContinuousWithDriftDetection
+	IgnoreForConfigurationDrift bool `json:"ignoreForConfigurationDrift"`
 }
 
 type Chart struct {

--- a/config/crd/bases/config.projectsveltos.io_clusterconfigurations.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterconfigurations.yaml
@@ -479,6 +479,12 @@ spec:
                                   description: Group of the resource deployed in the
                                     Cluster.
                                   type: string
+                                ignoreForConfigurationDrift:
+                                  description: |-
+                                    IgnoreForConfigurationDrift indicates to not track resource
+                                    for configuration drift detection.
+                                    This field has a meaning only when mode is ContinuousWithDriftDetection
+                                  type: boolean
                                 kind:
                                   description: Kind of the resource deployed in the
                                     Cluster.
@@ -551,6 +557,7 @@ spec:
                                   type: string
                               required:
                               - group
+                              - ignoreForConfigurationDrift
                               - kind
                               - name
                               - owner
@@ -644,6 +651,12 @@ spec:
                                   description: Group of the resource deployed in the
                                     Cluster.
                                   type: string
+                                ignoreForConfigurationDrift:
+                                  description: |-
+                                    IgnoreForConfigurationDrift indicates to not track resource
+                                    for configuration drift detection.
+                                    This field has a meaning only when mode is ContinuousWithDriftDetection
+                                  type: boolean
                                 kind:
                                   description: Kind of the resource deployed in the
                                     Cluster.
@@ -716,6 +729,7 @@ spec:
                                   type: string
                               required:
                               - group
+                              - ignoreForConfigurationDrift
                               - kind
                               - name
                               - owner

--- a/config/crd/bases/config.projectsveltos.io_clusterreports.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterreports.yaml
@@ -384,6 +384,12 @@ spec:
                         group:
                           description: Group of the resource deployed in the Cluster.
                           type: string
+                        ignoreForConfigurationDrift:
+                          description: |-
+                            IgnoreForConfigurationDrift indicates to not track resource
+                            for configuration drift detection.
+                            This field has a meaning only when mode is ContinuousWithDriftDetection
+                          type: boolean
                         kind:
                           description: Kind of the resource deployed in the Cluster.
                           minLength: 1
@@ -453,6 +459,7 @@ spec:
                           type: string
                       required:
                       - group
+                      - ignoreForConfigurationDrift
                       - kind
                       - name
                       - owner
@@ -530,6 +537,12 @@ spec:
                         group:
                           description: Group of the resource deployed in the Cluster.
                           type: string
+                        ignoreForConfigurationDrift:
+                          description: |-
+                            IgnoreForConfigurationDrift indicates to not track resource
+                            for configuration drift detection.
+                            This field has a meaning only when mode is ContinuousWithDriftDetection
+                          type: boolean
                         kind:
                           description: Kind of the resource deployed in the Cluster.
                           minLength: 1
@@ -599,6 +612,7 @@ spec:
                           type: string
                       required:
                       - group
+                      - ignoreForConfigurationDrift
                       - kind
                       - name
                       - owner

--- a/controllers/drift-detection-utils.go
+++ b/controllers/drift-detection-utils.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	// When this annotation is set, resource will be excluded from configuration
+	// drift detection
+	driftDetectionIgnoreAnnotation = "projectsveltos.io/driftDetectionIgnore"
+)
+
+// hasIgnoreConfigurationDriftAnnotation verifies whether resource has
+// `projectsveltos.io/driftDetectionIgnore` annotation. Any resource with such
+// annotation set won't be tracked for configuration drift.
+func hasIgnoreConfigurationDriftAnnotation(resource *unstructured.Unstructured) bool {
+	annotations := resource.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[driftDetectionIgnoreAnnotation]; ok {
+			return true
+		}
+	}
+
+	return false
+}

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -492,11 +492,12 @@ func deployResourceSummary(ctx context.Context, c client.Client,
 
 	for i := range deployed {
 		resources[i] = libsveltosv1beta1.Resource{
-			Namespace: deployed[i].Namespace,
-			Name:      deployed[i].Name,
-			Group:     deployed[i].Group,
-			Kind:      deployed[i].Kind,
-			Version:   deployed[i].Version,
+			Namespace:                   deployed[i].Namespace,
+			Name:                        deployed[i].Name,
+			Group:                       deployed[i].Group,
+			Kind:                        deployed[i].Kind,
+			Version:                     deployed[i].Version,
+			IgnoreForConfigurationDrift: deployed[i].IgnoreForConfigurationDrift,
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.32.1-0.20240624142620-affdfeb694be
+	github.com/projectsveltos/libsveltos v0.32.1-0.20240702090008-925c00e1be3d
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.32.1-0.20240624142620-affdfeb694be h1:IC9Ca6OqzSQRv//9NSRZt34gdZDyjudwyEz2hZVae7c=
-github.com/projectsveltos/libsveltos v0.32.1-0.20240624142620-affdfeb694be/go.mod h1:z6avfRqeHbzqkThyqqqoGcCWMI0JBeAjdeZlbJ7P8TI=
+github.com/projectsveltos/libsveltos v0.32.1-0.20240702090008-925c00e1be3d h1:wT8qFe4Yf97G/y2sY2I+f0iSnfgrnFF3SXwau4PJxYU=
+github.com/projectsveltos/libsveltos v0.32.1-0.20240702090008-925c00e1be3d/go.mod h1:m2CcqCd9Gq/czJS1lYmMPrnQTvVzc7AL9xlgXaAaQRE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -483,6 +483,12 @@ spec:
                                   description: Group of the resource deployed in the
                                     Cluster.
                                   type: string
+                                ignoreForConfigurationDrift:
+                                  description: |-
+                                    IgnoreForConfigurationDrift indicates to not track resource
+                                    for configuration drift detection.
+                                    This field has a meaning only when mode is ContinuousWithDriftDetection
+                                  type: boolean
                                 kind:
                                   description: Kind of the resource deployed in the
                                     Cluster.
@@ -555,6 +561,7 @@ spec:
                                   type: string
                               required:
                               - group
+                              - ignoreForConfigurationDrift
                               - kind
                               - name
                               - owner
@@ -648,6 +655,12 @@ spec:
                                   description: Group of the resource deployed in the
                                     Cluster.
                                   type: string
+                                ignoreForConfigurationDrift:
+                                  description: |-
+                                    IgnoreForConfigurationDrift indicates to not track resource
+                                    for configuration drift detection.
+                                    This field has a meaning only when mode is ContinuousWithDriftDetection
+                                  type: boolean
                                 kind:
                                   description: Kind of the resource deployed in the
                                     Cluster.
@@ -720,6 +733,7 @@ spec:
                                   type: string
                               required:
                               - group
+                              - ignoreForConfigurationDrift
                               - kind
                               - name
                               - owner
@@ -3268,6 +3282,12 @@ spec:
                         group:
                           description: Group of the resource deployed in the Cluster.
                           type: string
+                        ignoreForConfigurationDrift:
+                          description: |-
+                            IgnoreForConfigurationDrift indicates to not track resource
+                            for configuration drift detection.
+                            This field has a meaning only when mode is ContinuousWithDriftDetection
+                          type: boolean
                         kind:
                           description: Kind of the resource deployed in the Cluster.
                           minLength: 1
@@ -3337,6 +3357,7 @@ spec:
                           type: string
                       required:
                       - group
+                      - ignoreForConfigurationDrift
                       - kind
                       - name
                       - owner
@@ -3414,6 +3435,12 @@ spec:
                         group:
                           description: Group of the resource deployed in the Cluster.
                           type: string
+                        ignoreForConfigurationDrift:
+                          description: |-
+                            IgnoreForConfigurationDrift indicates to not track resource
+                            for configuration drift detection.
+                            This field has a meaning only when mode is ContinuousWithDriftDetection
+                          type: boolean
                         kind:
                           description: Kind of the resource deployed in the Cluster.
                           minLength: 1
@@ -3483,6 +3510,7 @@ spec:
                           type: string
                       required:
                       - group
+                      - ignoreForConfigurationDrift
                       - kind
                       - name
                       - owner


### PR DESCRIPTION
When resource has annotation projectsveltos.io/driftDetectionIgnore set, in ContinuousWithDriftDetection mode, the resource won't be tracked for configuration drift.

[Story](https://github.com/projectsveltos/addon-controller/issues/612)