### PR TITLE
ClusterSummary display

### DIFF
--- a/api/v1beta1/clustersummary_types.go
+++ b/api/v1beta1/clustersummary_types.go
@@ -207,10 +207,14 @@ type ClusterSummaryStatus struct {
 	HelmReleaseSummaries []HelmChartSummary `json:"helmReleaseSummaries,omitempty"`
 }
 
+//nolint: lll // marker
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=clustersummaries,scope=Namespaced
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="HelmCharts",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Helm\")].status",description="Indicates whether HelmCharts are all provisioned",priority=2
+// +kubebuilder:printcolumn:name="KustomizeRefs",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Kustomize\")].status",description="Indicates whether KustomizeRefs are all provisioned",priority=2
+// +kubebuilder:printcolumn:name="PolicyRefs",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Resources\")].status",description="Indicates whether PolicyRefs are all provisioned",priority=2
 
 // ClusterSummary is the Schema for the clustersummaries API
 type ClusterSummary struct {

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -941,7 +941,23 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Indicates whether HelmCharts are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Helm")].status
+      name: HelmCharts
+      priority: 2
+      type: string
+    - description: Indicates whether KustomizeRefs are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Kustomize")].status
+      name: KustomizeRefs
+      priority: 2
+      type: string
+    - description: Indicates whether PolicyRefs are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Resources")].status
+      name: PolicyRefs
+      priority: 2
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ClusterSummary is the Schema for the clustersummaries API

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -4480,7 +4480,23 @@ spec:
     storage: false
     subresources:
       status: {}
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - description: Indicates whether HelmCharts are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Helm")].status
+      name: HelmCharts
+      priority: 2
+      type: string
+    - description: Indicates whether KustomizeRefs are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Kustomize")].status
+      name: KustomizeRefs
+      priority: 2
+      type: string
+    - description: Indicates whether PolicyRefs are all provisioned
+      jsonPath: .status.featureSummaries[?(@.featureID=="Resources")].status
+      name: PolicyRefs
+      priority: 2
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ClusterSummary is the Schema for the clustersummaries API


### PR DESCRIPTION
Will print status for HelmCharts, KustomizeRefs and PolicyRefs

```yaml
 kubectl get clustersummary  -o wide
NAME                                        HELMCHARTS    KUSTOMIZEREFS   POLICYREFS
deploy-kyverno-2-capi-clusterapi-workload   Provisioned
```

Fixes: [306](https://github.com/projectsveltos/sveltos/issues/306)