### PR TITLE
ValuesFrom: treat as template only if annotation is present

### DIFF
--- a/controllers/handlers_kustomize_test.go
+++ b/controllers/handlers_kustomize_test.go
@@ -352,7 +352,7 @@ var _ = Describe("Hash methods", func() {
 				Name:      randomString(),
 			},
 			Data: map[string]string{
-				randomString(): randomString(),
+				"cluster-name": "{{ .Cluster.metadata.namespace }}-{{ .Cluster.metadata.name }}",
 				randomString(): randomString(),
 			},
 		}
@@ -568,41 +568,56 @@ var _ = Describe("Hash methods", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		// This will get alll substitute values considering only ValuesFrom
-		values, err := controllers.GetKustomizeSubstituteValuesFrom(context.TODO(), c, clusterSummary, kustomizationRef,
+		templatedValues, nonTemplatedValues, err := controllers.GetKustomizeSubstituteValuesFrom(context.TODO(), c, clusterSummary, kustomizationRef,
 			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		for k := range configMap.Data {
-			v, ok := values[k]
+			v, ok := templatedValues[k]
+			if !ok {
+				v, ok = nonTemplatedValues[k]
+			}
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal(configMap.Data[k]))
 		}
 
 		for k := range secret.Data {
-			v, ok := values[k]
+			v, ok := templatedValues[k]
+			if !ok {
+				v, ok = nonTemplatedValues[k]
+			}
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal(string(secret.Data[k])))
 		}
 
 		// This will get alll substitute values considering both Values and ValuesFrom
-		values, err = controllers.GetKustomizeSubstituteValues(context.TODO(), c, clusterSummary, kustomizationRef,
+		templatedValues, nonTemplatedValues, err = controllers.GetKustomizeSubstituteValues(context.TODO(), c, clusterSummary, kustomizationRef,
 			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
 		for k := range configMap.Data {
-			v, ok := values[k]
+			v, ok := templatedValues[k]
+			if !ok {
+				v, ok = nonTemplatedValues[k]
+			}
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal(configMap.Data[k]))
 		}
 
 		for k := range secret.Data {
-			v, ok := values[k]
+			v, ok := templatedValues[k]
+			if !ok {
+				v, ok = nonTemplatedValues[k]
+			}
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal(string(secret.Data[k])))
 		}
 
 		for k := range kustomizationRef.Values {
-			v, ok := values[k]
+			v, ok := templatedValues[k]
+			if !ok {
+				v, ok = nonTemplatedValues[k]
+			}
 			Expect(ok).To(BeTrue())
 			Expect(v).To(Equal(kustomizationRef.Values[k]))
 		}


### PR DESCRIPTION
HelmChart and KustomizeRef both have a field called `ValueFrom`. This field references a ConfigMap or a Secret containing:

- helm values for helm chart
- substitute values for kustomize

Those can potentially be expressed as templates and instantiated by Sveltos at deployment time before being used.
Before this PR, Sveltos always treated the content of referenced ConfigMap/Secret as a template and tried to instantiate it.

While this is OK most of the time (even if the content of those referenced resource is not a template) is:

- inefficient
- in some cases, it might lead to issues

This PR changes this behavior making it consistent with PolicyRefs. **Only** if referenced ConfigMap/Secret has the annotation `projectsveltos.io/template`, Sveltos will consider the content a template and will instantiate before using.

If such annotation is not present, such content will be used as it is.

Since ValuesFrom is an array (and so multiple ConfigMap/Secret instances can be referenced) it is possible for some referenced instances to have the annotation (and Sveltos will treat it as a template and will try to instantiate such content before using it) and other instances to not have the annotation (such content will be used as it is).

Whatever is present in Values instead will **always** be treated as a template. This has been day 1 implementation and it is not changing. Users are advised to put content in a ConfigMap/Secret and reference from ValuesFrom if such content **must** be treated as a non template.