### PR TITLE
Complete unqualified image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ prepare-configmap-with-kustomize: $(KUBECTL)
 
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
-	sed -i'' -e 's@image: .*@image: '"${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
 	sed -i'' -e 's@--version=.*@--version=$(TAG)"@' ./config/default/manager_auth_proxy_patch.yaml
 
 set-manifest-pull-policy:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: projectsveltos/addon-controller:main
+      - image: docker.io/projectsveltos/addon-controller:main
         name: controller

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -26,7 +26,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8408,7 +8408,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Add 'docker.io' registry server name where missing.

That allows applications to run on CRIs not configured to handle unqualified registries.