### PR TITLE
(feat) ClusterSet/Set: look at SveltosCluster ConnectionStatus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -1623,6 +1623,8 @@ spec:
                             https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               policyRefs:

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -1596,6 +1596,8 @@ spec:
                                 https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                               type: string
                           type: object
+                      required:
+                      - patch
                       type: object
                     type: array
                   policyRefs:

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -1623,6 +1623,8 @@ spec:
                             https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               policyRefs:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,4 +15,4 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/addon-controller:main
+      - image: docker.io/projectsveltos/addon-controller:dev
         name: controller

--- a/controllers/clusterset_controller.go
+++ b/controllers/clusterset_controller.go
@@ -143,7 +143,10 @@ func (r *ClusterSetReconciler) reconcileNormal(
 
 	setScope.SetMatchingClusterRefs(matchingCluster)
 
-	selectClusters(setScope)
+	err = selectClusters(ctx, r.Client, setScope, logger)
+	if err != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
+	}
 
 	r.updateMaps(setScope)
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -194,8 +194,9 @@ var (
 )
 
 var (
-	SelectClusters     = selectClusters
-	SelectMoreClusters = selectMoreClusters
+	SelectClusters              = selectClusters
+	SelectMoreClusters          = selectMoreClusters
+	PruneConnectionDownClusters = pruneConnectionDownClusters
 )
 
 var (

--- a/controllers/set_controller.go
+++ b/controllers/set_controller.go
@@ -152,7 +152,10 @@ func (r *SetReconciler) reconcileNormal(
 
 	setScope.SetMatchingClusterRefs(matchingCluster)
 
-	selectClusters(setScope)
+	err = selectClusters(ctx, r.Client, setScope, logger)
+	if err != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
+	}
 
 	r.updateMaps(setScope)
 

--- a/controllers/set_utils_test.go
+++ b/controllers/set_utils_test.go
@@ -17,12 +17,18 @@ limitations under the License.
 package controllers_test
 
 import (
+	"context"
+
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/projectsveltos/addon-controller/controllers"
 	"github.com/projectsveltos/addon-controller/pkg/scope"
@@ -30,6 +36,12 @@ import (
 )
 
 var _ = Describe("Set utils", func() {
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		logger = textlogger.NewLogger(textlogger.NewConfig())
+	})
+
 	It("selectMoreClusters does nothing when selected clusters matches MaxReplicas", func() {
 		selectedCluster := []corev1.ObjectReference{
 			{
@@ -79,7 +91,8 @@ var _ = Describe("Set utils", func() {
 			Set: &clusterSet,
 		}
 
-		controllers.SelectMoreClusters(setScope)
+		// Only ClusterAPI are used, so we can pass clusterSet.Status.MatchingClusterRefs
+		controllers.SelectMoreClusters(setScope, clusterSet.Status.MatchingClusterRefs)
 		Expect(len(clusterSet.Status.SelectedClusterRefs)).To(Equal(len(selectedCluster)))
 		for i := range selectedCluster {
 			Expect(clusterSet.Status.SelectedClusterRefs).To(ContainElement(selectedCluster[i]))
@@ -130,7 +143,8 @@ var _ = Describe("Set utils", func() {
 			Set: &clusterSet,
 		}
 
-		controllers.SelectMoreClusters(setScope)
+		// Only ClusterAPI are used, so we can pass clusterSet.Status.MatchingClusterRefs
+		controllers.SelectMoreClusters(setScope, clusterSet.Status.MatchingClusterRefs)
 		Expect(len(clusterSet.Status.SelectedClusterRefs)).To(Equal(clusterSet.Spec.MaxReplicas))
 	})
 
@@ -180,7 +194,8 @@ var _ = Describe("Set utils", func() {
 			Set: &clusterSet,
 		}
 
-		controllers.SelectMoreClusters(setScope)
+		// Only ClusterAPI are used, so we can pass clusterSet.Status.MatchingClusterRefs
+		controllers.SelectMoreClusters(setScope, setScope.GetStatus().MatchingClusterRefs)
 		Expect(len(clusterSet.Status.SelectedClusterRefs)).To(Equal(len(clusterSet.Status.MatchingClusterRefs)))
 	})
 
@@ -218,7 +233,107 @@ var _ = Describe("Set utils", func() {
 			Set: &clusterSet,
 		}
 
-		controllers.SelectClusters(setScope)
+		Expect(controllers.SelectClusters(context.TODO(), nil, setScope, logger)).To(Succeed())
 		Expect(len(clusterSet.Status.SelectedClusterRefs)).To(Equal(clusterSet.Spec.MaxReplicas))
+	})
+
+	It("pruneConnectionDownClusters remove SveltosCluster with connectionStatus set to Down", func() {
+		clusterSet := libsveltosv1beta1.ClusterSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: randomString(),
+			},
+			Spec: libsveltosv1beta1.Spec{
+				MaxReplicas: 2,
+				ClusterSelector: libsveltosv1beta1.Selector{
+					LabelSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							randomString(): randomString(),
+						},
+					},
+				},
+			},
+			Status: libsveltosv1beta1.Status{},
+		}
+
+		initObjects := []client.Object{}
+
+		clusterSet.Status.MatchingClusterRefs = make([]corev1.ObjectReference, 0)
+		// Add 3 SveltosCluster with Status.ConnectionStatus set to Down
+		for i := 0; i < 3; i++ {
+			sveltosCluster := libsveltosv1beta1.SveltosCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: randomString(),
+					Name:      randomString(),
+				},
+				Status: libsveltosv1beta1.SveltosClusterStatus{
+					ConnectionStatus: libsveltosv1beta1.ConnectionDown,
+					Ready:            true,
+				},
+			}
+
+			initObjects = append(initObjects, &sveltosCluster)
+
+			clusterSet.Status.MatchingClusterRefs = append(clusterSet.Status.MatchingClusterRefs,
+				corev1.ObjectReference{
+					Kind:       string(libsveltosv1beta1.ClusterTypeSveltos),
+					APIVersion: libsveltosv1beta1.GroupVersion.String(),
+					Namespace:  sveltosCluster.Namespace,
+					Name:       sveltosCluster.Name,
+				})
+		}
+
+		healthySveltosClusters := make(map[corev1.ObjectReference]bool)
+		// Add 3 SveltosCluster with Status.ConnectionStatus set to Healthy
+		for i := 0; i < 3; i++ {
+			sveltosCluster := libsveltosv1beta1.SveltosCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: randomString(),
+					Name:      randomString(),
+				},
+				Status: libsveltosv1beta1.SveltosClusterStatus{
+					ConnectionStatus: libsveltosv1beta1.ConnectionHealthy,
+					Ready:            true,
+				},
+			}
+
+			initObjects = append(initObjects, &sveltosCluster)
+
+			objectRef := &corev1.ObjectReference{
+				Kind:       string(libsveltosv1beta1.ClusterTypeSveltos),
+				APIVersion: libsveltosv1beta1.GroupVersion.String(),
+				Namespace:  sveltosCluster.Namespace,
+				Name:       sveltosCluster.Name,
+			}
+
+			clusterSet.Status.MatchingClusterRefs = append(clusterSet.Status.MatchingClusterRefs, *objectRef)
+
+			healthySveltosClusters[*objectRef] = true
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).
+			WithObjects(initObjects...).Build()
+
+		Expect(addTypeInformationToObject(scheme, &clusterSet)).To(Succeed())
+
+		setScope := &scope.SetScope{
+			Set: &clusterSet,
+		}
+
+		result, err := controllers.PruneConnectionDownClusters(context.TODO(), c, clusterSet.Status.MatchingClusterRefs, logger)
+		Expect(err).To(BeNil())
+		Expect(len(result)).To(Equal(3))
+		for i := range result {
+			v := healthySveltosClusters[result[i]]
+			Expect(v).To(BeTrue())
+		}
+
+		Expect(controllers.SelectClusters(context.TODO(), c, setScope, logger)).To(Succeed())
+		Expect(len(clusterSet.Status.SelectedClusterRefs)).To(Equal(clusterSet.Spec.MaxReplicas))
+		// Verify only SveltosCluster with connectionStatus set to Healthy are picked
+		for i := range clusterSet.Status.SelectedClusterRefs {
+			clusterRef := clusterSet.Status.SelectedClusterRefs[i]
+			v := healthySveltosClusters[clusterRef]
+			Expect(v).To(BeTrue())
+		}
 	})
 })

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.35.1-0.20240726065655-ee3b7dc30da2
+	github.com/projectsveltos/libsveltos v0.35.1-0.20240805114830-bfe0e2b5e213
 	github.com/prometheus/client_golang v1.19.1
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.35.1-0.20240726065655-ee3b7dc30da2 h1:DE4fivtx4pjPFpjAyDWbG46RQQCyDMgJ7ZI/5zkHq88=
-github.com/projectsveltos/libsveltos v0.35.1-0.20240726065655-ee3b7dc30da2/go.mod h1:8cr9lSt8i0fRQ47AItTElqxsiD/ni80GJALVQgxfdG4=
+github.com/projectsveltos/libsveltos v0.35.1-0.20240805114830-bfe0e2b5e213 h1:TU8nNO5kQhjkRN29a74sLGypriQCE7PL4Lw2DiFrkPw=
+github.com/projectsveltos/libsveltos v0.35.1-0.20240805114830-bfe0e2b5e213/go.mod h1:8cr9lSt8i0fRQ47AItTElqxsiD/ni80GJALVQgxfdG4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --agent-in-mgmt-cluster
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -2408,6 +2408,8 @@ spec:
                             https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               policyRefs:
@@ -5163,6 +5165,8 @@ spec:
                                 https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                               type: string
                           type: object
+                      required:
+                      - patch
                       type: object
                     type: array
                   policyRefs:
@@ -7222,6 +7226,8 @@ spec:
                             https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-machinery/api-group.md
                           type: string
                       type: object
+                  required:
+                  - patch
                   type: object
                 type: array
               policyRefs:
@@ -8405,10 +8411,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Sveltos periodically attempts to connect to managed SveltosClusters. Upon successful initial connection, the `Ready` status is set to true and remains unchanged.

To indicate connection health, this PR introduces a `ConnectionStatus` field within the Status. This field can be either `Healthy` or `Down`. The status transitions to `Down` after a configurable number of consecutive connection failures, which defaults to three.

This PR changes ClusterSet/Set to only pick clusters that are:

1. Ready (it was already the case)
2. With `Healthy` ConnectionStatus