### PR TITLE
(bug) react to referenced ConfigMap/Secret/Sources annotation changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ARCH ?= $(shell go env GOARCH)
 OS ?= $(shell uname -s | tr A-Z a-z)
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= main
+TAG ?= dev
 
 .PHONY: all
 all: build

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -15,4 +15,4 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--v=5"
-        - "--version=main"
+        - "--version=dev"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/addon-controller:main
+      - image: docker.io/projectsveltos/addon-controller:dev
         name: controller

--- a/controllers/handlers_kustomize.go
+++ b/controllers/handlers_kustomize.go
@@ -351,8 +351,7 @@ func getHashFromKustomizationRef(ctx context.Context, c client.Client, clusterSu
 		if configMap == nil {
 			return nil, nil
 		}
-		result += getDataSectionHash(configMap.Data)
-		result += getDataSectionHash(configMap.BinaryData)
+		result += getConfigMapHash(configMap)
 	} else if kustomizationRef.Kind == string(libsveltosv1beta1.SecretReferencedResourceKind) {
 		secret, err := getSecret(ctx, c, types.NamespacedName{Namespace: namespace, Name: name})
 		if err != nil {
@@ -362,8 +361,7 @@ func getHashFromKustomizationRef(ctx context.Context, c client.Client, clusterSu
 		if secret == nil {
 			return nil, nil
 		}
-		result += getDataSectionHash(secret.Data)
-		result += getDataSectionHash(secret.StringData)
+		result += getSecretHash(secret)
 	} else {
 		source, err := getSource(ctx, c, namespace, name, kustomizationRef.Kind)
 		if err != nil {
@@ -376,6 +374,9 @@ func getHashFromKustomizationRef(ctx context.Context, c client.Client, clusterSu
 		s := source.(sourcev1.Source)
 		if s.GetArtifact() != nil {
 			result += s.GetArtifact().Revision
+		}
+		if source.GetAnnotations() != nil {
+			result += getDataSectionHash(source.GetAnnotations())
 		}
 	}
 

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -371,15 +371,13 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummaryScope *sc
 			configmap := &corev1.ConfigMap{}
 			err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, configmap)
 			if err == nil {
-				config += getDataSectionHash(configmap.Data)
-				config += getDataSectionHash(configmap.BinaryData)
+				config += getConfigMapHash(configmap)
 			}
 		} else if reference.Kind == string(libsveltosv1beta1.SecretReferencedResourceKind) {
 			secret := &corev1.Secret{}
 			err = c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, secret)
 			if err == nil {
-				config += getDataSectionHash(secret.Data)
-				config += getDataSectionHash(secret.StringData)
+				config += getSecretHash(secret)
 			}
 		} else {
 			var source client.Object
@@ -389,6 +387,9 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummaryScope *sc
 				if s.GetArtifact() != nil {
 					config += s.GetArtifact().Revision
 				}
+			}
+			if source.GetAnnotations() != nil {
+				config += getDataSectionHash(source.GetAnnotations())
 			}
 		}
 		if err != nil {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -334,6 +334,30 @@ func removeDuplicates(references []corev1.ObjectReference) []corev1.ObjectRefere
 	return set.Items()
 }
 
+func getConfigMapHash(configmap *corev1.ConfigMap) string {
+	var config string
+	if configmap.Annotations != nil {
+		config += getDataSectionHash(configmap.Annotations)
+	}
+
+	config += getDataSectionHash(configmap.Data)
+	config += getDataSectionHash(configmap.BinaryData)
+
+	return config
+}
+
+func getSecretHash(secret *corev1.Secret) string {
+	var config string
+	if secret.Annotations != nil {
+		config += getDataSectionHash(secret.Annotations)
+	}
+
+	config += getDataSectionHash(secret.Data)
+	config += getDataSectionHash(secret.StringData)
+
+	return config
+}
+
 // getDataSectionHash sorts map and return the hash
 func getDataSectionHash[T any](data map[string]T) string {
 	var keys []string

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --agent-in-mgmt-cluster
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -23,10 +23,10 @@ spec:
         - --report-mode=0
         - --shard-key={{.SHARD}}
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8109,10 +8109,10 @@ spec:
         - --report-mode=0
         - --shard-key=
         - --v=5
-        - --version=main
+        - --version=dev
         command:
         - /manager
-        image: docker.io/projectsveltos/addon-controller:main
+        image: docker.io/projectsveltos/addon-controller:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -46,7 +46,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -28,7 +28,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -130,7 +130,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -112,7 +112,7 @@ spec:
         - --run-mode=do-not-send-updates
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager:main
+        image: docker.io/projectsveltos/drift-detection-manager:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Referenced ConfigMap/Secret/Sources can have annotations indicating:

1. `projectsveltos.io/template` => the content is a template and must be instantiated
2. `projectsveltos.io/subresources: status` => status must be updated as well

So when annotations change, ClusterSummary must be reconcilied (this was already happening) and Sveltos should detect a change in the hash and redeploy (this was not happening).

This PR fixes that.

Fixes #670 