### PR TITLE
(bug) move compatibility check down

### DIFF
--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -94,12 +94,6 @@ func collectResourceSummariesFromCluster(ctx context.Context, c client.Client,
 		return err
 	}
 
-	if !sveltos_upgrade.IsDriftDetectionVersionCompatible(ctx, remoteClient, version) {
-		msg := "compatibility checks failed"
-		logger.V(logs.LogDebug).Info(msg)
-		return errors.New(msg)
-	}
-
 	var installed bool
 	installed, err = isResourceSummaryInstalled(ctx, remoteClient)
 	if err != nil {
@@ -109,6 +103,12 @@ func collectResourceSummariesFromCluster(ctx context.Context, c client.Client,
 
 	if !installed {
 		return nil
+	}
+
+	if !sveltos_upgrade.IsDriftDetectionVersionCompatible(ctx, remoteClient, version) {
+		msg := "compatibility checks failed"
+		logger.V(logs.LogDebug).Info(msg)
+		return errors.New(msg)
 	}
 
 	logger.V(logs.LogVerbose).Info("collecting ResourceSummaries from cluster")


### PR DESCRIPTION
When trying to collect ResourceSummary before this PR checks where:

1. compatibility check
2. ResourceSummary CRD deployed

In cases where drift-detection-manager (and so ResourceSummary CRD) was not deployed on a managed cluster (no ContinuousWithDriftDetection profile matching) this lead to following error being logged continiously

```
failed to collect ResourceSummaries from cluster: mgmt/mgmt compatibility checks failed
```

This PR fixes that by re-arranging the checks to:

1. ResourceSummary CRD deployed
2. compatibility check