### PR TITLE
Revert "(bug) when cluster is marked as deleted avoid triggering clea…

### DIFF
--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -234,7 +234,6 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 	if err != nil {
 		return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
 	}
-
 	if isPresent && isReady { // if cluster is not ready, do not try to clean up. It would fail.
 		// Cleanup
 		paused, err := r.isPaused(ctx, clusterSummaryScope.ClusterSummary)
@@ -252,21 +251,18 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 			return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
 		}
 
-		if !isDeleted { // if cluster is being deleted do not try to undeploy. Helm client gets stuck and never returns
-			// if undeploy starts and cluster apiserver is not reachable anymore while helm undeploy is in process
-			err = r.undeploy(ctx, clusterSummaryScope, logger)
-			if err != nil {
-				// In DryRun mode it is expected to always get an error back
-				if !clusterSummaryScope.IsDryRunSync() {
-					logger.V(logs.LogInfo).Error(err, "failed to undeploy")
-					return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
-				}
-			}
-
-			if !r.canRemoveFinalizer(ctx, clusterSummaryScope, logger) {
-				logger.V(logs.LogInfo).Error(err, "cannot remove finalizer yet")
+		err = r.undeploy(ctx, clusterSummaryScope, logger)
+		if err != nil {
+			// In DryRun mode it is expected to always get an error back
+			if !clusterSummaryScope.IsDryRunSync() {
+				logger.V(logs.LogInfo).Error(err, "failed to undeploy")
 				return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
 			}
+		}
+
+		if !r.canRemoveFinalizer(ctx, clusterSummaryScope, logger) {
+			logger.V(logs.LogInfo).Error(err, "cannot remove finalizer yet")
+			return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
 		}
 	}
 


### PR DESCRIPTION
Sveltos deploys resources in the management cluster when the `deploymenType` is set to `Local`.
Even if a cluster is marked as deleted, Sveltos will still need to remove all resources deployed in the management cluster for that cluster. So this PR lets Sveltos undeploy even for clusters marked as deleted.

If the managed cluster API server is unreachable after the Helm SDK uninstall is triggered, the Helm SDK will get stuck. Helm charts are only deployed in the matching cluster, so Sveltos will skip calling Helm uninstall for any deleted cluster.

This reverts commit ce9e7f6.

Fixes #719