### PR TITLE
(bug) better handle deleted cluster

### DIFF
--- a/controllers/clustercache/clustercache_suite_test.go
+++ b/controllers/clustercache/clustercache_suite_test.go
@@ -101,6 +101,10 @@ var _ = BeforeSuite(func() {
 	Expect(testEnv.Create(context.TODO(), sveltosCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, sveltosCRD)).To(Succeed())
 
+	// Wait for synchronization
+	// Sometimes we otherwise get "no matches for kind "..." in version "lib.projectsveltos.io/v1beta1"
+	time.Sleep(2 * time.Second)
+
 	if synced := testEnv.GetCache().WaitForCacheSync(ctx); !synced {
 		time.Sleep(time.Second)
 	}

--- a/controllers/clustersummary_deployer_test.go
+++ b/controllers/clustersummary_deployer_test.go
@@ -51,8 +51,6 @@ var _ = Describe("ClustersummaryDeployer", func() {
 	var clusterName string
 
 	BeforeEach(func() {
-		logger = textlogger.NewLogger(textlogger.NewConfig())
-
 		namespace = randomString()
 
 		logger = textlogger.NewLogger(textlogger.NewConfig())

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -136,7 +136,7 @@ var _ = BeforeSuite(func() {
 	Expect(waitForObject(context.TODO(), testEnv.Client, projectsveltosNs)).To(Succeed())
 
 	// Wait for synchronization
-	// Sometimes we otherwise get "no matches for kind "AddonCompliance" in version "lib.projectsveltos.io/v1beta1"
+	// Sometimes we otherwise get "no matches for kind ... in version "lib.projectsveltos.io/v1beta1"
 	time.Sleep(2 * time.Second)
 
 	controllers.InitializeManager(textlogger.NewLogger(textlogger.NewConfig()),

--- a/controllers/profile_utils_test.go
+++ b/controllers/profile_utils_test.go
@@ -887,10 +887,18 @@ var _ = Describe("Profile: Reconciler", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		Expect(controllers.CleanClusterReports(context.TODO(), c, clusterProfile)).To(Succeed())
+		clusterProfileScope, err := scope.NewProfileScope(scope.ProfileScopeParams{
+			Client:         c,
+			Logger:         logger,
+			Profile:        clusterProfile,
+			ControllerName: "clusterprofile",
+		})
+		Expect(err).To(BeNil())
+
+		Expect(controllers.CleanClusterReports(context.TODO(), c, clusterProfileScope)).To(Succeed())
 		// ClusterReport1 is gone
 		currentClusterReport := &configv1beta1.ClusterReport{}
-		err := c.Get(context.TODO(),
+		err = c.Get(context.TODO(),
 			types.NamespacedName{Namespace: clusterReport1.Namespace, Name: clusterReport1.Name}, currentClusterReport)
 		Expect(err).ToNot(BeNil())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -969,10 +977,18 @@ var _ = Describe("Profile: Reconciler", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		Expect(controllers.CleanClusterReports(context.TODO(), c, &profile)).To(Succeed())
+		profileScope, err := scope.NewProfileScope(scope.ProfileScopeParams{
+			Client:         c,
+			Logger:         logger,
+			Profile:        &profile,
+			ControllerName: "profile",
+		})
+		Expect(err).To(BeNil())
+
+		Expect(controllers.CleanClusterReports(context.TODO(), c, profileScope)).To(Succeed())
 		// ClusterReport1 is gone
 		currentClusterReport := &configv1beta1.ClusterReport{}
-		err := c.Get(context.TODO(),
+		err = c.Get(context.TODO(),
 			types.NamespacedName{Namespace: clusterReport1.Namespace, Name: clusterReport1.Name}, currentClusterReport)
 		Expect(err).ToNot(BeNil())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())


### PR DESCRIPTION
When cluster is still present but marked as deleted, Sveltos can avoid removing resources (helm charts and/or kubernetes resources) from such a cluster.
Anything else created in the management cluster for such managed cluster still needs to be removed.

Fixes #735 
Fixes #732 