### PR TITLE
Telemetry data

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,7 +166,7 @@ func main() {
 	debug.SetMemoryLimit(gibibytes_per_bytes)
 	go printMemUsage(ctrl.Log.WithName("memory-usage"))
 
-	if !disableTelemetry {
+	if shardKey == "" && !disableTelemetry {
 		err = telemetry.StartCollecting(ctx, mgr.GetClient(), version)
 		if err != nil {
 			setupLog.Error(err, "failed starting telemetry client")


### PR DESCRIPTION
If Sveltos is scaled and multiple addon-controller pods are present, only one will send telemetry data.

When number of clusters managed by Sveltos increases, Sveltos can be [horizontally scaled](https://projectsveltos.github.io/sveltos/scalability/sharding/). In this scenario multiple instances of addon-controller will be present. Only one will collect and send telemetry data.