### PR TITLE
(feat): track full diff for resources

### DIFF
--- a/api/v1beta1/clustersummary_types.go
+++ b/api/v1beta1/clustersummary_types.go
@@ -212,6 +212,7 @@ type ClusterSummaryStatus struct {
 // +kubebuilder:resource:path=clustersummaries,scope=Namespaced
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of ClusterSummary"
 // +kubebuilder:printcolumn:name="HelmCharts",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Helm\")].status",description="Indicates whether HelmCharts are all provisioned",priority=2
 // +kubebuilder:printcolumn:name="KustomizeRefs",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Kustomize\")].status",description="Indicates whether KustomizeRefs are all provisioned",priority=2
 // +kubebuilder:printcolumn:name="PolicyRefs",type="string",JSONPath=".status.featureSummaries[?(@.featureID==\"Resources\")].status",description="Indicates whether PolicyRefs are all provisioned",priority=2

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -936,6 +936,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterSummary
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: Indicates whether HelmCharts are all provisioned
       jsonPath: .status.featureSummaries[?(@.featureID=="Helm")].status
       name: HelmCharts

--- a/controllers/clustercache/cluster_cache_test.go
+++ b/controllers/clustercache/cluster_cache_test.go
@@ -86,7 +86,6 @@ var _ = Describe("Clustercache", func() {
 			Expect(cacheMgr.GetConfigFromMap(clusterObj)).To(BeNil())
 			Expect(cacheMgr.GetSecretForCluster(clusterObj)).To(BeNil())
 			Expect(cacheMgr.GetClusterFromSecret(secretObj)).To(BeNil())
-
 		})
 
 	It("RemoveSecret removes entries for all clusters using the modified secret", func() {
@@ -136,9 +135,12 @@ func createClusterResources(cluster *libsveltosv1beta1.SveltosCluster) *corev1.S
 	}
 
 	Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+	Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
 	Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
 	Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
 
+	Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv.Client, secret)).To(Succeed())
 	return secret
 }

--- a/controllers/clustercache/clustercache_suite_test.go
+++ b/controllers/clustercache/clustercache_suite_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/projectsveltos/addon-controller/internal/test/helpers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	libsveltoscrd "github.com/projectsveltos/libsveltos/lib/crd"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 var (
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 	}()
 
 	var sveltosCRD *unstructured.Unstructured
-	sveltosCRD, err = utils.GetUnstructured(libsveltoscrd.GetSveltosClusterCRDYAML())
+	sveltosCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetSveltosClusterCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), sveltosCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, sveltosCRD)).To(Succeed())

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -366,7 +366,7 @@ func (r *ClusterSummaryReconciler) reconcileNormal(
 		err = r.removeResourceSummary(ctx, clusterSummaryScope, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Error(err, "failed to remove ResourceSummary.")
-			return reconcile.Result{Requeue: true, RequeueAfter: deleteRequeueAfter}, nil
+			return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 		}
 	}
 

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -43,8 +43,8 @@ import (
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	libsveltoscrd "github.com/projectsveltos/libsveltos/lib/crd"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	libsveltosset "github.com/projectsveltos/libsveltos/lib/set"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var (
@@ -92,37 +92,37 @@ var _ = BeforeSuite(func() {
 	}()
 
 	var sveltosCRD *unstructured.Unstructured
-	sveltosCRD, err = utils.GetUnstructured(libsveltoscrd.GetSveltosClusterCRDYAML())
+	sveltosCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetSveltosClusterCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), sveltosCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, sveltosCRD)).To(Succeed())
 
 	var resourceSummaryCRD *unstructured.Unstructured
-	resourceSummaryCRD, err = utils.GetUnstructured(libsveltoscrd.GetResourceSummaryCRDYAML())
+	resourceSummaryCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetResourceSummaryCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), resourceSummaryCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, resourceSummaryCRD)).To(Succeed())
 
 	var dcCRD *unstructured.Unstructured
-	dcCRD, err = utils.GetUnstructured(libsveltoscrd.GetDebuggingConfigurationCRDYAML())
+	dcCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetDebuggingConfigurationCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), dcCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, dcCRD)).To(Succeed())
 
 	var reloaderCRD *unstructured.Unstructured
-	reloaderCRD, err = utils.GetUnstructured(libsveltoscrd.GetReloaderCRDYAML())
+	reloaderCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetReloaderCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), reloaderCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, reloaderCRD)).To(Succeed())
 
 	var setCRD *unstructured.Unstructured
-	setCRD, err = utils.GetUnstructured(libsveltoscrd.GetSetCRDYAML())
+	setCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetSetCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), setCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, setCRD)).To(Succeed())
 
 	var clusterSetCRD *unstructured.Unstructured
-	clusterSetCRD, err = utils.GetUnstructured(libsveltoscrd.GetClusterSetCRDYAML())
+	clusterSetCRD, err = k8s_utils.GetUnstructured(libsveltoscrd.GetClusterSetCRDYAML())
 	Expect(err).To(BeNil())
 	Expect(testEnv.Create(context.TODO(), clusterSetCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, clusterSetCRD)).To(Succeed())

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -67,10 +67,10 @@ import (
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/patcher"
 	libsveltostemplate "github.com/projectsveltos/libsveltos/lib/template"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 var (
@@ -1186,7 +1186,7 @@ func upgradeCRDs(ctx context.Context, requestedChart *configv1beta1.HelmChart, k
 		return err
 	}
 
-	dr, err := utils.GetDynamicResourceInterface(destConfig, apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), "")
+	dr, err := k8s_utils.GetDynamicResourceInterface(destConfig, apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"), "")
 	if err != nil {
 		return err
 	}
@@ -1933,7 +1933,7 @@ func collectHelmContent(manifest string, logger logr.Logger) ([]*unstructured.Un
 	resources := make([]*unstructured.Unstructured, 0, len(elements))
 
 	for i := range elements {
-		policy, err := utils.GetUnstructured([]byte(elements[i]))
+		policy, err := k8s_utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {
 			logger.Error(err, fmt.Sprintf("failed to get policy from Data %.100s", elements[i]))
 			return nil, err
@@ -2350,7 +2350,7 @@ func addExtraMetadata(ctx context.Context, requestedChart *configv1beta1.HelmCha
 		}
 
 		var dr dynamic.ResourceInterface
-		dr, err = utils.GetDynamicResourceInterface(config, r.GroupVersionKind(), namespace)
+		dr, err = k8s_utils.GetDynamicResourceInterface(config, r.GroupVersionKind(), namespace)
 		if err != nil {
 			return err
 		}
@@ -2358,7 +2358,7 @@ func addExtraMetadata(ctx context.Context, requestedChart *configv1beta1.HelmCha
 		addExtraLabels(r, clusterSummary.Spec.ClusterProfileSpec.ExtraLabels)
 		addExtraAnnotations(r, clusterSummary.Spec.ClusterProfileSpec.ExtraAnnotations)
 
-		err = updateResource(ctx, dr, clusterSummary, r, []string{}, logger)
+		_, err = updateResource(ctx, dr, clusterSummary, r, []string{}, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to update resource %s %s/%s: %v",
 				r.GetKind(), r.GetNamespace(), r.GetName(), err))

--- a/controllers/handlers_kustomize.go
+++ b/controllers/handlers_kustomize.go
@@ -53,9 +53,9 @@ import (
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
 	"github.com/projectsveltos/libsveltos/lib/funcmap"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	libsveltostemplate "github.com/projectsveltos/libsveltos/lib/template"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 const (
@@ -663,7 +663,7 @@ func getKustomizedResources(ctx context.Context, c client.Client, clusterSummary
 		}
 
 		var u *unstructured.Unstructured
-		u, err = utils.GetUnstructured(yaml)
+		u, err = k8s_utils.GetUnstructured(yaml)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get unstructured %v", err))
 			return nil, nil, nil, err

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -453,7 +453,6 @@ func updateClusterReportWithResourceReports(ctx context.Context, c client.Client
 		} else if featureID == configv1beta1.FeatureKustomize {
 			clusterReport.Status.KustomizeResourceReports = resourceReports
 		}
-
 		return c.Status().Update(ctx, clusterReport)
 	})
 	return err

--- a/controllers/reloader_utils_test.go
+++ b/controllers/reloader_utils_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	libsveltoscrd "github.com/projectsveltos/libsveltos/lib/crd"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 var _ = Describe("Reloader utils", func() {
@@ -162,7 +162,7 @@ var _ = Describe("Reloader utils", func() {
 		c := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		var reloaderCRD *unstructured.Unstructured
-		reloaderCRD, err := utils.GetUnstructured(libsveltoscrd.GetReloaderCRDYAML())
+		reloaderCRD, err := k8s_utils.GetUnstructured(libsveltoscrd.GetReloaderCRDYAML())
 		Expect(err).To(BeNil())
 		Expect(c.Create(context.TODO(), reloaderCRD)).To(Succeed())
 

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -37,10 +37,10 @@ import (
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/crd"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	"github.com/projectsveltos/libsveltos/lib/logsettings"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/patcher"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 const (
@@ -149,14 +149,14 @@ func deployDriftDetectionCRDs(ctx context.Context, remoteRestConfig *rest.Config
 func deployDebuggingConfigurationCRD(ctx context.Context, remoteRestConfig *rest.Config,
 	logger logr.Logger) error {
 
-	u, err := utils.GetUnstructured(crd.GetDebuggingConfigurationCRDYAML())
+	u, err := k8s_utils.GetUnstructured(crd.GetDebuggingConfigurationCRDYAML())
 	if err != nil {
 		logger.V(logs.LogInfo).Info(
 			fmt.Sprintf("failed to get DebuggingConfiguration CRD unstructured: %v", err))
 		return err
 	}
 
-	dr, err := utils.GetDynamicResourceInterface(remoteRestConfig, u.GroupVersionKind(), "")
+	dr, err := k8s_utils.GetDynamicResourceInterface(remoteRestConfig, u.GroupVersionKind(), "")
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get dynamic client: %v", err))
 		return err
@@ -178,14 +178,14 @@ func deployDebuggingConfigurationCRD(ctx context.Context, remoteRestConfig *rest
 func deployResourceSummaryCRD(ctx context.Context, remoteRestConfig *rest.Config,
 	logger logr.Logger) error {
 
-	rsCRD, err := utils.GetUnstructured(crd.GetResourceSummaryCRDYAML())
+	rsCRD, err := k8s_utils.GetUnstructured(crd.GetResourceSummaryCRDYAML())
 	if err != nil {
 		logger.V(logs.LogInfo).Info(
 			fmt.Sprintf("failed to get ResourceSummary CRD unstructured: %v", err))
 		return err
 	}
 
-	dr, err := utils.GetDynamicResourceInterface(remoteRestConfig, rsCRD.GroupVersionKind(), "")
+	dr, err := k8s_utils.GetDynamicResourceInterface(remoteRestConfig, rsCRD.GroupVersionKind(), "")
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get dynamic client: %v", err))
 		return err
@@ -272,7 +272,7 @@ func deployDriftDetectionManagerResources(ctx context.Context, restConfig *rest.
 		return err
 	}
 	for i := range elements {
-		policy, err := utils.GetUnstructured([]byte(elements[i]))
+		policy, err := k8s_utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to parse drift detection manager yaml: %v", err))
 			return err
@@ -318,7 +318,7 @@ func deployDriftDetectionManagerPatchedResources(ctx context.Context, restConfig
 
 	for i := range referencedUnstructured {
 		policy := referencedUnstructured[i]
-		dr, err := utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
+		dr, err := k8s_utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
 		if err != nil {
 			logger.V(logsettings.LogInfo).Info(fmt.Sprintf("failed to get dynamic client: %v", err))
 			return err
@@ -586,13 +586,13 @@ func removeDriftDetectionManagerFromManagementCluster(ctx context.Context,
 		return err
 	}
 	for i := range elements {
-		policy, err := utils.GetUnstructured([]byte(elements[i]))
+		policy, err := k8s_utils.GetUnstructured([]byte(elements[i]))
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to parse drift detection manager yaml: %v", err))
 			return err
 		}
 
-		dr, err := utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
+		dr, err := k8s_utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
 		if err != nil {
 			logger.V(logsettings.LogInfo).Info(fmt.Sprintf("failed to get dynamic client: %v", err))
 			return err

--- a/controllers/template_instantiation.go
+++ b/controllers/template_instantiation.go
@@ -34,8 +34,8 @@ import (
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	"github.com/projectsveltos/libsveltos/lib/funcmap"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
-	"github.com/projectsveltos/libsveltos/lib/utils"
 )
 
 type currentClusterObjects struct {
@@ -59,7 +59,7 @@ func fetchResource(ctx context.Context, config *rest.Config, namespace, name, ap
 		Kind:    kind,
 	}
 	var dr dynamic.ResourceInterface
-	dr, err = utils.GetDynamicResourceInterface(config, gvk, namespace)
+	dr, err = k8s_utils.GetDynamicResourceInterface(config, gvk, namespace)
 	if err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to fetch %s: %v", kind, err))
 		return nil, err

--- a/controllers/template_instantiation_test.go
+++ b/controllers/template_instantiation_test.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 var _ = Describe("Template instantiation", func() {
@@ -181,7 +181,7 @@ var _ = Describe("Template instantiation", func() {
 		Expect(err).To(BeNil())
 		Expect(result).To(ContainSubstring(fmt.Sprintf("namespace: %s", namespace)))
 
-		policy, err := utils.GetUnstructured([]byte(result))
+		policy, err := k8s_utils.GetUnstructured([]byte(result))
 		Expect(err).To(BeNil())
 		Expect(policy.GetNamespace()).To(Equal(namespace))
 	})
@@ -370,7 +370,7 @@ var _ = Describe("Template instantiation", func() {
 		Expect(*modifiedDepl.Spec.Replicas).To(Equal(int32(5)))
 		Expect(modifiedDepl.Spec.Paused).To(BeTrue())
 
-		policy, err := utils.GetUnstructured([]byte(result))
+		policy, err := k8s_utils.GetUnstructured([]byte(result))
 		Expect(err).To(BeNil())
 		Expect(policy.GetNamespace()).To(Equal(namespace))
 	})

--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -28,7 +28,7 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/funcmap"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 // The TemplateResource namespace can be specified or it will inherit the cluster namespace
@@ -104,7 +104,7 @@ func collectTemplateResourceRefs(ctx context.Context, clusterSummary *configv1be
 			return nil, err
 		}
 
-		dr, err := utils.GetDynamicResourceInterface(restConfig, ref.Resource.GroupVersionKind(), ref.Resource.Namespace)
+		dr, err := k8s_utils.GetDynamicResourceInterface(restConfig, ref.Resource.GroupVersionKind(), ref.Resource.Namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -38,7 +38,7 @@ import (
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	"github.com/projectsveltos/libsveltos/lib/utils"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 const (
@@ -304,13 +304,13 @@ var _ = Describe("getClusterProfileOwner ", func() {
 	})
 
 	It("isNamespaced returns true for namespaced resources", func() {
-		clusterRole, err := utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
+		clusterRole, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
 		Expect(err).To(BeNil())
 		isNamespaced, err := controllers.IsNamespaced(clusterRole, testEnv.Config)
 		Expect(err).To(BeNil())
 		Expect(isNamespaced).To(BeFalse())
 
-		deployment, err := utils.GetUnstructured([]byte(fmt.Sprintf(deplTemplate, randomString())))
+		deployment, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(deplTemplate, randomString())))
 		Expect(err).To(BeNil())
 		isNamespaced, err = controllers.IsNamespaced(deployment, testEnv.Config)
 		Expect(err).To(BeNil())

--- a/controllers/validate_health_test.go
+++ b/controllers/validate_health_test.go
@@ -33,7 +33,7 @@ import (
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
-	libsveltosutils "github.com/projectsveltos/libsveltos/lib/utils"
+	libsveltosutils "github.com/projectsveltos/libsveltos/lib/k8s_utils"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -13,10 +13,11 @@ require (
 	github.com/gdexlab/go-render v1.0.1
 	github.com/go-logr/logr v1.4.2
 	github.com/google/gofuzz v1.2.0
+	github.com/hexops/gotextdiff v1.0.3
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.42.1
+	github.com/projectsveltos/libsveltos v0.42.1-0.20241129122707-e7c51baedfbd
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/hashicorp/golang-lru/arc/v2 v2.0.5 h1:l2zaLDubNhW4XO3LnliVj0GXO3+/CGN
 github.com/hashicorp/golang-lru/arc/v2 v2.0.5/go.mod h1:ny6zBSQZi2JxIeYcv7kt2sH2PXJtirBN7RDhRpxPkxU=
 github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
 github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
@@ -304,8 +306,6 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/onsi/ginkgo/v2 v2.22.0 h1:Yed107/8DjTr0lKCNt7Dn8yQ6ybuDRQoMGrNFKzMfHg=
 github.com/onsi/ginkgo/v2 v2.22.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
-github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
-github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/onsi/gomega v1.36.0 h1:Pb12RlruUtj4XUuPUqeEWc6j5DkVVVA49Uf6YLfC95Y=
 github.com/onsi/gomega v1.36.0/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
 github.com/opencontainers/go-digest v1.0.1-0.20240426182413-22b78e47854a h1:JgnDqvmVl/kOyC4pEpn2Ra2QtisfpG27Hp+xFKF26AE=
@@ -326,8 +326,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.42.1 h1:B7c8cF+vhR5AZJT8D4h19PSJfZqWUCR3CKEDUf032JI=
-github.com/projectsveltos/libsveltos v0.42.1/go.mod h1:XPev2TKsMxVG5LwhbbMkcCs/U0730ZMmOXIvu2HEtWo=
+github.com/projectsveltos/libsveltos v0.42.1-0.20241129122707-e7c51baedfbd h1:csSkEGSZS8DJ+EioxTdJDC+dDcyvVWzWo8yaWlgBOoc=
+github.com/projectsveltos/libsveltos v0.42.1-0.20241129122707-e7c51baedfbd/go.mod h1:4hqQRjwZ/DZ6u0haL3zhdARZ3lpspLv57rkhpXIzbsg=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -4518,6 +4518,10 @@ spec:
     subresources:
       status: {}
   - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterSummary
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - description: Indicates whether HelmCharts are all provisioned
       jsonPath: .status.featureSummaries[?(@.featureID=="Helm")].status
       name: HelmCharts


### PR DESCRIPTION
When in DryRun mode, Sveltos creates a ClusterReport containing the list of changes compared to current configuration. For raw Kubernetes resources this includes listing:
1. resources that would be created
2. resources that would be deleted
3. resources that would be updated

Sveltos now provides a more granular view of proposed changes during Dry Run mode for updates. A detailed diff highlighting exact changes, such as added, modified, or removed fields.

Example:

```yaml
    resourceReports:
    - action: Update
      message: |
        --- ClusterPolicy disallow-latest-tag
        +++ ClusterPolicy disallow-latest-tag
        @@ -49,7 +49,7 @@
                       name: validate-image-tag
                       skipBackgroundRequests: true
                       validate:
        -                message: Using a mutable image tag e.g. 'latest' is not allowed.
        +                message: Using a mutable image tag e.g. 'latest' is not allowed in produdction clusters.
                         pattern:
                             spec:
```