### PR TITLE
(perf) ClusterSummary in DryRun mode

### DIFF
--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -124,10 +124,6 @@ func deployResources(ctx context.Context, c client.Client,
 		return err
 	}
 
-	if clusterSummary.Spec.ClusterProfileSpec.SyncMode == configv1beta1.SyncModeDryRun {
-		return &configv1beta1.DryRunReconciliationError{}
-	}
-
 	if deployError != nil {
 		return deployError
 	}


### PR DESCRIPTION
DryRun ClusterSummaries are periodically updated to reflect changes in the cluster.
This PR ensures the Status is always set to Provisioning to avoid unnecessary reconciliations.