### PR TITLE
StopMatchingBehavior: accept only two correct values

### DIFF
--- a/api/v1alpha1/spec.go
+++ b/api/v1alpha1/spec.go
@@ -436,6 +436,7 @@ type KustomizationRef struct {
 // a ClusterProfile. By default, withdrawpolicies, deployed Helm charts and Kubernetes
 // resources will be removed from Cluster. LeavePolicy instead leaves Helm charts
 // and Kubernetes policies in the Cluster.
+// +kubebuilder:validation:Enum:=WithdrawPolicies;LeavePolicies
 type StopMatchingBehavior string
 
 // Define the StopMatchingBehavior constants.

--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -505,6 +505,7 @@ type KustomizationRef struct {
 // a ClusterProfile. By default, withdrawpolicies, deployed Helm charts and Kubernetes
 // resources will be removed from Cluster. LeavePolicy instead leaves Helm charts
 // and Kubernetes policies in the Cluster.
+// +kubebuilder:validation:Enum:=WithdrawPolicies;LeavePolicies
 type StopMatchingBehavior string
 
 // Define the StopMatchingBehavior constants.

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -583,6 +583,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous
@@ -1781,6 +1784,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -601,6 +601,9 @@ spec:
                       the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                       be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                       leave ClusterProfile deployed policies in the Cluster.
+                    enum:
+                    - WithdrawPolicies
+                    - LeavePolicies
                     type: string
                   syncMode:
                     default: Continuous
@@ -1809,6 +1812,9 @@ spec:
                       the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                       be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                       leave ClusterProfile deployed policies in the Cluster.
+                    enum:
+                    - WithdrawPolicies
+                    - LeavePolicies
                     type: string
                   syncMode:
                     default: Continuous

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -583,6 +583,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous
@@ -1781,6 +1784,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1364,6 +1364,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous
@@ -2562,6 +2565,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous
@@ -4184,6 +4190,9 @@ spec:
                       the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                       be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                       leave ClusterProfile deployed policies in the Cluster.
+                    enum:
+                    - WithdrawPolicies
+                    - LeavePolicies
                     type: string
                   syncMode:
                     default: Continuous
@@ -5392,6 +5401,9 @@ spec:
                       the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                       be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                       leave ClusterProfile deployed policies in the Cluster.
+                    enum:
+                    - WithdrawPolicies
+                    - LeavePolicies
                     type: string
                   syncMode:
                     default: Continuous
@@ -6327,6 +6339,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous
@@ -7525,6 +7540,9 @@ spec:
                   the ClusterProfile. By default all deployed Helm charts and Kubernetes resources will
                   be withdrawn from Cluster. Setting StopMatchingBehavior to LeavePolicies will instead
                   leave ClusterProfile deployed policies in the Cluster.
+                enum:
+                - WithdrawPolicies
+                - LeavePolicies
                 type: string
               syncMode:
                 default: Continuous


### PR DESCRIPTION
Enforce validations for StopMatchingBehavior.

This PR also changes behavior when in DryRun mode. Value hashes are not considered in DryRun mode. That is because in this mode if version is same, value diffs will be evaluated and reported.