### PR TITLE
(bug) DryRun and tier for helm chart

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -121,7 +121,7 @@ var (
 	ShouldUninstall                          = shouldUninstall
 	ShouldUpgrade                            = shouldUpgrade
 	UpdateChartsInClusterConfiguration       = updateChartsInClusterConfiguration
-	UpdateStatusForeferencedHelmReleases     = updateStatusForeferencedHelmReleases
+	UpdateStatusForReferencedHelmReleases    = updateStatusForReferencedHelmReleases
 	UpdateStatusForNonReferencedHelmReleases = updateStatusForNonReferencedHelmReleases
 	CreateReportForUnmanagedHelmRelease      = createReportForUnmanagedHelmRelease
 	UpdateClusterReportWithHelmReports       = updateClusterReportWithHelmReports

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -215,7 +215,7 @@ var _ = Describe("HandlersHelm", func() {
 
 		manager.RegisterClusterSummaryForCharts(clusterSummary)
 
-		clusterSummary, conflict, err := controllers.UpdateStatusForeferencedHelmReleases(context.TODO(),
+		clusterSummary, conflict, err := controllers.UpdateStatusForReferencedHelmReleases(context.TODO(),
 			testEnv.Client, clusterSummary, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(conflict).To(BeFalse())
@@ -271,7 +271,7 @@ var _ = Describe("HandlersHelm", func() {
 
 		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
 
-		clusterSummary, conflict, err := controllers.UpdateStatusForeferencedHelmReleases(context.TODO(), c, clusterSummary, nil,
+		clusterSummary, conflict, err := controllers.UpdateStatusForReferencedHelmReleases(context.TODO(), c, clusterSummary, nil,
 			textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 		Expect(conflict).To(BeFalse())


### PR DESCRIPTION
When in DryRun mode, in case of conflict, still consider tiers to decide which ClusterProfile can manage an Helm chart.

This will make sure the right message is generated. For instance, if a ClusterProfile in DryRun mode has a better tier than the profile currently managing the Helm chart, moving the ClusterProfile to Continuous (from DryRun) will cause a change to the helm chart.

If we start with

```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: deploy-kyverno
spec:
  clusterSelector:
    matchLabels:
      env: fv
  helmCharts:
  - repositoryURL:    https://kyverno.github.io/kyverno/
    repositoryName:   kyverno
    chartName:        kyverno/kyverno
    chartVersion:     v3.2.6
    releaseName:      kyverno-latest
    releaseNamespace: kyverno
    helmChartAction:  Install
```

when adding

```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: deploy-kyverno-2
spec:
  tier: 10
  clusterSelector:
    matchLabels:
      env: fv
  syncMode: DryRun
  helmCharts:
  - repositoryURL:    https://kyverno.github.io/kyverno/
    repositoryName:   kyverno
    chartName:        kyverno/kyverno
    chartVersion:     v3.3.0
    releaseName:      kyverno-latest
    releaseNamespace: kyverno
    helmChartAction:  Install
```

the result is:
- Nothing happens to the Kyverno Helm chart;
- show dryrun display that deploy-kyverno-2 would upgrade the Kyverno Helm chart from 3.2.6 to 3.3.0

Fixes #894 

