### PR TITLE
(bug) login to private registries

### DIFF
--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -929,6 +929,7 @@ var _ = Describe("Hash methods", func() {
 			Data: map[string][]byte{
 				"config.json": credentialsBytes,
 			},
+			Type: corev1.SecretTypeDockerConfigJson,
 		}
 
 		caByte := []byte(randomString())


### PR DESCRIPTION
If the Secret with credentials is of type kubernetes.io/dockerconfigjson create the credentials file and pass to Helm registry. Otherwise expects secret to contain username and password and use just those to login

