### PR TITLE
(feat) introduce maxConsecutiveFailures knob

### DIFF
--- a/api/v1alpha1/zz_generated.conversion.go
+++ b/api/v1alpha1/zz_generated.conversion.go
@@ -1494,6 +1494,7 @@ func autoConvert_v1beta1_Spec_To_v1alpha1_Spec(in *v1beta1.Spec, out *Spec, s co
 	out.ValidateHealths = *(*[]ValidateHealth)(unsafe.Pointer(&in.ValidateHealths))
 	// WARNING: in.Patches requires manual conversion: does not exist in peer-type
 	// WARNING: in.DriftExclusions requires manual conversion: does not exist in peer-type
+	// WARNING: in.MaxConsecutiveFailures requires manual conversion: does not exist in peer-type
 	out.ExtraLabels = *(*map[string]string)(unsafe.Pointer(&in.ExtraLabels))
 	out.ExtraAnnotations = *(*map[string]string)(unsafe.Pointer(&in.ExtraAnnotations))
 	return nil

--- a/api/v1beta1/clustersummary_types.go
+++ b/api/v1beta1/clustersummary_types.go
@@ -91,6 +91,11 @@ type FeatureSummary struct {
 	// +optional
 	Hash []byte `json:"hash,omitempty"`
 
+	// The maximum number of consecutive deployment failures that Sveltos will permit.
+	// After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+	// This field is optional. If not set, Sveltos default behavior is to keep retrying.
+	ConsecutiveFailures uint `json:"consecutiveFailures"`
+
 	// Status represents the state of the feature in the workload cluster
 	// +optional
 	Status FeatureStatus `json:"status,omitempty"`

--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -724,6 +724,13 @@ type Spec struct {
 	// +optional
 	DriftExclusions []DriftExclusion `json:"driftExclusions,omitempty"`
 
+	// The maximum number of consecutive deployment failures that Sveltos will permit.
+	// After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+	// This setting applies only to feature deployments, not resource removal.
+	// This field is optional. If not set, Sveltos default behavior is to keep retrying.
+	// +optional
+	MaxConsecutiveFailures *uint `json:"maxConsecutiveFailures,omitempty"`
+
 	// ExtraLabels: These labels will be added by Sveltos to all Kubernetes resources deployed in
 	// a managed cluster based on this ClusterProfile/Profile instance.
 	// **Important:** If a resource deployed by Sveltos already has a label with a key present in

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -986,6 +986,11 @@ func (in *Spec) DeepCopyInto(out *Spec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MaxConsecutiveFailures != nil {
+		in, out := &in.MaxConsecutiveFailures, &out.MaxConsecutiveFailures
+		*out = new(uint)
+		**out = **in
+	}
 	if in.ExtraLabels != nil {
 		in, out := &in.ExtraLabels, &out.ExtraLabels
 		*out = make(map[string]string, len(*in))

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -1638,6 +1638,13 @@ spec:
                   - namespace
                   type: object
                 type: array
+              maxConsecutiveFailures:
+                description: |-
+                  The maximum number of consecutive deployment failures that Sveltos will permit.
+                  After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                  This setting applies only to feature deployments, not resource removal.
+                  This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                type: integer
               maxUpdate:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -1666,6 +1666,13 @@ spec:
                       - namespace
                       type: object
                     type: array
+                  maxConsecutiveFailures:
+                    description: |-
+                      The maximum number of consecutive deployment failures that Sveltos will permit.
+                      After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                      This setting applies only to feature deployments, not resource removal.
+                      This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                    type: integer
                   maxUpdate:
                     anyOf:
                     - type: integer
@@ -2069,6 +2076,12 @@ spec:
                     FeatureSummary contains a summary of the state of a workload
                     cluster feature.
                   properties:
+                    consecutiveFailures:
+                      description: |-
+                        The maximum number of consecutive deployment failures that Sveltos will permit.
+                        After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                        This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                      type: integer
                     deployedGroupVersionKind:
                       description: |-
                         DeployedGroupVersionKind contains all GroupVersionKinds deployed in either
@@ -2116,6 +2129,7 @@ spec:
                       - Removed
                       type: string
                   required:
+                  - consecutiveFailures
                   - featureID
                   type: object
                 type: array

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -1638,6 +1638,13 @@ spec:
                   - namespace
                   type: object
                 type: array
+              maxConsecutiveFailures:
+                description: |-
+                  The maximum number of consecutive deployment failures that Sveltos will permit.
+                  After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                  This setting applies only to feature deployments, not resource removal.
+                  This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                type: integer
               maxUpdate:
                 anyOf:
                 - type: integer

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -1285,13 +1285,13 @@ func (r *ClusterSummaryReconciler) setFailureMessage(clusterSummaryScope *scope.
 
 func (r *ClusterSummaryReconciler) resetFeatureStatus(clusterSummaryScope *scope.ClusterSummaryScope, status configv1beta1.FeatureStatus) {
 	if clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.HelmCharts != nil {
-		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureHelm, status, nil)
+		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureHelm, status, nil, nil)
 	}
 	if clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.PolicyRefs != nil {
-		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureResources, status, nil)
+		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureResources, status, nil, nil)
 	}
 	if clusterSummaryScope.ClusterSummary.Spec.ClusterProfileSpec.KustomizationRefs != nil {
-		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureKustomize, status, nil)
+		clusterSummaryScope.SetFeatureStatus(configv1beta1.FeatureKustomize, status, nil, nil)
 	}
 }
 

--- a/controllers/conflicts.go
+++ b/controllers/conflicts.go
@@ -125,7 +125,7 @@ func requeueClusterSummary(ctx context.Context, featureID configv1beta1.FeatureI
 	// Reset the hash a deployment happens again
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("reset status of ClusterSummary %s/%s",
 		clusterSummary.Namespace, clusterSummary.Name))
-	clusterSummaryScope.SetFeatureStatus(featureID, configv1beta1.FeatureStatusProvisioning, nil)
+	clusterSummaryScope.SetFeatureStatus(featureID, configv1beta1.FeatureStatusProvisioning, nil, nil)
 
 	return c.Status().Update(ctx, clusterSummaryScope.ClusterSummary)
 }

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -2419,6 +2419,13 @@ spec:
                   - namespace
                   type: object
                 type: array
+              maxConsecutiveFailures:
+                description: |-
+                  The maximum number of consecutive deployment failures that Sveltos will permit.
+                  After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                  This setting applies only to feature deployments, not resource removal.
+                  This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                type: integer
               maxUpdate:
                 anyOf:
                 - type: integer
@@ -5269,6 +5276,13 @@ spec:
                       - namespace
                       type: object
                     type: array
+                  maxConsecutiveFailures:
+                    description: |-
+                      The maximum number of consecutive deployment failures that Sveltos will permit.
+                      After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                      This setting applies only to feature deployments, not resource removal.
+                      This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                    type: integer
                   maxUpdate:
                     anyOf:
                     - type: integer
@@ -5672,6 +5686,12 @@ spec:
                     FeatureSummary contains a summary of the state of a workload
                     cluster feature.
                   properties:
+                    consecutiveFailures:
+                      description: |-
+                        The maximum number of consecutive deployment failures that Sveltos will permit.
+                        After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                        This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                      type: integer
                     deployedGroupVersionKind:
                       description: |-
                         DeployedGroupVersionKind contains all GroupVersionKinds deployed in either
@@ -5719,6 +5739,7 @@ spec:
                       - Removed
                       type: string
                   required:
+                  - consecutiveFailures
                   - featureID
                   type: object
                 type: array
@@ -7422,6 +7443,13 @@ spec:
                   - namespace
                   type: object
                 type: array
+              maxConsecutiveFailures:
+                description: |-
+                  The maximum number of consecutive deployment failures that Sveltos will permit.
+                  After this many consecutive failures, the deployment will be considered failed, and Sveltos will stop retrying.
+                  This setting applies only to feature deployments, not resource removal.
+                  This field is optional. If not set, Sveltos default behavior is to keep retrying.
+                type: integer
               maxUpdate:
                 anyOf:
                 - type: integer


### PR DESCRIPTION
The maxConsecutiveFailures option allows control over deployment retry behavior. This optional field defines a threshold for consecutive deployment failures. After the specified number of consecutive failures, Sveltos will stop retrying the deployment.
Retries will only resume if the profile configuration is updated.

If maxConsecutiveFailures is not configured, Sveltos will retry indefinitely

This PR also solves two errors seen few times.
    
The first error as Helm stuck with:  "cannot re-use a name that is still in use"
This condition should never occur.  A previous check ensures that only one
ClusterProfile/Profile can manage a Helm Chart with a given name in a
specific namespace within a managed cluster. So after an install such error
is seen, Sveltos switches to an upgrade.
    
The second error as Helm stck with: "another operation (install/upgrade/rollback) is in progress"
As described above this condition should never happen. Sveltos tries to recover
by doing first an uninstall and then install back. While this is not ideal, there is no
other way to recover from this condition without manual intervention.