### PR TITLE
(feat) CAPI clusters

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -86,6 +86,7 @@ var (
 	profilerAddress         string
 	driftDetectionConfigMap string
 	luaConfigMap            string
+	capiOnboardAnnotation   string
 	disableCaching          bool
 	disableTelemetry        bool
 )
@@ -171,6 +172,7 @@ func main() {
 	controllers.SetManagementClusterAccess(mgr.GetClient(), mgr.GetConfig())
 	controllers.SetDriftdetectionConfigMap(driftDetectionConfigMap)
 	controllers.SetLuaConfigMap(luaConfigMap)
+	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
 
 	logsettings.RegisterForLogSettings(ctx,
 		libsveltosv1beta1.ComponentAddonManager, ctrl.Log.WithName("log-setter"),
@@ -222,7 +224,10 @@ func initFlags(fs *pflag.FlagSet) {
 		"Enable insecure diagnostics serving. For more details see the description of --diagnostics-address.")
 
 	fs.StringVar(&shardKey, "shard-key", "",
-		"If set, only clusters will annotation matching this shard key will be reconciled by this deployment")
+		"If set, only clusters will annotation matching this shard key will be reconciled by this deployment.")
+
+	fs.StringVar(&capiOnboardAnnotation, "capi-onboard-annotation", "",
+		"If provided, Sveltos will only manage CAPI clusters that have this exact annotation.")
 
 	fs.IntVar(&workers, "worker-number", defaultWorkers,
 		"Number of worker. Workers are used to deploy features in CAPI clusters")

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,6 +14,7 @@ spec:
         - "--diagnostics-address=:8443"
         - "--report-mode=0"
         - --shard-key=
+        - --capi-onboard-annotation=
         - "--v=5"
         - "--version=main"
         env:

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -1023,7 +1023,8 @@ func (r *ClusterSummaryReconciler) isReady(ctx context.Context,
 		clusterRef.APIVersion = clusterv1.GroupVersion.String()
 	}
 
-	isClusterReady, err := clusterproxy.IsClusterReadyToBeConfigured(ctx, r.Client, clusterRef, logger)
+	isClusterReady, err := clusterproxy.IsClusterReadyToBeConfigured(ctx, r.Client, clusterRef,
+		logger)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return false, nil

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -147,7 +147,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	// Do this read so library is initialized with CAPI present
-	_, err = clusterproxy.GetListOfClusters(context.TODO(), testEnv.Client, "",
+	_, err = clusterproxy.GetListOfClusters(context.TODO(), testEnv.Client, "", "",
 		textlogger.NewLogger(textlogger.NewConfig()))
 	Expect(err).To(BeNil())
 })

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -30,6 +30,7 @@ var (
 	managementClusterConfig *rest.Config
 	driftdetectionConfigMap string
 	luaConfigMap            string
+	capiOnboardAnnotation   string
 )
 
 func SetManagementClusterAccess(c client.Client, config *rest.Config) {
@@ -43,6 +44,10 @@ func SetDriftdetectionConfigMap(name string) {
 
 func SetLuaConfigMap(name string) {
 	luaConfigMap = name
+}
+
+func SetCAPIOnboardAnnotation(key string) {
+	capiOnboardAnnotation = key
 }
 
 func getManagementClusterConfig() *rest.Config {
@@ -59,6 +64,10 @@ func getDriftDetectionConfigMap() string {
 
 func getLuaConfigMap() string {
 	return luaConfigMap
+}
+
+func getCAPIOnboardAnnotation() string {
+	return capiOnboardAnnotation
 }
 
 func collectDriftDetectionConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {

--- a/controllers/profile_utils.go
+++ b/controllers/profile_utils.go
@@ -51,7 +51,8 @@ func getMatchingClusters(ctx context.Context, c client.Client, namespace string,
 	var matchingCluster []corev1.ObjectReference
 	if clusterSelector != nil {
 		var err error
-		matchingCluster, err = clusterproxy.GetMatchingClusters(ctx, c, clusterSelector, namespace, logger)
+		matchingCluster, err = clusterproxy.GetMatchingClusters(ctx, c, clusterSelector, namespace,
+			getCAPIOnboardAnnotation(), logger)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -46,7 +46,8 @@ func collectAndProcessResourceSummaries(ctx context.Context, c client.Client, sh
 
 	for {
 		logger.V(logs.LogVerbose).Info("collecting ResourceSummaries")
-		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", shardkey, logger)
+		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", getCAPIOnboardAnnotation(),
+			shardkey, logger)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clusters: %v", err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.48.1
+	github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f
 	github.com/prometheus/client_golang v1.21.0
 	github.com/spf13/pflag v1.0.6
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2 h1:aB
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/cli v27.5.1+incompatible h1:JB9cieUT9YNiMITtIsguaN55PLOHhBSz3LKVc6cqWaY=
-github.com/docker/cli v27.5.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v28.0.0+incompatible h1:ido37VmLUqEp+5NFb9icd6BuBB+SNDgCn+5kPCr2buA=
 github.com/docker/cli v28.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
@@ -243,8 +241,6 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
-github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
@@ -331,8 +327,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.48.1 h1:SWtACXeVNehWNxh/jEeFB/Z1QqMd4HeSh5Z60czwJbQ=
-github.com/projectsveltos/libsveltos v0.48.1/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f h1:QyRB2GW8b2D4d9a5fT8spSSW5NzDzOdz/cQsg7toehs=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223075846-d9184ce7344f/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250215155204-2e8364e9ce73 h1:Sgh71mZil6CXZXcRPrzfl7XuetK+CyvruWOajU95qhs=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250215155204-2e8364e9ce73/go.mod h1:AIzg+JWbfrFWazyM5Ka2fX69r9aFr3+o2Mvn9SfKDYU=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20250215155204-2e8364e9ce73 h1:VdjrXW3hU6JPP9kUtUC6K8ulW82uAjPyiMKf4iJGIXg=
@@ -342,8 +338,6 @@ github.com/projectsveltos/lua-utils/glua-strings v0.0.0-20250215155204-2e8364e9c
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
-github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
-github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_golang v1.21.0 h1:DIsaGmiaBkSangBgMtWdNfxbMNdku5IK6iNhrEqWvdA=
 github.com/prometheus/client_golang v1.21.0/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -352,8 +346,6 @@ github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
-github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G1dc=
-github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
 github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -22,6 +22,7 @@ spec:
         - --diagnostics-address=:8443
         - --report-mode=0
         - --agent-in-mgmt-cluster
+        - --capi-onboard-annotation=
         - --v=5
         - --version=main
         command:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -22,6 +22,7 @@ spec:
         - --diagnostics-address=:8443
         - --report-mode=0
         - --shard-key={{.SHARD}}
+        - --capi-onboard-annotation=
         - --v=5
         - --version=main
         command:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8512,6 +8512,7 @@ spec:
         - --diagnostics-address=:8443
         - --report-mode=0
         - --shard-key=
+        - --capi-onboard-annotation=
         - --v=5
         - --version=main
         command:

--- a/test/fv/capi_onboard_annotation_test.go
+++ b/test/fv/capi_onboard_annotation_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/controllers"
+)
+
+// This test runs in Serial because it requires the addon controller to only onboard
+// capi cluster with onboard annotations
+var _ = Describe("Helm", Serial, func() {
+	const (
+		namePrefix        = "onboard-"
+		onboardAnnotation = "onboard-capi"
+
+		addonDeplNamespace = "projectsveltos"
+		addonDeplName      = "addon-controller"
+	)
+
+	BeforeEach(func() {
+		Byf("Set capi-onboard-annotation for addon-controller")
+		updateOnboardAnnotationArg(addonDeplNamespace, addonDeplName, onboardAnnotation)
+	})
+
+	AfterEach(func() {
+		Byf("Reset capi-onboard-annotation for addon-controller")
+		updateOnboardAnnotationArg(addonDeplNamespace, addonDeplName, "")
+	})
+
+	It("Onboards CAPI Cluster with onboard annotation", Label("NEW-FV", "EXTENDED"), func() {
+		Byf("Create a ClusterProfile matching Cluster %s/%s", kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeContinuous
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		currentClusterProfile := &configv1beta1.ClusterProfile{}
+		Byf("Update ClusterProfile %s to deploy helm charts", clusterProfile.Name)
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+			currentClusterProfile.Spec.HelmCharts = []configv1beta1.HelmChart{
+				{
+					RepositoryURL:    "https://prometheus-community.github.io/helm-charts",
+					RepositoryName:   "prometheus-community",
+					ChartName:        "prometheus-community/prometheus",
+					ChartVersion:     "25.24.0",
+					ReleaseName:      "prometheus",
+					ReleaseNamespace: "prometheus",
+					HelmChartAction:  configv1beta1.HelmChartActionInstall,
+				},
+				{
+					RepositoryURL:    "https://grafana.github.io/helm-charts",
+					RepositoryName:   "grafana",
+					ChartName:        "grafana/grafana",
+					ChartVersion:     "8.3.4",
+					ReleaseName:      "grafana",
+					ReleaseNamespace: "grafana",
+					HelmChartAction:  configv1beta1.HelmChartActionInstall,
+				},
+			}
+			return k8sClient.Update(context.TODO(), currentClusterProfile)
+		})
+		Expect(err).To(BeNil())
+
+		// Addon-controller is set to only onboard CAPI cluster with onboard-capi annotation
+		// CAPI cluster does not have onboard annotation
+		Byf("Verifying Cluster %s/%s is NOT a match for ClusterProfile %s",
+			kindWorkloadCluster.Namespace, kindWorkloadCluster.Name, clusterProfile.Name)
+		Consistently(func() bool {
+			currentClusterProfile := &configv1beta1.ClusterProfile{}
+			err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)
+			if err != nil {
+				return false
+			}
+			for i := range currentClusterProfile.Status.MatchingClusterRefs {
+				if currentClusterProfile.Status.MatchingClusterRefs[i].Namespace == kindWorkloadCluster.Namespace &&
+					currentClusterProfile.Status.MatchingClusterRefs[i].Name == kindWorkloadCluster.Name &&
+					currentClusterProfile.Status.MatchingClusterRefs[i].APIVersion == clusterv1.GroupVersion.String() {
+
+					return false
+				}
+			}
+			return true
+		}, time.Minute, pollingInterval).Should(BeTrue())
+
+		Byf("Add onboard annotation on CAPI cluster")
+		currentCluster := &clusterv1.Cluster{}
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: kindWorkloadCluster.Namespace, Name: kindWorkloadCluster.Name},
+			currentCluster)).To(Succeed())
+		annotations := currentCluster.Annotations
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[onboardAnnotation] = randomString()
+		currentCluster.Annotations = annotations
+		Expect(k8sClient.Update(context.TODO(), currentCluster)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		clusterSummary := verifyClusterSummary(controllers.ClusterProfileLabelName,
+			currentClusterProfile.Name, &currentClusterProfile.Spec,
+			kindWorkloadCluster.Namespace, kindWorkloadCluster.Name)
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.Namespace, clusterSummary.Name, configv1beta1.FeatureHelm)
+
+		charts := []configv1beta1.Chart{
+			{ReleaseName: "grafana", ChartVersion: "8.3.4", Namespace: "grafana"},
+			{ReleaseName: "prometheus", ChartVersion: "25.24.0", Namespace: "prometheus"},
+		}
+
+		verifyClusterConfiguration(configv1beta1.ClusterProfileKind, clusterProfile.Name,
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, configv1beta1.FeatureHelm,
+			nil, charts)
+
+		deleteClusterProfile(clusterProfile)
+	})
+})
+
+func updateOnboardAnnotationArg(addonDeplNamespace, addonDeplName, value string) {
+	depl := &appsv1.Deployment{}
+	Expect(k8sClient.Get(context.TODO(),
+		types.NamespacedName{Namespace: addonDeplNamespace, Name: addonDeplName},
+		depl)).To(Succeed())
+
+	for i := range depl.Spec.Template.Spec.Containers {
+		container := depl.Spec.Template.Spec.Containers[i]
+		for j := range container.Args {
+			Byf("MGIANLUC %s", container.Args[j])
+			if container.Args[j] == "--capi-onboard-annotation=" {
+				Byf("MGIANLUC found")
+				container.Args[j] = fmt.Sprintf("--capi-onboard-annotation=%s", value)
+			}
+		}
+	}
+
+	Expect(k8sClient.Update(context.TODO(), depl)).To(Succeed())
+
+	time.Sleep(pollingInterval)
+
+	Eventually(func() bool {
+		err := k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: addonDeplNamespace, Name: addonDeplName},
+			depl)
+		if err != nil {
+			return false
+		}
+		return depl.Status.AvailableReplicas == *depl.Spec.Replicas
+	}, timeout, pollingInterval).Should(BeTrue())
+}


### PR DESCRIPTION
addon-controller can be passed a new arg: `capi-onboard-annotation`. It allows administrators to specify a custom annotation key. When this annotation is set, Sveltos will only manage and apply add-ons and applications to CAPI clusters that have this specific annotation with any value.

CAPI clusters without this annotation will be ignored by the addon-controller.