### PR TITLE
Add registry option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,6 +93,7 @@ var (
 	disableCaching          bool
 	disableTelemetry        bool
 	autoDeployDependencies  bool
+	registry                string
 )
 
 const (
@@ -179,6 +180,7 @@ func main() {
 	controllers.SetDriftdetectionConfigMap(driftDetectionConfigMap)
 	controllers.SetLuaConfigMap(luaConfigMap)
 	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
+	controllers.SetDriftDetectionRegistry(registry)
 	// Start dependency manager
 	dependencymanager.InitializeManagerInstance(ctx, mgr.GetClient(), autoDeployDependencies, ctrl.Log.WithName("dependency_manager"))
 
@@ -257,6 +259,9 @@ func initFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&luaConfigMap, "lua-methods", "",
 		"The name of the ConfigMap in the projectsveltos namespace containing lua utilities to be loaded."+
 			"Changing the content of the ConfigMap does not cause Sveltos to redeploy.")
+
+	fs.StringVar(&registry, "registry", "",
+		"Container registry for drift-detection images. Defaults to docker.io/ if empty.")
 
 	const defautlRestConfigQPS = 20
 	fs.Float32Var(&restConfigQPS, "kube-api-qps", defautlRestConfigQPS,

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -31,6 +31,7 @@ var (
 	driftdetectionConfigMap string
 	luaConfigMap            string
 	capiOnboardAnnotation   string
+	driftDetectionRegistry  string
 )
 
 func SetManagementClusterAccess(c client.Client, config *rest.Config) {
@@ -70,6 +71,10 @@ func getCAPIOnboardAnnotation() string {
 	return capiOnboardAnnotation
 }
 
+func SetDriftDetectionRegistry(reg string) {
+	driftDetectionRegistry = reg
+}
+
 func collectDriftDetectionConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 	c := getManagementClusterClient()
 	configMap := &corev1.ConfigMap{}
@@ -94,4 +99,8 @@ func collectLuaConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 	}
 
 	return configMap, nil
+}
+
+func getDriftDetectionRegistry() string {
+	return driftDetectionRegistry
 }

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -219,7 +219,17 @@ func prepareDriftDetectionManagerYAML(driftDetectionManagerYAML, clusterNamespac
 	driftDetectionManagerYAML =
 		strings.ReplaceAll(driftDetectionManagerYAML, "v=5", "v=0")
 
+	registry := getDriftDetectionRegistry()
+	if registry != "" {
+		driftDetectionManagerYAML = replaceRegistry(driftDetectionManagerYAML, registry)
+	}
+
 	return driftDetectionManagerYAML
+}
+
+func replaceRegistry(agentYAML, registry string) string {
+	oldRegistry := "docker.io"
+	return strings.Replace(agentYAML, oldRegistry, registry, 1)
 }
 
 // deployDriftDetectionManager deploys drift-detection-manager in the managed cluster


### PR DESCRIPTION
If set`, when deploying drift-detection-manager, this will replace docker.io with the value passed. For instance to use mirror.gcr.io

```
- --registry=mirror.gcr.io
```

Part of [102](https://github.com/projectsveltos/helm-charts/issues/102)