### PR TITLE
(bug) Flux Source Artifact changes

### DIFF
--- a/controllers/clustersummary_predicates.go
+++ b/controllers/clustersummary_predicates.go
@@ -275,6 +275,7 @@ func fluxGenericPredicate(obj client.Object, logger logr.Logger) bool {
 }
 
 func hasArtifactChanged(objNew, objOld client.Object) bool {
+	addTypeInformationToObject(getManagementClusterClient().Scheme(), objNew)
 	switch objNew.GetObjectKind().GroupVersionKind().Kind {
 	case sourcev1.GitRepositoryKind:
 		newGitRepo := objNew.(*sourcev1.GitRepository)
@@ -312,5 +313,5 @@ func isArtifactSame(oldArtifact, newArtifact *sourcev1.Artifact) bool {
 	if oldArtifact != nil && newArtifact == nil {
 		return false
 	}
-	return reflect.DeepEqual(oldArtifact, newArtifact)
+	return reflect.DeepEqual(oldArtifact.Digest, newArtifact.Digest)
 }


### PR DESCRIPTION
Before this PR, hasArtifactChanged always returned false even when the Flux source Status.Artifact changed.
Reason was missing type information in the object. This PR fixes that

Fixes #1094 