### PR TITLE
(bug) reset profile Status.DependenciesHash

### DIFF
--- a/controllers/dependencymanager/manager.go
+++ b/controllers/dependencymanager/manager.go
@@ -470,8 +470,8 @@ func (m *instance) updateClusterProfile(ctx context.Context, c client.Client, cl
 		return nil
 	}
 
-	currentClusterProfile.Spec.ClusterRefs = clusterRef
-	return c.Update(ctx, currentClusterProfile)
+	currentClusterProfile.Status.DependenciesHash = calculateHash(clusters.Clusters)
+	return c.Status().Update(ctx, currentClusterProfile)
 }
 
 func (m *instance) updateProfiles(ctx context.Context, c client.Client, logger logr.Logger) {


### PR DESCRIPTION
In Sveltos v0.50.0, when a ClusterProfile utilizes the `dependsOn` field to establish dependencies between profiles, Sveltos incorrectly modifies the `Spec.ClusterRefs` field. This field is intended for user configuration and should not be altered by Sveltos.

**Root Cause:**

When Sveltos determines that a ClusterProfile needs to be deployed to a new cluster due to dependency requirements, it mistakenly updates the `Spec.ClusterRefs` field. This unintended modification leads to  potential conflicts with user-defined configurations.

**Solution:**

Instead of modifying `Spec.ClusterRefs`, Sveltos should reset the `Status.DependenciesHash` field of the ClusterProfile. This action will trigger a new reconciliation loop, ensuring that Sveltos correctly evaluates and deploys the ClusterProfile to the necessary clusters based on its dependencies.

**Detailed Explanation:**

1.  **Dependencies and Deployment:**
    * ClusterProfiles can define dependencies using the `dependsOn` field.
    * Sveltos tracks these dependencies to ensure that prerequisite profiles are deployed before dependent profiles.
    * This dependency tracking should function independently of the `ClusterSelectors` specified in the ClusterProfile.
    * If a ClusterProfile is required on a cluster due to its dependencies, even if its `ClusterSelectors` do not initially match, Sveltos should deploy it.

2.  **The Bug:**
    * In v0.50.0, Sveltos incorrectly modifies `Spec.ClusterRefs` when a dependent ClusterProfile needs to be deployed to a new cluster.
    * `Spec.ClusterRefs` is a user-configurable field that should only be modified by the user.
    * Modifying this field breaks the principle of least surprise and can lead to unexpected behavior.

3.  **The Correct Approach:**
    * When Sveltos detects a dependency that requires deployment to a new cluster, it should reset the `Status.DependenciesHash` field of the ClusterProfile.
    * Resetting `Status.DependenciesHash` forces a reconciliation of the ClusterProfile.
    * During reconciliation, Sveltos will re-evaluate the dependencies and the cluster selection logic.
    * This ensures that the ClusterProfile is deployed to the necessary clusters without modifying the user-defined `Spec.ClusterRefs`.

4.  **Benefits of the Solution:**
    * Preserves the integrity of the user-defined `Spec.ClusterRefs` field.
    * Maintains the expected behavior of ClusterProfile dependencies.
    * Ensures that ClusterProfiles are deployed correctly based on dependencies, regardless of their `ClusterSelectors`.
    * Avoids unintended side effects.
    
Fixes #1100 