### PR TITLE
(bug) fix ServiceMonitor

### DIFF
--- a/manifest/service_monitor.yaml
+++ b/manifest/service_monitor.yaml
@@ -12,8 +12,10 @@ spec:
     port: metrics
     scheme: https
     tlsConfig:
-      caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
       insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - projectsveltos      
   selector:
     matchLabels:
       control-plane: addon-controller


### PR DESCRIPTION
This PR removes

```
caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```

and adds

```
  namespaceSelector:
    matchNames:
    - projectsveltos
```

making addon-controller ServiceMonitor matches sveltoscluster ServiceMonitor