### PR TITLE
Fix for failing to deploy helm chart from plain HTTP registry

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -837,6 +837,8 @@ func createRegistryClientOptions(ctx context.Context, clusterSummary *configv1be
 
 	registryOptions.credentialsPath = credentialsPath
 	registryOptions.caPath = caPath
+	registryOptions.plainHTTP = getPlainHTTP(currentChart)
+	registryOptions.skipTLSVerify = getInsecureSkipTLSVerify(currentChart)
 
 	if currentChart.RegistryCredentialsConfig.CredentialsSecretRef != nil {
 		credentialSecretNamespace := libsveltostemplate.GetReferenceResourceNamespace(clusterSummary.Spec.ClusterNamespace,
@@ -861,9 +863,6 @@ func createRegistryClientOptions(ctx context.Context, clusterSummary *configv1be
 		registryOptions.username = username
 		registryOptions.password = password
 		registryOptions.hostname = hostname
-
-		registryOptions.plainHTTP = getPlainHTTP(currentChart)
-		registryOptions.skipTLSVerify = getInsecureSkipTLSVerify(currentChart)
 	}
 
 	return registryOptions, nil


### PR DESCRIPTION
# Description
This PR fixes https://github.com/projectsveltos/addon-controller/issues/1116.

# Verification

- I built a new addon-controller image including changes in this PR:
```sh
➜  ~ kubectl -n projectsveltos get deployments.apps addon-controller -o yaml | grep image:
        image: msr.ci.mirantis.com/projectsveltos/addon-controller:6e25e99
```
- I have the following plain-http helm repository:
```sh
➜  ~ kubectl -n kcm-system get helmrepository kcm-templates -o yaml
apiVersion: source.toolkit.fluxcd.io/v1
kind: HelmRepository
metadata:
  creationTimestamp: "2025-03-26T13:21:32Z"
  generation: 1
  labels:
    k0rdent.mirantis.com/managed: "true"
  name: kcm-templates
  namespace: kcm-system
  resourceVersion: "1282"
  uid: 11a062ee-f5a5-4f8c-bea5-94f71116a24b
spec:
  insecure: true
  interval: 10m0s
  provider: generic
  type: oci
  url: oci://kcm-local-registry:5000/charts
status: {}
```
- I create the following `ClusterSummary` object which deploys the `myapp` helm chart successfully onto the target cluster from this helm repository:
```sh
➜  ~ kubectl -n kcm-system get clustersummary p--wali-dev-1-capi-wali-dev-1 -o yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterSummary
metadata:
  creationTimestamp: "2025-03-26T13:35:53Z"
  finalizers:
  - clustersummaryfinalizer.projectsveltos.io
  generation: 1
  labels:
    k0rdent.mirantis.com/managed: "true"
    projectsveltos.io/cluster-name: wali-dev-1
    projectsveltos.io/cluster-type: Capi
    projectsveltos.io/profile-name: wali-dev-1
  name: p--wali-dev-1-capi-wali-dev-1
  namespace: kcm-system
  ownerReferences:
  - apiVersion: config.projectsveltos.io/v1beta1
    kind: Profile
    name: wali-dev-1
    uid: ee6216d9-e885-4131-9521-24252b932839
  resourceVersion: "11997"
  uid: 7a8b2d1f-414c-4ce6-9805-97c62d7b4842
spec:
  clusterName: wali-dev-1
  clusterNamespace: kcm-system
  clusterProfileSpec:
    clusterSelector:
      matchLabels:
        helm.toolkit.fluxcd.io/name: wali-dev-1
        helm.toolkit.fluxcd.io/namespace: kcm-system
    continueOnConflict: true
    continueOnError: false
    helmCharts:
    - chartName: myapp
      chartVersion: 0.1.0
      helmChartAction: Install
      registryCredentialsConfig:
        plainHTTP: true
      releaseName: myapp
      releaseNamespace: myapp
      repositoryName: myapp
      repositoryURL: oci://kcm-local-registry:5000/charts
    policyRefs:
    - deploymentType: Remote
      kind: ConfigMap
      name: aws-cluster-identity-resource-template
      namespace: kcm-system
    reloader: false
    stopMatchingBehavior: WithdrawPolicies
    syncMode: Continuous
    templateResourceRefs:
    - identifier: InfrastructureProviderIdentity
      resource:
        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
        kind: AWSClusterStaticIdentity
        name: aws-cluster-identity
        namespace: kcm-system
    - identifier: InfrastructureProviderIdentitySecret
      resource:
        apiVersion: v1
        kind: Secret
        name: aws-cluster-identity-secret
        namespace: kcm-system
    tier: 2147483547
  clusterType: Capi
status:
  dependencies: no dependencies
  featureSummaries:
  - featureID: Resources
    hash: ag6WKW67BZKqB3DKjA2SEQ+bdJdoBIzG/IbUypdlwjQ=
    lastAppliedTime: "2025-03-26T13:35:56Z"
    status: Provisioned
  - featureID: Helm
    hash: PVRIyq5LbbkQiwBWoqKOoUvZbVtTvTfXTAjQ5haqlcM=
    lastAppliedTime: "2025-03-26T13:35:57Z"
    status: Provisioned
  helmReleaseSummaries:
  - releaseName: myapp
    releaseNamespace: myapp
    status: Managing
    valuesHash: Eq4yyx7ALQHto1gbEnwf7jsNxTVy7WuvI5choD2C4SY=
```
