### PR TITLE
(feat) drift-detection in management cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,7 @@ deploy-projectsveltos: $(KUSTOMIZE)
 
 	@echo 'Install libsveltos CRDs'
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_debuggingconfigurations.lib.projectsveltos.io.yaml
+	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_resourcesummaries.lib.projectsveltos.io.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sveltosclusters.lib.projectsveltos.io.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_clustersets.lib.projectsveltos.io.yaml
 	$(KUBECTL) apply -f https://raw.githubusercontent.com/projectsveltos/libsveltos/$(TAG)/manifests/apiextensions.k8s.io_v1_customresourcedefinition_sets.lib.projectsveltos.io.yaml

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,6 +181,8 @@ func main() {
 	controllers.SetLuaConfigMap(luaConfigMap)
 	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
 	controllers.SetDriftDetectionRegistry(registry)
+	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
+
 	// Start dependency manager
 	dependencymanager.InitializeManagerInstance(ctx, mgr.GetClient(), autoDeployDependencies, ctrl.Log.WithName("dependency_manager"))
 
@@ -495,7 +497,6 @@ func getClusterSummaryReconciler(ctx context.Context, mgr manager.Manager) *cont
 		ShardKey:             shardKey,
 		Version:              version,
 		ReportMode:           reportMode,
-		AgentInMgmtCluster:   agentInMgmtCluster,
 		Deployer:             d,
 		ClusterMap:           make(map[corev1.ObjectReference]*libsveltosset.Set),
 		ReferenceMap:         make(map[corev1.ObjectReference]*libsveltosset.Set),

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -145,6 +145,7 @@ rules:
   - lib.projectsveltos.io
   resources:
   - clustersets
+  - resourcesummaries
   - sets
   verbs:
   - create
@@ -180,6 +181,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - resourcesummaries/status
+  verbs:
+  - get
+  - list
+  - update
 - apiGroups:
   - source.toolkit.fluxcd.io
   resources:

--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -164,7 +164,7 @@ func (r *ClusterSummaryReconciler) proceedDeployingFeature(ctx context.Context, 
 	// Getting here means either feature failed to be deployed or configuration has changed.
 	// Feature must be (re)deployed.
 	options := deployer.Options{HandlerOptions: map[string]string{}}
-	if r.AgentInMgmtCluster {
+	if getAgentInMgmtCluster() {
 		options.HandlerOptions[driftDetectionInMgtmCluster] = "management"
 	}
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -153,6 +153,7 @@ var (
 var (
 	DeployDebuggingConfigurationCRD                  = deployDebuggingConfigurationCRD
 	DeployResourceSummaryCRD                         = deployResourceSummaryCRD
+	DeployDriftDetectionManagerInCluster             = deployDriftDetectionManagerInCluster
 	DeployResourceSummaryInCluster                   = deployResourceSummaryInCluster
 	DeployResourceSummaryInstance                    = deployResourceSummaryInstance
 	UpdateDeployedGroupVersionKind                   = updateDeployedGroupVersionKind
@@ -162,8 +163,8 @@ var (
 	GetDriftDetectionNamespaceInMgmtCluster          = getDriftDetectionNamespaceInMgmtCluster
 	TransformDriftExclusionsToPatches                = transformDriftExclusionsToPatches
 
-	GetResourceSummaryNamespace = getResourceSummaryNamespace
-	GetResourceSummaryName      = getResourceSummaryName
+	GetResourceSummaryNamespaceInManagedCluster = getResourceSummaryNamespaceInManagedCluster
+	GetResourceSummaryNameInManagedCluster      = getResourceSummaryNameInManagedCluster
 )
 
 var (

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -1977,6 +1977,12 @@ func getClusterProfileSpecHash(ctx context.Context, clusterSummary *configv1beta
 	// or viceversa) reconcile.
 	config += fmt.Sprintf("%v", clusterProfileSpec.SyncMode)
 
+	// When using ContinuousWithDriftDetection in agentless mode, ResourceSummary instances are now managed in the management cluster.
+	// This addition ensures the ClusterSummary is redeployed due to the change in deployment location.
+	if clusterProfileSpec.SyncMode == configv1beta1.SyncModeContinuousWithDriftDetection && getAgentInMgmtCluster() {
+		config += ("agentless")
+	}
+
 	// If Reloader changes, Reloader needs to be deployed or undeployed
 	// So consider it in the hash
 	config += fmt.Sprintf("%v", clusterProfileSpec.Reloader)

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -32,6 +32,7 @@ var (
 	luaConfigMap            string
 	capiOnboardAnnotation   string
 	driftDetectionRegistry  string
+	agentInMgmtCluster      bool
 )
 
 func SetManagementClusterAccess(c client.Client, config *rest.Config) {
@@ -49,6 +50,14 @@ func SetLuaConfigMap(name string) {
 
 func SetCAPIOnboardAnnotation(key string) {
 	capiOnboardAnnotation = key
+}
+
+func SetDriftDetectionRegistry(reg string) {
+	driftDetectionRegistry = reg
+}
+
+func SetAgentInMgmtCluster(isInMgmtCluster bool) {
+	agentInMgmtCluster = isInMgmtCluster
 }
 
 func getManagementClusterConfig() *rest.Config {
@@ -71,8 +80,12 @@ func getCAPIOnboardAnnotation() string {
 	return capiOnboardAnnotation
 }
 
-func SetDriftDetectionRegistry(reg string) {
-	driftDetectionRegistry = reg
+func getDriftDetectionRegistry() string {
+	return driftDetectionRegistry
+}
+
+func getAgentInMgmtCluster() bool {
+	return agentInMgmtCluster
 }
 
 func collectDriftDetectionConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
@@ -99,8 +112,4 @@ func collectLuaConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 	}
 
 	return configMap, nil
-}
-
-func getDriftDetectionRegistry() string {
-	return driftDetectionRegistry
 }

--- a/controllers/resourcesummary_collection_test.go
+++ b/controllers/resourcesummary_collection_test.go
@@ -122,7 +122,7 @@ var _ = Describe("ResourceSummary Collection", func() {
 		// CollectResourceSummariesFromCluster will:
 		// - reset ClusterSummary.Status.FeatureSummaries hash for helm (indicating new reconciliation is needed)
 		// - reset ResourceSummary.Status
-		Expect(controllers.CollectResourceSummariesFromCluster(context.TODO(), testEnv.Client, getClusterRef(cluster),
+		Expect(controllers.CollectResourceSummariesFromCluster(context.TODO(), testEnv.Client, false, getClusterRef(cluster),
 			version, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
 
 		// Eventual loop so testEnv Cache is synced

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.23.3
 	github.com/onsi/gomega v1.36.3
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.51.1
+	github.com/projectsveltos/libsveltos v0.51.2-0.20250329132248-33ded0c31199
 	github.com/prometheus/client_golang v1.21.1
 	github.com/spf13/pflag v1.0.6
 	github.com/yuin/gopher-lua v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v0.51.1 h1:pLU2ud5ZQPInxCKJcOb63rcbaemZfRCLsV5ryu4xsmM=
-github.com/projectsveltos/libsveltos v0.51.1/go.mod h1:z1glMCADHOojPDIfHqSThp5X44XNMfEAf9LnnJgOe7M=
+github.com/projectsveltos/libsveltos v0.51.2-0.20250329132248-33ded0c31199 h1:J2rzms00CTztdI7pSOrYIHayUmQMi9d73kRmEfE0tR4=
+github.com/projectsveltos/libsveltos v0.51.2-0.20250329132248-33ded0c31199/go.mod h1:4oVljwYBrrtSUXo33zbRMiqhTswqOO8THt9mcpIMyos=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250301182851-e4fbb9fd7ff7 h1:KdDtBEJPgavOHlut1gq2i6bFm5dgoNHNsOUC8oe2hK4=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250301182851-e4fbb9fd7ff7/go.mod h1:AIzg+JWbfrFWazyM5Ka2fX69r9aFr3+o2Mvn9SfKDYU=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20250301182851-e4fbb9fd7ff7 h1:kZzOx+XTEfCRjxw1yACuGhFSyS7ybP/NNJFAZYNARCk=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -4968,6 +4968,7 @@ rules:
   - lib.projectsveltos.io
   resources:
   - clustersets
+  - resourcesummaries
   - sets
   verbs:
   - create
@@ -5003,6 +5004,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - lib.projectsveltos.io
+  resources:
+  - resourcesummaries/status
+  verbs:
+  - get
+  - list
+  - update
 - apiGroups:
   - source.toolkit.fluxcd.io
   resources:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -47,7 +47,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:8f9e2d913dff4a38b85a5ca51157a004f3f67731be33a9fe05e695924c3e2cab
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:598b207231940899bc10ea4bf808522dbdf2af6ecea8be170b7c786e219328aa
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -29,7 +29,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:8f9e2d913dff4a38b85a5ca51157a004f3f67731be33a9fe05e695924c3e2cab
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:598b207231940899bc10ea4bf808522dbdf2af6ecea8be170b7c786e219328aa
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -141,7 +141,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:8f9e2d913dff4a38b85a5ca51157a004f3f67731be33a9fe05e695924c3e2cab
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:598b207231940899bc10ea4bf808522dbdf2af6ecea8be170b7c786e219328aa
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -123,7 +123,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:8f9e2d913dff4a38b85a5ca51157a004f3f67731be33a9fe05e695924c3e2cab
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:598b207231940899bc10ea4bf808522dbdf2af6ecea8be170b7c786e219328aa
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
By deploying drift detection within the management cluster,
ResourceSummary instances are also deployed there, effectively
preventing accidental deletion of Sveltos resources in managed
clusters and avoiding potential disruptions.

Fixes #1119 