### PR TITLE
(bug) ResourceSummary collection

### DIFF
--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -393,14 +393,14 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummaryScope *sc
 		} else {
 			var source client.Object
 			source, err = getSource(ctx, c, reference.Namespace, reference.Name, reference.Kind)
-			if err == nil && source == nil {
+			if err == nil && source != nil {
 				s := source.(sourcev1.Source)
 				if s.GetArtifact() != nil {
 					config += s.GetArtifact().Revision
 				}
-			}
-			if source.GetAnnotations() != nil {
-				config += getDataSectionHash(source.GetAnnotations())
+				if source.GetAnnotations() != nil {
+					config += getDataSectionHash(source.GetAnnotations())
+				}
 			}
 		}
 		if err != nil {


### PR DESCRIPTION
When agents are deployed in managed cluster, collecting ResourceSummary from the management cluster always caused an error to be logged (configMap projectsveltos/drift-detection-version missing).

That is because ResourceSummary CRD is present in the management cluster irrespective of whether there is a profile in drift detection mode is matching the management cluster.

To fix this, irrespective of the mode, always collect clusters with drift detection deployed and only collect resourceSummary instances from those clusters.

This PR also fixes a crash when Sveltos is referencing a Flux Source and the Flux source is deleted.

Fixes #1158 
Fixes #1159 