### PR TITLE
(bug) change profile while a ClusterSummary is being deleted

### DIFF
--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -570,3 +570,11 @@ func resourceToDeployedResource(resource *libsveltosv1beta1.Resource,
 		LastAppliedTime: resource.LastAppliedTime,
 	}
 }
+
+type ClusterSummaryDeletedError struct {
+	Message string
+}
+
+func (r *ClusterSummaryDeletedError) Error() string {
+	return r.Message
+}


### PR DESCRIPTION
If the profile's clusterSelector is changed and then immediately reverted, any ClusterSummary instances still undergoing deletion during the reversion will not be recreated, leading to a missing ClusterSummary.

This PR fixes that.