### PR TITLE
(bug) Fix an issue detecting clusters with dritf detection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -123,7 +123,6 @@ func main() {
 	pflag.Parse()
 
 	reportMode = controllers.ReportMode(tmpReportMode)
-
 	disableFor := []client.Object{}
 	byObject := map[client.Object]cache.ByObject{}
 	if disableCaching {

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -434,7 +434,6 @@ func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctr
 
 	// At this point we don't know yet whether CAPI is present in the cluster.
 	// Later on, in main, we detect that and if CAPI is present WatchForCAPI will be invoked.
-
 	if r.ReportMode == CollectFromManagementCluster {
 		go collectAndProcessResourceSummaries(ctx, mgr.GetClient(), r.ShardKey, r.Version, mgr.GetLogger())
 	}

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -97,11 +97,11 @@ func deployDriftDetectionManagerInCluster(ctx context.Context, c client.Client,
 	if startInMgmtCluster {
 		restConfig := getManagementClusterConfig()
 		return deployDriftDetectionManagerInManagementCluster(ctx, restConfig, clusterNamespace,
-			clusterName, "do-not-send-reports", clusterType, patches, logger)
+			clusterName, "do-not-send-updates", clusterType, patches, logger)
 	}
 
 	return deployDriftDetectionManagerInManagedCluster(ctx, clusterNamespace,
-		clusterName, "do-not-send-reports", clusterType, patches, logger)
+		clusterName, "do-not-send-updates", clusterType, patches, logger)
 }
 
 func deployResourceSummaryInCluster(ctx context.Context, c client.Client,

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -47,7 +47,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:4d516e5bde2982489541282f90224339c75bd173a2463dd97d36039edb10445a
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:e91de004f751c5943500c821c3e9b5a76c7c873d9daf24b06b83a9d510ee1b7f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -29,7 +29,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:4d516e5bde2982489541282f90224339c75bd173a2463dd97d36039edb10445a
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:e91de004f751c5943500c821c3e9b5a76c7c873d9daf24b06b83a9d510ee1b7f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -141,7 +141,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:4d516e5bde2982489541282f90224339c75bd173a2463dd97d36039edb10445a
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:e91de004f751c5943500c821c3e9b5a76c7c873d9daf24b06b83a9d510ee1b7f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -123,7 +123,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:4d516e5bde2982489541282f90224339c75bd173a2463dd97d36039edb10445a
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:e91de004f751c5943500c821c3e9b5a76c7c873d9daf24b06b83a9d510ee1b7f
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Collect ClusterProfile/Profiles with SyncMode set to ContinuousWithDriftDetection. Then collect ResourceSummaries from all matching clusters.

Previous check was incorrect and caused no ResourceSummary to be collected when agents where deployed in the managed clusters

This PR also updates drift-detection image

Fixes #1172 