### PR TITLE
(bug) fix core

### DIFF
--- a/controllers/clustersummary_watchers.go
+++ b/controllers/clustersummary_watchers.go
@@ -417,6 +417,8 @@ func (m *manager) react(obj client.Object, logger logr.Logger) {
 		Name:       obj.GetName(),
 	}
 
+	logger = logger.WithValues("resource", fmt.Sprintf("%s/%s", ref.Namespace, ref.Name))
+
 	// finds all ClusterSummary objects that want to be informed about updates to this specific resource.
 	// It takes into account registrations made through KustomizationRefs
 	if v, ok := m.mgmtResourcesWatchedKustomizeRef[ref]; ok {

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -543,8 +543,10 @@ func deployUnstructured(ctx context.Context, deployingToMgmtCluster bool, destCo
 			policy.GetKind(), policy.GetNamespace(), policy.GetName(), deployingToMgmtCluster))
 
 		updatedPolicy, err := updateResource(ctx, dr, clusterSummary, policy, subresources, logger)
-		resource.LastAppliedTime = &metav1.Time{Time: time.Now()}
-		reports = append(reports, *generateResourceReport(policyHash, resourceInfo, updatedPolicy, resource))
+		if updatedPolicy != nil {
+			resource.LastAppliedTime = &metav1.Time{Time: time.Now()}
+			reports = append(reports, *generateResourceReport(policyHash, resourceInfo, updatedPolicy, resource))
+		}
 		if err != nil {
 			if clusterSummary.Spec.ClusterProfileSpec.ContinueOnError {
 				errorMsg += fmt.Sprintf("%v", err)


### PR DESCRIPTION
This PR fixes a core when updateResource fails. In this case, the updateResource is nil (which was leading to core)

Fixes #1168 