### PR TITLE
(Bug Fix) Conflict Handover

### DIFF
--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -47,7 +47,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:17c2c10741ecf13fa7dceb495edb62dc905b8f9f76a645c6bacea087137f5fa3
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:34aebc52b3aeb98d31a14393ca11ae07eee0b2836e15d53c4a559186ee45957f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -29,7 +29,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:17c2c10741ecf13fa7dceb495edb62dc905b8f9f76a645c6bacea087137f5fa3
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:34aebc52b3aeb98d31a14393ca11ae07eee0b2836e15d53c4a559186ee45957f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -141,7 +141,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:17c2c10741ecf13fa7dceb495edb62dc905b8f9f76a645c6bacea087137f5fa3
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:34aebc52b3aeb98d31a14393ca11ae07eee0b2836e15d53c4a559186ee45957f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -123,7 +123,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:17c2c10741ecf13fa7dceb495edb62dc905b8f9f76a645c6bacea087137f5fa3
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:34aebc52b3aeb98d31a14393ca11ae07eee0b2836e15d53c4a559186ee45957f
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
When Profile A manages a set of Helm charts and Profile B attempts to deploy one of the same charts, Sveltos correctly identifies and reports a conflict.

However, if the chart is later removed from Profile A, Profile B should be able to take over its management. A bug was preventing this handover from occurring. This PR resolves that issue.

Fixes #1208 