### PR TITLE
(bug) Ignore ErrReleaseNotFound

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -1066,7 +1066,10 @@ func handleInstall(ctx context.Context, clusterSummary *configv1beta1.ClusterSum
 			if fs.ConsecutiveFailures%maxHistory == 0 && fs.FailureMessage != nil {
 				err := doUninstallRelease(ctx, clusterSummary, currentChart, kubeconfig, registryOptions, logger)
 				if err != nil {
-					return nil, nil, err
+					// Ignore release not found error
+					if !(errors.Is(err, driver.ErrReleaseNotFound) || strings.Contains(err.Error(), "release: not found")) {
+						return nil, nil, err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When Sveltos is installing a release, if an error happens before retrying again, Sveltos might try to do an uninstall in order to remove any stale helm Secret. This behavior was introduced because while fixing this [bug](https://github.com/projectsveltos/addon-controller/issues/1204)

If uninstall fails with "release not found" ignore the error and proceed with install.

Root caused in #1264 1264