### PR TITLE
(bug) dependencies fix incorrect undeploy after restart

### DIFF
--- a/controllers/clusterprofile_controller.go
+++ b/controllers/clusterprofile_controller.go
@@ -160,6 +160,12 @@ func (r *ClusterProfileReconciler) reconcileNormal(
 		}
 	}
 
+	// Get all clusters where deployment is required based on dependent ClusterProfile instances
+	depManager, err := dependencymanager.GetManagerInstance()
+	if err != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
+	}
+
 	// Get all clusters matching clusterSelector and ClusterRefs
 	matchingCluster, err := getMatchingClusters(ctx, r.Client, "", profileScope.GetSelector(),
 		profileScope.GetSpec().ClusterRefs, logger)
@@ -174,11 +180,6 @@ func (r *ClusterProfileReconciler) reconcileNormal(
 	}
 	matchingCluster = append(matchingCluster, clusterSetClusters...)
 
-	// Get all clusters where deployment is required based on dependent ClusterProfile instances
-	depManager, err := dependencymanager.GetManagerInstance()
-	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
-	}
 	profileRef := getKeyFromObject(r.Scheme, profileScope.Profile)
 	depClusters := depManager.GetClusterDeployments(profileRef)
 	matchingCluster = append(matchingCluster, depClusters...)

--- a/controllers/profile_controller.go
+++ b/controllers/profile_controller.go
@@ -191,6 +191,11 @@ func (r *ProfileReconciler) reconcileNormal(
 		}
 	}
 
+	depManager, err := dependencymanager.GetManagerInstance()
+	if err != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
+	}
+
 	// Limit the search of matching cluster to the Profile namespace
 	matchingCluster, err := getMatchingClusters(ctx, r.Client, profileScope.Profile.GetNamespace(),
 		profileScope.GetSelector(), profileScope.GetSpec().ClusterRefs, logger)
@@ -206,10 +211,6 @@ func (r *ProfileReconciler) reconcileNormal(
 	matchingCluster = append(matchingCluster, clusterSetClusters...)
 
 	// Get all clusters where deployment is required based on dependent ClusterProfile instances
-	depManager, err := dependencymanager.GetManagerInstance()
-	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
-	}
 	profileRef := getKeyFromObject(r.Scheme, profileScope.Profile)
 	depClusters := depManager.GetClusterDeployments(profileRef)
 	matchingCluster = append(matchingCluster, depClusters...)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/TwiN/go-color v1.4.1
 	github.com/dariubs/percent v1.0.0
-	github.com/docker/cli v28.3.0+incompatible
+	github.com/docker/cli v28.3.1+incompatible
 	github.com/fluxcd/pkg/http/fetch v0.16.0
 	github.com/fluxcd/pkg/tar v0.12.0
 	github.com/fluxcd/source-controller/api v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v28.3.0+incompatible h1:s+ttruVLhB5ayeuf2BciwDVxYdKi+RoUlxmwNHV3Vfo=
 github.com/docker/cli v28.3.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v28.3.1+incompatible h1:ZUdwOLDEBoE3TE5rdC9IXGY5HPHksJK3M+hJEWhh2mc=
+github.com/docker/cli v28.3.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
 github.com/docker/docker-credential-helpers v0.8.2/go.mod h1:P3ci7E3lwkZg6XiHdRKft1KckHiO9a2rNtyFbZ/ry9M=
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ+oDZB4KHQFypsfjYlq/C4rfL7D3g8=

--- a/test/fv/helm_test.go
+++ b/test/fv/helm_test.go
@@ -286,6 +286,9 @@ var _ = Describe("Helm", func() {
 				nil, charts)
 		}
 
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name, libsveltosv1beta1.FeatureHelm)
+
 		deleteClusterProfile(clusterProfile)
 
 		Byf("Verifying kyverno deployment is removed from workload cluster")


### PR DESCRIPTION
On addon-controller restarts some profiles deployed due to dependencies were getting removed. For instance, posting this:

```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: deploy-kyverno
spec:
  syncMode: Continuous
  helmCharts:
  - repositoryURL:    https://kyverno.github.io/kyverno/
    repositoryName:   kyverno
    chartName:        kyverno/kyverno
    chartVersion:     3.4.2
    releaseName:      kyverno-latest
    releaseNamespace: kyverno
    helmChartAction:  Install
    values: |
      admissionController:
        replicas: 3
      backgroundController:
        replicas: 3
      cleanupController:
        replicas: 3
      reportsController:
        replicas: 3
---
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterProfile
metadata:
  name: deploy-kyverno-resources
spec:
  dependsOn:
  - deploy-kyverno
  clusterSelector:
    matchLabels:
      env: fv
  policyRefs:
  - name: disallow-latest-tag # contains Kyverno ClusterPolicy
    namespace: default
    kind: ConfigMap
---
apiVersion: v1
kind: ConfigMap
metadata:
  name: disallow-latest-tag
  namespace: default
data:
  kyverno.yaml: |
    apiVersion: kyverno.io/v1
    kind: ClusterPolicy
    metadata:
      name: disallow-latest-tag
      annotations:
        policies.kyverno.io/title: Disallow Latest Tag
        policies.kyverno.io/category: Best Practices
        policies.kyverno.io/severity: medium
        policies.kyverno.io/subject: Pod
        policies.kyverno.io/description: >-
          The ':latest' tag is mutable and can lead to unexpected errors if the
          image changes. A best practice is to use an immutable tag that maps to
          a specific version of an application Pod. This policy validates that the image
          specifies a tag and that it is not called `latest`.
    spec:
      validationFailureAction: audit
      background: true
      rules:
      - name: require-image-tag
        match:
          resources:
            kinds:
            - Pod
        validate:
          message: "An image tag is required."
          pattern:
            spec:
              containers:
              - image: "*:*"
      - name: validate-image-tag
        match:
          resources:
            kinds:
            - Pod
        validate:
          message: "Using a mutable image tag e.g. 'latest' is not allowed."
          pattern:
            spec:
              containers:
              - image: "!*:latest"
```

The ClusterProfile __deploy-kyverno__ was getting deployed on every cluster with label env: fv because of the dependency defined in the CLusterProfile __deploy-kyverno-resources__.

A bug though was causing __deploy-kyverno__ to get undeployed if the addon-controller pod were to restart.

This PR fixes that.