### PR TITLE
(bug) Deployed GVK

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -4042,6 +4042,15 @@ func prepareChartForAgent(ctx context.Context, clusterSummary *configv1beta1.Clu
 		}
 	}
 
+	// Update Deployed GVK. In case ClusterSummary is deleted while applier is still deploying this content,
+	// we know what needs to be deleted
+	currentReports := prepareReports(resources)
+	_, err = updateDeployedGroupVersionKind(ctx, clusterSummary, libsveltosv1beta1.FeatureHelm,
+		nil, currentReports, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	logger.V(logs.LogDebug).Info(fmt.Sprintf("found %d resources", len(resources)))
 
 	err = stageHelmResourcesForDeployment(ctx, clusterSummary, currentChart, resources, action, rInfo, logger)


### PR DESCRIPTION
In pull mode, store deployed GVK when preparing the configuration for sveltos-applier. Do not wait for Sveltos-applier to deploy it.

If a ClusterSummary is deleted while Sveltos-applier is still processing a previous update, some resources might remain stale otherwise.