### PR TITLE
(bug) Missing TemplateResourceRefs

### DIFF
--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -97,7 +97,9 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 	// Get hash of current configuration (at this very precise moment)
 	currentHash, err := f.currentHash(ctx, r.Client, clusterSummary, logger)
 	if err != nil {
-		return err
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 	storedHash := r.getHash(clusterSummaryScope, f.id)
 

--- a/controllers/clustersummary_watchers.go
+++ b/controllers/clustersummary_watchers.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
@@ -462,7 +463,8 @@ func (m *manager) notifyConsumer(consumer *corev1.ObjectReference) {
 			currentRequestor.Namespace, currentRequestor.Name))
 		// reset hash
 		for i := range currentRequestor.Status.FeatureSummaries {
-			currentRequestor.Status.FeatureSummaries[i].Hash = nil
+			const length = 20
+			currentRequestor.Status.FeatureSummaries[i].Hash = []byte(util.RandomString(length))
 		}
 		return m.Status().Update(context.TODO(), currentRequestor)
 	})

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -611,7 +611,9 @@ func uninstallHelmCharts(ctx context.Context, c client.Client, clusterSummary *c
 
 	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
 	if err != nil {
-		return nil, err
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
 	}
 
 	releaseReports := make([]configv1beta1.ReleaseReport, 0)

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -720,6 +720,10 @@ func deployReferencedObjects(ctx context.Context, c client.Client, remoteConfig 
 	var mgmtResources map[string]*unstructured.Unstructured
 	mgmtResources, err = collectTemplateResourceRefs(ctx, clusterSummary)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(logs.LogInfo).Info(err.Error())
+			return nil, nil, &configv1beta1.NonRetriableError{Message: err.Error()}
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
When a resource referenced in TemplateResourceRefs was missing, Sveltos detected it but reported no issue and kept retrying deploying the ClusterSummary instance at regular interval.

This PR fixes that. Sveltos now reports the error in the ClusterSummary Status and stops retrying. It retries only if the missing resource is created or the corresponding profile is modified

Fixes #1298 