### PR TITLE
(bug) always instantiate helm release namespace/name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OS ?= $(shell uname -s)
 OS := $(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.0-beta.0
+TAG ?= v1.0.0
 
 .PHONY: all
 all: build

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.0.0-beta.0"
+        - "--version=v1.0.0"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/addon-controller:v1.0.0-beta.0
+      - image: docker.io/projectsveltos/addon-controller:v1.0.0
         name: controller

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -437,7 +437,7 @@ func (r *ClusterSummaryReconciler) proceedDeployingClusterSummary(ctx context.Co
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
-		For(&configv1beta1.ClusterSummary{}, builder.WithPredicates(ClusterSummaryPredicate{})).
+		For(&configv1beta1.ClusterSummary{}, builder.WithPredicates(ClusterSummaryPredicate{Logger: r.Logger.WithName("clusterSummaryPredicate")})).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.ConcurrentReconciles,
 		}).
@@ -755,7 +755,7 @@ func (r *ClusterSummaryReconciler) updateMaps(ctx context.Context, clusterSummar
 	logger.V(logs.LogDebug).Info("update policy map")
 	currentReferences, err := r.getCurrentReferences(ctx, clusterSummaryScope)
 	if err != nil {
-		logger.V(logs.LogInfo).Info("failed to get current references: %v", err)
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get current references: %v", err))
 		return err
 	}
 

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -312,6 +312,29 @@ var _ = Describe("HandlersHelm", func() {
 		clusterSummary.Spec.ClusterProfileSpec = configv1beta1.Spec{
 			HelmCharts: []configv1beta1.HelmChart{*contourChart},
 		}
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: cluster.Namespace,
+			},
+		}
+
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		Expect(testEnv.Create(context.TODO(), clusterSummary)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, clusterSummary)).To(Succeed())
+
 		// List a helm chart non referenced anymore as managed
 		clusterSummary.Status = configv1beta1.ClusterSummaryStatus{
 			HelmReleaseSummaries: []configv1beta1.HelmChartSummary{
@@ -324,29 +347,46 @@ var _ = Describe("HandlersHelm", func() {
 			},
 		}
 
-		initObjects := []client.Object{
-			clusterSummary,
-		}
+		Expect(testEnv.Status().Update(context.TODO(), clusterSummary)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, clusterSummary)).To(Succeed())
 
-		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
+		Eventually(func() bool {
+			currentlClusterSummary := &configv1beta1.ClusterSummary{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Name: clusterSummary.Name, Namespace: clusterSummary.Namespace},
+				currentlClusterSummary)
+			if err != nil {
+				return false
+			}
+			return len(currentlClusterSummary.Spec.ClusterProfileSpec.HelmCharts) == 1 &&
+				len(currentlClusterSummary.Status.HelmReleaseSummaries) == 2
+		}, timeout, pollingInterval).Should(BeTrue())
 
-		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), c)
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
 		Expect(err).To(BeNil())
 
 		manager.RegisterClusterSummaryForCharts(clusterSummary)
 
-		clusterSummary, err = controllers.UpdateStatusForNonReferencedHelmReleases(context.TODO(), c, clusterSummary)
+		clusterSummary, err = controllers.UpdateStatusForNonReferencedHelmReleases(context.TODO(), testEnv.Client,
+			clusterSummary, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).To(BeNil())
 
-		currentClusterSummary := &configv1beta1.ClusterSummary{}
-		Expect(c.Get(context.TODO(),
-			types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
-			currentClusterSummary)).To(Succeed())
-		Expect(currentClusterSummary.Status.HelmReleaseSummaries).ToNot(BeNil())
-		Expect(len(currentClusterSummary.Status.HelmReleaseSummaries)).To(Equal(1))
-		Expect(currentClusterSummary.Status.HelmReleaseSummaries[0].Status).To(Equal(configv1beta1.HelmChartStatusManaging))
-		Expect(currentClusterSummary.Status.HelmReleaseSummaries[0].ReleaseName).To(Equal(contourChart.ReleaseName))
-		Expect(currentClusterSummary.Status.HelmReleaseSummaries[0].ReleaseNamespace).To(Equal(contourChart.ReleaseNamespace))
+		Eventually(func() bool {
+			currentClusterSummary := &configv1beta1.ClusterSummary{}
+			err := testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+				currentClusterSummary)
+			if err != nil {
+				return false
+			}
+			if len(currentClusterSummary.Status.HelmReleaseSummaries) == 1 &&
+				currentClusterSummary.Status.HelmReleaseSummaries[0].Status == configv1beta1.HelmChartStatusManaging &&
+				currentClusterSummary.Status.HelmReleaseSummaries[0].ReleaseName == contourChart.ReleaseName &&
+				currentClusterSummary.Status.HelmReleaseSummaries[0].ReleaseNamespace == contourChart.ReleaseNamespace {
+				return true
+			}
+			return false
+		}, timeout, pollingInterval).Should(BeTrue())
 	})
 
 	It("updateChartsInClusterConfiguration updates ClusterConfiguration with deployed helm releases", func() {
@@ -644,7 +684,7 @@ var _ = Describe("HandlersHelm", func() {
 		// helm chart. So expect action for Install will be install, and the action for Uninstall will be no action as
 		// such release has never been installed.
 		err = controllers.HandleCharts(context.TODO(), clusterSummary, testEnv.Client, testEnv.Client, kubeconfig,
-			false, nil, textlogger.NewLogger(textlogger.NewConfig()))
+			false, nil, nil, textlogger.NewLogger(textlogger.NewConfig()))
 		Expect(err).ToNot(BeNil())
 
 		var druRunError *configv1beta1.DryRunReconciliationError

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,7 +24,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=v1.0.0
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.0-beta.0
+        image: docker.io/projectsveltos/addon-controller:v1.0.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,7 +24,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=v1.0.0
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.0-beta.0
+        image: docker.io/projectsveltos/addon-controller:v1.0.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -5170,7 +5170,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.0-beta.0
+        - --version=v1.0.0
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -5183,7 +5183,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.0-beta.0
+        image: docker.io/projectsveltos/addon-controller:v1.0.0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Helm charts can be expressed as templates and instaniated at run time.
Two paths were not instantiating the helm charts and this was causing the addon controller to first deploy and immediately after undeploy an Helm chart whose release namespace was expressed as a template

Fixes #1319 