### PR TITLE
(chore) DeploymentType Local and management cluster

### DIFF
--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -469,6 +469,7 @@ type KustomizationRef struct {
 
 	// DeploymentType indicates whether resources need to be deployed
 	// into the management cluster (local) or the managed cluster (remote)
+	// NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
 	// +kubebuilder:default:=Remote
 	// +optional
 	DeploymentType DeploymentType `json:"deploymentType,omitempty"`

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -633,6 +633,7 @@ spec:
                       description: |-
                         DeploymentType indicates whether resources need to be deployed
                         into the management cluster (local) or the managed cluster (remote)
+                        NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                       enum:
                       - Local
                       - Remote

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -671,6 +671,7 @@ spec:
                           description: |-
                             DeploymentType indicates whether resources need to be deployed
                             into the management cluster (local) or the managed cluster (remote)
+                            NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                           enum:
                           - Local
                           - Remote

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -633,6 +633,7 @@ spec:
                       description: |-
                         DeploymentType indicates whether resources need to be deployed
                         into the management cluster (local) or the managed cluster (remote)
+                        NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                       enum:
                       - Local
                       - Remote

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -938,6 +938,7 @@ spec:
                       description: |-
                         DeploymentType indicates whether resources need to be deployed
                         into the management cluster (local) or the managed cluster (remote)
+                        NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                       enum:
                       - Local
                       - Remote
@@ -2605,6 +2606,7 @@ spec:
                           description: |-
                             DeploymentType indicates whether resources need to be deployed
                             into the management cluster (local) or the managed cluster (remote)
+                            NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                           enum:
                           - Local
                           - Remote
@@ -3910,6 +3912,7 @@ spec:
                       description: |-
                         DeploymentType indicates whether resources need to be deployed
                         into the management cluster (local) or the managed cluster (remote)
+                        NOTE: DeploymentType Local cannot be used when the matching cluster is the management cluster itself.
                       enum:
                       - Local
                       - Remote


### PR DESCRIPTION
Add a note that deploymentType cannot be set to Local if the matching cluster is the management cluster itself