### PR TITLE
(feat) add logic to upgrade drift detection instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OS ?= $(shell uname -s)
 OS := $(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.0.1
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -203,7 +203,6 @@ func main() {
 	startControllersAndWatchers(ctx, mgr)
 
 	setupChecks(mgr)
-	controllers.SetVersion(version)
 
 	setupIndexes(ctx, mgr)
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,7 +16,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.0.1"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/addon-controller:v1.0.1
+      - image: docker.io/projectsveltos/addon-controller:main
         name: controller

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -466,6 +466,7 @@ func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctr
 
 	// At this point we don't know yet whether CAPI is present in the cluster.
 	// Later on, in main, we detect that and if CAPI is present WatchForCAPI will be invoked.
+
 	if r.ReportMode == CollectFromManagementCluster {
 		go collectAndProcessResourceSummaries(ctx, mgr.GetClient(), r.ShardKey, r.Version, mgr.GetLogger())
 	}
@@ -473,6 +474,10 @@ func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctr
 	if getAgentInMgmtCluster() {
 		go removeStaleDriftDetectionResources(ctx, r.Logger)
 	}
+
+	// This is one time operation that upgrades drift detection instances in all managed cluster
+	// where drift detection has been deployed
+	go upgradeDriftDetection(ctx, r.Logger)
 
 	initializeManager(ctrl.Log.WithName("watchers"), mgr.GetConfig(), mgr.GetClient())
 

--- a/controllers/clustersummary_features.go
+++ b/controllers/clustersummary_features.go
@@ -54,14 +54,15 @@ func RegisterFeatures(d deployer.DeployerInterface, setupLog logr.Logger) {
 func creatFeatureHandlerMaps() {
 	featuresHandlers = make(map[libsveltosv1beta1.FeatureID]feature)
 
-	featuresHandlers[libsveltosv1beta1.FeatureResources] = feature{id: libsveltosv1beta1.FeatureResources, currentHash: resourcesHash,
-		deploy: deployResources, undeploy: undeployResources, getRefs: getResourceRefs}
+	featuresHandlers[libsveltosv1beta1.FeatureResources] = feature{id: libsveltosv1beta1.FeatureResources,
+		currentHash: resourcesHash, deploy: deployResources, undeploy: undeployResources, getRefs: getResourceRefs}
 
-	featuresHandlers[libsveltosv1beta1.FeatureHelm] = feature{id: libsveltosv1beta1.FeatureHelm, currentHash: helmHash,
-		deploy: deployHelmCharts, undeploy: undeployHelmCharts, getRefs: getHelmRefs}
+	featuresHandlers[libsveltosv1beta1.FeatureHelm] = feature{id: libsveltosv1beta1.FeatureHelm,
+		currentHash: helmHash, deploy: deployHelmCharts, undeploy: undeployHelmCharts, getRefs: getHelmRefs}
 
-	featuresHandlers[libsveltosv1beta1.FeatureKustomize] = feature{id: libsveltosv1beta1.FeatureKustomize, currentHash: kustomizationHash,
-		deploy: deployKustomizeRefs, undeploy: undeployKustomizeRefs, getRefs: getKustomizationRefs}
+	featuresHandlers[libsveltosv1beta1.FeatureKustomize] = feature{id: libsveltosv1beta1.FeatureKustomize,
+		currentHash: kustomizationHash, deploy: deployKustomizeRefs, undeploy: undeployKustomizeRefs,
+		getRefs: getKustomizationRefs}
 }
 
 func getHandlersForFeature(featureID libsveltosv1beta1.FeatureID) feature {

--- a/controllers/drift_detection_upgrade.go
+++ b/controllers/drift_detection_upgrade.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2024. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func upgradeDriftDetection(ctx context.Context, logger logr.Logger) {
+	if getAgentInMgmtCluster() {
+		logger.V(logs.LogInfo).Info("upgrade drift detection on management cluster")
+		upgradeDriftDetectionDeploymentsInMgmtCluster(ctx, logger)
+		return
+	}
+
+	logger.V(logs.LogInfo).Info("upgrade drift detection on managed clusters")
+	upgradeDriftDetectionDeploymentsInManagedClusters(ctx, logger)
+}
+
+func upgradeDriftDetectionDeploymentsInManagedClusters(ctx context.Context, logger logr.Logger) {
+	const retryAfter = 5 * time.Second
+
+	mgmtClient := getManagementClusterClient()
+	for {
+		patches, err := getDriftDetectionManagerPatches(ctx, mgmtClient, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to collect drift detection patches: %v", err))
+			time.Sleep(retryAfter)
+			continue
+		}
+
+		clusters, err := getListOfClustersWithDriftDetection(ctx, mgmtClient, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to collect drift detection patches: %v", err))
+			time.Sleep(retryAfter)
+			continue
+		}
+
+		// featureID is not important in this context. Drift detection is not tracked anyway. One is required
+		// so setting this.
+		featureID := string(libsveltosv1beta1.FeatureKustomize)
+
+		allProcessed := true
+		for i := range clusters {
+			clusterType := clusterproxy.GetClusterType(&clusters[i])
+
+			cluster, err := clusterproxy.GetCluster(ctx, mgmtClient, clusters[i].Namespace, clusters[i].Name,
+				clusterType)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				if !cluster.GetDeletionTimestamp().IsZero() {
+					continue
+				}
+			}
+
+			err = deployDriftDetectionManagerInManagedCluster(ctx, clusters[i].Namespace, clusters[i].Name,
+				"sveltos-upgrade", featureID,
+				"do-not-send-updates", clusterType, patches, logger)
+			if err != nil {
+				logger.V(logs.LogInfo).Info(
+					fmt.Sprintf("cluster %s %s/%s failed to upgrade driftDetection deployment: %v",
+						clusterType, clusters[i].Namespace, clusters[i].Name, err))
+				allProcessed = false
+			}
+		}
+
+		if allProcessed {
+			break
+		}
+
+		time.Sleep(retryAfter)
+	}
+}
+
+func upgradeDriftDetectionDeploymentsInMgmtCluster(ctx context.Context, logger logr.Logger) {
+	config := getManagementClusterConfig()
+	c := getManagementClusterClient()
+	const retryAfter = 5 * time.Second
+
+	for {
+		patches, err := getDriftDetectionManagerPatches(ctx, c, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to collect drift detection patches: %v", err))
+			time.Sleep(retryAfter)
+			continue
+		}
+
+		listOptions := []client.ListOption{
+			client.MatchingLabels{
+				driftDetectionFeatureLabelKey: driftDetectionFeatureLabelValue,
+			},
+		}
+
+		driftDetectionDeployments := &appsv1.DeploymentList{}
+		err = c.List(ctx, driftDetectionDeployments, listOptions...)
+		if err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to collect driftDetection deployment: %v", err))
+			time.Sleep(retryAfter)
+			continue
+		}
+
+		allProcessed := true
+		for i := range driftDetectionDeployments.Items {
+			// Ignore deleted drift detection deployment
+			if !driftDetectionDeployments.Items[i].DeletionTimestamp.IsZero() {
+				continue
+			}
+
+			err = upgradeDriftDetectionDeployment(ctx, config, c, &driftDetectionDeployments.Items[i],
+				patches, logger)
+			if err != nil {
+				logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to upgrade driftDetection deployment: %v", err))
+				allProcessed = false
+			}
+		}
+
+		if allProcessed {
+			break
+		}
+
+		time.Sleep(retryAfter)
+	}
+}
+
+func upgradeDriftDetectionDeployment(ctx context.Context, config *rest.Config, c client.Client,
+	depl *appsv1.Deployment, patches []libsveltosv1beta1.Patch, logger logr.Logger) error {
+
+	exist, clusterNs, clusterName, clusterType := deplAssociatedClusterExist(ctx, c, depl, logger)
+	if exist {
+		logger.V(logs.LogDebug).Info(fmt.Sprintf("Upgrade drift detection deployment for cluster %s %s/%s",
+			clusterType, clusterNs, clusterName))
+		return deployDriftDetectionManagerInManagementCluster(ctx, config, clusterNs, clusterName,
+			"do-not-send-updates", clusterType, patches, logger)
+	}
+
+	return nil
+}
+
+func getListOfClustersWithDriftDetection(ctx context.Context, c client.Client,
+	logger logr.Logger) ([]corev1.ObjectReference, error) {
+
+	clusterSummaries := &configv1beta1.ClusterSummaryList{}
+
+	err := c.List(ctx, clusterSummaries)
+	if err != nil {
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to fetch clusterSummary instances: %v", err))
+		return nil, err
+	}
+
+	clusters := []corev1.ObjectReference{}
+	for i := range clusterSummaries.Items {
+		cs := &clusterSummaries.Items[i]
+		if cs.Spec.ClusterProfileSpec.SyncMode == configv1beta1.SyncModeContinuousWithDriftDetection {
+			kind := libsveltosv1beta1.SveltosClusterKind
+			apiVersion := libsveltosv1beta1.GroupVersion.String()
+			if cs.Spec.ClusterType == libsveltosv1beta1.ClusterTypeCapi {
+				kind = clusterv1.ClusterKind
+				apiVersion = clusterv1.GroupVersion.String()
+			}
+
+			clusters = append(clusters, corev1.ObjectReference{
+				Namespace:  cs.Spec.ClusterNamespace,
+				Name:       cs.Spec.ClusterName,
+				Kind:       kind,
+				APIVersion: apiVersion,
+			})
+		}
+	}
+
+	return clusters, nil
+}

--- a/controllers/drift_detection_upgrade_test.go
+++ b/controllers/drift_detection_upgrade_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/textlogger"
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/controllers"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+var _ = Describe("Drift Detection Upgrade", func() {
+	var logger logr.Logger
+
+	BeforeEach(func() {
+		logger = textlogger.NewLogger(textlogger.NewConfig())
+	})
+
+	It("getListOfClustersWithDriftDetection returns the list of clusters with drift detection enabled", func() {
+		cluster1 := corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       libsveltosv1beta1.SveltosClusterKind,
+			APIVersion: libsveltosv1beta1.GroupVersion.String(),
+		}
+		clusterSummary1 := &configv1beta1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+			},
+			Spec: configv1beta1.ClusterSummarySpec{
+				ClusterNamespace: cluster1.Namespace,
+				ClusterName:      cluster1.Name,
+				ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+				ClusterProfileSpec: configv1beta1.Spec{
+					SyncMode: configv1beta1.SyncModeContinuousWithDriftDetection,
+				},
+			},
+		}
+
+		cluster2 := corev1.ObjectReference{
+			Namespace:  randomString(),
+			Name:       randomString(),
+			Kind:       clusterv1.ClusterKind,
+			APIVersion: clusterv1.GroupVersion.String(),
+		}
+		clusterSummary2 := &configv1beta1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+			},
+			Spec: configv1beta1.ClusterSummarySpec{
+				ClusterNamespace: cluster2.Namespace,
+				ClusterName:      cluster2.Name,
+				ClusterType:      libsveltosv1beta1.ClusterTypeCapi,
+				ClusterProfileSpec: configv1beta1.Spec{
+					SyncMode: configv1beta1.SyncModeContinuousWithDriftDetection,
+				},
+			},
+		}
+
+		initObjects := []client.Object{
+			clusterSummary1,
+			clusterSummary2,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
+
+		clusters, err := controllers.GetListOfClustersWithDriftDetection(context.TODO(), c, logger)
+		Expect(err).To(BeNil())
+		Expect(len(clusters)).To(Equal(2))
+		Expect(clusters).To(ContainElement(cluster1))
+		Expect(clusters).To(ContainElement(cluster2))
+
+		// This is continuous, so this cluster wont be included
+		clusterSummary3 := &configv1beta1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      randomString(),
+				Namespace: randomString(),
+			},
+			Spec: configv1beta1.ClusterSummarySpec{
+				ClusterNamespace: randomString(),
+				ClusterName:      randomString(),
+				ClusterType:      libsveltosv1beta1.ClusterTypeCapi,
+				ClusterProfileSpec: configv1beta1.Spec{
+					SyncMode: configv1beta1.SyncModeContinuous,
+				},
+			},
+		}
+
+		Expect(c.Create(context.TODO(), clusterSummary3)).To(Succeed())
+		clusters, err = controllers.GetListOfClustersWithDriftDetection(context.TODO(), c, logger)
+		Expect(err).To(BeNil())
+		Expect(len(clusters)).To(Equal(2))
+	})
+})

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -175,3 +175,7 @@ var (
 	RemoveStaleResourceSummary = removeStaleResourceSummary
 	RemoveDuplicates           = removeDuplicates
 )
+
+var (
+	GetListOfClustersWithDriftDetection = getListOfClustersWithDriftDetection
+)

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -1348,9 +1348,10 @@ func getClusterProfileSpecHash(ctx context.Context, clusterSummary *configv1beta
 	config += fmt.Sprintf("%t", clusterProfileSpec.ContinueOnConflict)
 
 	if clusterProfileSpec.SyncMode == configv1beta1.SyncModeContinuousWithDriftDetection {
-		// Use the version. This will cause drift-detection, Sveltos CRDs
-		// to be redeployed on upgrade
-		config += getVersion()
+		// Drift detection is now upgraded on its own. v1.0.1 was last release triggering
+		// the upgrade via ClusterSummary redeployment. v1.0.1 is still added here to make
+		// sure hash does not change
+		config += "v1.0.1"
 	}
 
 	mgmtResourceHash, err := getTemplateResourceRefHash(ctx, clusterSummary)

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -64,10 +64,6 @@ const (
 	clusterKind   = "Cluster"
 )
 
-var (
-	version string
-)
-
 func InitScheme() (*runtime.Scheme, error) {
 	s := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(s); err != nil {
@@ -212,14 +208,6 @@ func isCluterSummaryProvisioned(clusterSumary *configv1beta1.ClusterSummary) boo
 	}
 
 	return true
-}
-
-func SetVersion(v string) {
-	version = v
-}
-
-func getVersion() string {
-	return version
 }
 
 func isNamespaced(r *unstructured.Unstructured, config *rest.Config) (bool, error) {
@@ -501,7 +489,7 @@ func removeStaleResourceSummary(ctx context.Context, clusterNamespace, clusterNa
 }
 
 func deplAssociatedClusterExist(ctx context.Context, c client.Client, depl *appsv1.Deployment,
-	logger logr.Logger) (exist bool, clusterName, clusterNamespace string, clusterType libsveltosv1beta1.ClusterType) {
+	logger logr.Logger) (exist bool, clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType) {
 
 	if depl.Labels == nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("driftDetection %s/%s has no label",

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -24,7 +24,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.1
+        - --version=main
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.1
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -24,7 +24,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.1
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -37,7 +37,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.1
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -5173,7 +5173,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.0.1
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -5186,7 +5186,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.0.1
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -44,10 +44,10 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.0.1
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b429c4957c7727b982204c4f65a3d3c6d1c71dd913361e6a2c766a70ef4880fe
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:1e59e8724488d60d17f32983c1bded73c01f28078810376df9508b0a777d6766
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -26,10 +26,10 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.0.1
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b429c4957c7727b982204c4f65a3d3c6d1c71dd913361e6a2c766a70ef4880fe
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:1e59e8724488d60d17f32983c1bded73c01f28078810376df9508b0a777d6766
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -138,10 +138,10 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.0.1
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b429c4957c7727b982204c4f65a3d3c6d1c71dd913361e6a2c766a70ef4880fe
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:1e59e8724488d60d17f32983c1bded73c01f28078810376df9508b0a777d6766
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -120,10 +120,10 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.0.1
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b429c4957c7727b982204c4f65a3d3c6d1c71dd913361e6a2c766a70ef4880fe
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:1e59e8724488d60d17f32983c1bded73c01f28078810376df9508b0a777d6766
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/clusterapi-workload.yaml
+++ b/test/clusterapi-workload.yaml
@@ -1,30 +1,31 @@
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: ClusterClass
 metadata:
   name: quick-start
   namespace: default
 spec:
   controlPlane:
-    machineHealthCheck:
-      unhealthyConditions:
-      - status: Unknown
-        timeout: 300s
-        type: Ready
-      - status: "False"
-        timeout: 300s
-        type: Ready
+    healthCheck:
+      checks:
+        unhealthyNodeConditions:
+        - status: Unknown
+          timeoutSeconds: 300
+          type: Ready
+        - status: "False"
+          timeoutSeconds: 300
+          type: Ready
     machineInfrastructure:
-      ref:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      templateRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         name: quick-start-control-plane
-    ref:
-      apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    templateRef:
+      apiVersion: controlplane.cluster.x-k8s.io/v1beta2
       kind: KubeadmControlPlaneTemplate
       name: quick-start-control-plane
   infrastructure:
-    ref:
-      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    templateRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
       kind: DockerClusterTemplate
       name: quick-start-cluster
   patches:
@@ -35,7 +36,7 @@ spec:
         valueFrom:
           variable: imageRepository
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: KubeadmControlPlaneTemplate
         matchResources:
           controlPlane: true
@@ -51,11 +52,12 @@ spec:
             local:
               imageTag: {{ .etcdImageTag }}
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: KubeadmControlPlaneTemplate
         matchResources:
           controlPlane: true
     description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+    enabledIf: '{{ ne .etcdImageTag "" }}'
     name: etcdImageTag
   - definitions:
     - jsonPatches:
@@ -65,11 +67,12 @@ spec:
           template: |
             imageTag: {{ .coreDNSImageTag }}
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: KubeadmControlPlaneTemplate
         matchResources:
           controlPlane: true
     description: Sets tag to use for the etcd image in the KubeadmControlPlane.
+    enabledIf: '{{ ne .coreDNSImageTag "" }}'
     name: coreDNSImageTag
   - definitions:
     - jsonPatches:
@@ -79,7 +82,7 @@ spec:
           template: |
             kindest/node:{{ .builtin.machineDeployment.version | replace "+" "_" }}
       selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         matchResources:
           machineDeploymentClass:
@@ -92,7 +95,7 @@ spec:
           template: |
             kindest/node:{{ .builtin.machinePool.version | replace "+" "_" }}
       selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachinePoolTemplate
         matchResources:
           machinePoolClass:
@@ -105,7 +108,7 @@ spec:
           template: |
             kindest/node:{{ .builtin.controlPlane.version | replace "+" "_" }}
       selector:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
         kind: DockerMachineTemplate
         matchResources:
           controlPlane: true
@@ -117,7 +120,8 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
         value:
-          admission-control-config-file: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+        - name: admission-control-config-file
+          value: /etc/kubernetes/kube-apiserver-admission-pss.yaml
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
         value:
@@ -136,7 +140,7 @@ spec:
                 plugins:
                 - name: PodSecurity
                   configuration:
-                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25" .builtin.controlPlane.version }}beta1{{ end }}
+                    apiVersion: pod-security.admission.config.k8s.io/v1{{ if semverCompare "< v1.25-0" .builtin.controlPlane.version }}beta1{{ end }}
                     kind: PodSecurityConfiguration
                     defaults:
                       enforce: "{{ .podSecurityStandard.enforce }}"
@@ -151,7 +155,7 @@ spec:
                       namespaces: [kube-system]
               path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
       selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta2
         kind: KubeadmControlPlaneTemplate
         matchResources:
           controlPlane: true
@@ -212,41 +216,40 @@ spec:
         type: object
   workers:
     machineDeployments:
-    - class: default-worker
-      machineHealthCheck:
-        unhealthyConditions:
-        - status: Unknown
-          timeout: 300s
-          type: Ready
-        - status: "False"
-          timeout: 300s
-          type: Ready
-      template:
-        bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-            kind: KubeadmConfigTemplate
-            name: quick-start-default-worker-bootstraptemplate
-        infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: DockerMachineTemplate
-            name: quick-start-default-worker-machinetemplate
+    - bootstrap:
+        templateRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KubeadmConfigTemplate
+          name: quick-start-default-worker-bootstraptemplate
+      class: default-worker
+      healthCheck:
+        checks:
+          unhealthyNodeConditions:
+          - status: Unknown
+            timeoutSeconds: 300
+            type: Ready
+          - status: "False"
+            timeoutSeconds: 300
+            type: Ready
+      infrastructure:
+        templateRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: DockerMachineTemplate
+          name: quick-start-default-worker-machinetemplate
     machinePools:
-    - class: default-worker
-      template:
-        bootstrap:
-          ref:
-            apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
-            kind: KubeadmConfigTemplate
-            name: quick-start-default-worker-bootstraptemplate
-        infrastructure:
-          ref:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: DockerMachinePoolTemplate
-            name: quick-start-default-worker-machinepooltemplate
+    - bootstrap:
+        templateRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+          kind: KubeadmConfigTemplate
+          name: quick-start-default-worker-bootstraptemplate
+      class: default-worker
+      infrastructure:
+        templateRef:
+          apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
+          kind: DockerMachinePoolTemplate
+          name: quick-start-default-worker-machinepooltemplate
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerClusterTemplate
 metadata:
   name: quick-start-cluster
@@ -255,7 +258,7 @@ spec:
   template:
     spec: {}
 ---
-apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 kind: KubeadmControlPlaneTemplate
 metadata:
   name: quick-start-control-plane
@@ -272,11 +275,17 @@ spec:
             - 0.0.0.0
             - host.docker.internal
         initConfiguration:
-          nodeRegistration: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
         joinConfiguration:
-          nodeRegistration: {}
+          nodeRegistration:
+            kubeletExtraArgs:
+            - name: eviction-hard
+              value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-control-plane
@@ -288,7 +297,7 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachineTemplate
 metadata:
   name: quick-start-default-worker-machinetemplate
@@ -300,7 +309,7 @@ spec:
       - containerPath: /var/run/docker.sock
         hostPath: /var/run/docker.sock
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
 kind: DockerMachinePoolTemplate
 metadata:
   name: quick-start-default-worker-machinepooltemplate
@@ -310,7 +319,7 @@ spec:
     spec:
       template: {}
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
   name: quick-start-default-worker-bootstraptemplate
@@ -319,9 +328,12 @@ spec:
   template:
     spec:
       joinConfiguration:
-        nodeRegistration: {}
+        nodeRegistration:
+          kubeletExtraArgs:
+          - name: eviction-hard
+            value: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: clusterapi-workload
@@ -338,9 +350,9 @@ spec:
       cidrBlocks:
       - 10.225.0.0/16
   topology:
-    class: quick-start
+    classRef:
+      name: quick-start
     controlPlane:
-      metadata: {}
       replicas: 1
     variables:
     - name: imageRepository


### PR DESCRIPTION
Moving this logic out of ClusterSummary deployment. This will make sure on upgrade ClusterSummary instances on ContinuousWithDriftDetection mode wont be redeployed while all drift detection instances, whether on the management or managed clusters, are all upgraded