### PR TITLE
(feat) add new Helm option

### DIFF
--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -219,6 +219,10 @@ type HelmOptions struct {
 	// +optional
 	Description string `json:"description,omitempty"`
 
+	// PassCredentialsAll is the flag to pass credentials to all domains
+	// +optional
+	PassCredentialsAll bool `json:"passCredentialsAll,omitempty"`
+
 	// HelmInstallOptions are options specific to helm install
 	// +optional
 	InstallOptions HelmInstallOptions `json:"installOptions,omitempty"`

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -329,6 +329,10 @@ spec:
                             type: string
                           description: Labels that would be added to release metadata.
                           type: object
+                        passCredentialsAll:
+                          description: PassCredentialsAll is the flag to pass credentials
+                            to all domains
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -366,6 +366,10 @@ spec:
                                 type: string
                               description: Labels that would be added to release metadata.
                               type: object
+                            passCredentialsAll:
+                              description: PassCredentialsAll is the flag to pass
+                                credentials to all domains
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -329,6 +329,10 @@ spec:
                             type: string
                           description: Labels that would be added to release metadata.
                           type: object
+                        passCredentialsAll:
+                          description: PassCredentialsAll is the flag to pass credentials
+                            to all domains
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -3066,6 +3066,14 @@ func getSkipCRDsHelmValue(options *configv1beta1.HelmOptions) bool {
 	return false
 }
 
+func getPassCredentialsToAllValue(options *configv1beta1.HelmOptions) bool {
+	if options != nil {
+		return options.PassCredentialsAll
+	}
+
+	return false
+}
+
 func getAtomicHelmValue(options *configv1beta1.HelmOptions) bool {
 	if options != nil {
 		return options.Atomic
@@ -3278,6 +3286,7 @@ func getHelmInstallClient(ctx context.Context, requestedChart *configv1beta1.Hel
 	installClient.Replace = getReplaceValue(requestedChart.Options)
 	installClient.Labels = getLabelsValue(requestedChart.Options)
 	installClient.Description = getDescriptionValue(requestedChart.Options)
+	installClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
 	if actionConfig.RegistryClient != nil {
 		installClient.SetRegistryClient(actionConfig.RegistryClient)
 	}
@@ -3337,6 +3346,7 @@ func getHelmUpgradeClient(requestedChart *configv1beta1.HelmChart, actionConfig 
 	upgradeClient.InsecureSkipTLSverify = registryOptions.skipTLSVerify
 	upgradeClient.PlainHTTP = registryOptions.plainHTTP
 	upgradeClient.CaFile = registryOptions.caPath
+	upgradeClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
 
 	if actionConfig.RegistryClient != nil {
 		upgradeClient.SetRegistryClient(actionConfig.RegistryClient)

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -634,6 +634,10 @@ spec:
                             type: string
                           description: Labels that would be added to release metadata.
                           type: object
+                        passCredentialsAll:
+                          description: PassCredentialsAll is the flag to pass credentials
+                            to all domains
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-
@@ -2302,6 +2306,10 @@ spec:
                                 type: string
                               description: Labels that would be added to release metadata.
                               type: object
+                            passCredentialsAll:
+                              description: PassCredentialsAll is the flag to pass
+                                credentials to all domains
+                              type: boolean
                             skipCRDs:
                               default: false
                               description: |-
@@ -3610,6 +3618,10 @@ spec:
                             type: string
                           description: Labels that would be added to release metadata.
                           type: object
+                        passCredentialsAll:
+                          description: PassCredentialsAll is the flag to pass credentials
+                            to all domains
+                          type: boolean
                         skipCRDs:
                           default: false
                           description: |-


### PR DESCRIPTION
```
	// PassCredentialsAll is the flag to pass credentials to all domains
	// +optional
	PassCredentialsAll bool `json:"passCredentialsAll,omitempty"`
```

This is passed to install and upgrade client.