### PR TITLE
(bug) dependencies: sort before evaluating hash

### DIFF
--- a/controllers/clusterprofile_controller_test.go
+++ b/controllers/clusterprofile_controller_test.go
@@ -248,6 +248,17 @@ var _ = Describe("Profile: Reconciler", func() {
 		err = testEnv.Get(context.TODO(), clusterProfileName, currentClusterProfile)
 		Expect(err).ToNot(HaveOccurred())
 
+		Eventually(func() bool {
+			currentClusterSummary := &configv1beta1.ClusterSummary{}
+			err = testEnv.Get(context.TODO(),
+				types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+				currentClusterSummary)
+			if err != nil {
+				return false
+			}
+			return !currentClusterSummary.DeletionTimestamp.IsZero()
+		}, timeout, pollingInterval).Should(BeTrue())
+
 		// Remove ClusterSummary finalizer
 		currentClusterSummary := &configv1beta1.ClusterSummary{}
 		Expect(testEnv.Get(context.TODO(),

--- a/controllers/dependencymanager/manager.go
+++ b/controllers/dependencymanager/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -409,7 +410,15 @@ func calculateHash(data map[corev1.ObjectReference]RequestingProfiles) []byte {
 	h := sha256.New()
 	var config string
 
+	// 1. Extract all keys into a slice.
+	keys := make([]corev1.ObjectReference, 0, len(data))
 	for k := range data {
+		keys = append(keys, k)
+	}
+
+	sort.Sort(SortedCorev1ObjectReference(keys))
+
+	for k := range keys {
 		config += render.AsCode(k)
 	}
 

--- a/controllers/dependencymanager/sort_v1reference.go
+++ b/controllers/dependencymanager/sort_v1reference.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dependencymanager
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SortedCorev1ObjectReference []corev1.ObjectReference
+
+func (a SortedCorev1ObjectReference) Len() int      { return len(a) }
+func (a SortedCorev1ObjectReference) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a SortedCorev1ObjectReference) Less(i, j int) bool {
+	if a[i].Kind != a[j].Kind {
+		return a[i].Kind < a[j].Kind
+	}
+	if a[i].Namespace != a[j].Namespace {
+		return a[i].Namespace < a[j].Namespace
+	}
+	return a[i].Name < a[j].Name
+}

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -35,6 +35,7 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers/clustercache"
+	"github.com/projectsveltos/addon-controller/controllers/dependencymanager"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
@@ -525,7 +526,7 @@ func resourcesHash(ctx context.Context, c client.Client, clusterSummary *configv
 		}
 	}
 
-	sort.Sort(SortedCorev1ObjectReference(referencedObjects))
+	sort.Sort(dependencymanager.SortedCorev1ObjectReference(referencedObjects))
 
 	for i := range referencedObjects {
 		reference := &referencedObjects[i]

--- a/controllers/handlers_resources_test.go
+++ b/controllers/handlers_resources_test.go
@@ -39,6 +39,7 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers"
+	"github.com/projectsveltos/addon-controller/controllers/dependencymanager"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	"github.com/projectsveltos/addon-controller/pkg/scope"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
@@ -419,7 +420,7 @@ var _ = Describe("Hash methods", func() {
 				Name:      clusterSummary.Spec.ClusterProfileSpec.PolicyRefs[i].Name,
 			}
 		}
-		sort.Sort(controllers.SortedCorev1ObjectReference(referencedObjects))
+		sort.Sort(dependencymanager.SortedCorev1ObjectReference(referencedObjects))
 		for i := range referencedObjects {
 			switch referencedObjects[i].Name {
 			case configMap1.Name:

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -349,20 +349,6 @@ func getFeatureDeploymentInfoForFeatureID(clusterSummay *configv1beta1.ClusterSu
 	return nil
 }
 
-type SortedCorev1ObjectReference []corev1.ObjectReference
-
-func (a SortedCorev1ObjectReference) Len() int      { return len(a) }
-func (a SortedCorev1ObjectReference) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a SortedCorev1ObjectReference) Less(i, j int) bool {
-	if a[i].Kind != a[j].Kind {
-		return a[i].Kind < a[j].Kind
-	}
-	if a[i].Namespace != a[j].Namespace {
-		return a[i].Namespace < a[j].Namespace
-	}
-	return a[i].Name < a[j].Name
-}
-
 type SortedHelmCharts []configv1beta1.HelmChart
 
 func (a SortedHelmCharts) Len() int      { return len(a) }


### PR DESCRIPTION
Currently, because clusters are not sorted, DependenciesHash keeps changing causing un-needed reconciliations to happen