### PR TITLE
feat: add GitHub runner scale set controller configuration 🎉

### DIFF
--- a/examples/github-runner-scale-set-controller.yaml
+++ b/examples/github-runner-scale-set-controller.yaml
@@ -1,0 +1,17 @@
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterProfile
+metadata:
+  name: runner-scale-set-controller
+spec:
+  clusterSelector:
+    matchLabels:
+      env: fv
+  syncMode: Continuous
+  helmCharts:
+  - chartName: gha-runner-scale-set-controller
+    chartVersion: "0.12.1"
+    helmChartAction: Install
+    releaseName: arc
+    releaseNamespace: arc-systems
+    repositoryName: gha-runner-scale-set-controller
+    repositoryURL: oci://ghcr.io/actions/actions-runner-controller-charts


### PR DESCRIPTION
Introduce a new ClusterProfile for the GitHub runner scale set controller, enabling continuous synchronization and installation of the specified Helm chart. This configuration enhances the deployment capabilities for environments labeled as 'fv' and streamlines the management of GitHub runners. 🚀