### PR TITLE
build: add missing dependencies to deploy-projectsveltos target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ create-cluster-pullmode: $(KIND) $(KUBECTL) $(ENVSUBST) $(KUSTOMIZE)
 	@echo "Switching to cluster1..."
 	$(KUBECTL) config use-context kind-$(CONTROL_CLUSTER_NAME)
 
-deploy-projectsveltos: $(KUSTOMIZE)
+deploy-projectsveltos: $(KUSTOMIZE) $(ENVSUBST) $(KUBECTL)
 	# Load projectsveltos image into cluster
 	@echo 'Load projectsveltos image into cluster'
 	$(MAKE) load-image


### PR DESCRIPTION
The deploy-projectsveltos make target was missing required dependencies
(ENVSUBST and KUBECTL) which could cause the target to fail when run
independently. This fix ensures all necessary tools are available before
executing the target.

Fixes: #1401