### PR TITLE
(bug) KustomizationRefs and ContinuousWithDriftDetection

### DIFF
--- a/controllers/handlers_kustomize.go
+++ b/controllers/handlers_kustomize.go
@@ -958,7 +958,7 @@ func handleDriftDetectionManagerDeploymentForKustomize(ctx context.Context, clus
 		// Deploy drift detection manager first. Have manager up by the time resourcesummary is created
 		err := deployDriftDetectionManagerInCluster(ctx, getManagementClusterClient(), clusterNamespace,
 			clusterName, clusterSummary.Name, string(libsveltosv1beta1.FeatureKustomize), clusterType,
-			startInMgmtCluster, isPullMode, logger)
+			isPullMode, startInMgmtCluster, logger)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When Sveltos is deployed with agent in the management cluster, the drift-detection-manager deployments are created in the management cluster.

A bug in the KustomizationRefs section was causing Sveltos to deploy drift-detection-manager in the managed clusters instead.

This PR fixes that.