### PR TITLE
(bug) Exclude trigger from ClusterPromotion Stage hash evaluation

### DIFF
--- a/examples/oci.yaml
+++ b/examples/oci.yaml
@@ -11,7 +11,7 @@ spec:
   - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
     repositoryName:   oci-vault
     chartName:        vault
-    chartVersion:     0.7.2
+    chartVersion:     1.9.0
     releaseName:      vault
     releaseNamespace: vault
     helmChartAction:  Install


### PR DESCRIPTION
The Trigger field in the Stage struct is used for runtime progression logic (like manual approval), changes to it shouldn't trigger a re-hash.