### PR TITLE
Lua options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-logr/logr"
 	"github.com/spf13/pflag"
+	lua "github.com/yuin/gopher-lua"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -96,6 +97,8 @@ var (
 	disableTelemetry        bool
 	autoDeployDependencies  bool
 	registry                string
+	luaCallStackSize        int
+	luaRegistrySize         int
 )
 
 const (
@@ -165,6 +168,8 @@ func main() {
 	controllers.SetManagementClusterAccess(mgr.GetClient(), mgr.GetConfig())
 	controllers.SetDriftdetectionConfigMap(driftDetectionConfigMap)
 	controllers.SetLuaConfigMap(luaConfigMap)
+	controllers.SetLuaCallStackSize(luaCallStackSize)
+	controllers.SetLuaRegistrySize(luaRegistrySize)
 	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
 	controllers.SetDriftDetectionRegistry(registry)
 	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
@@ -331,6 +336,10 @@ func initFlags(fs *pflag.FlagSet) {
 	// configuration inconsistencies.
 	fs.BoolVar(&autoDeployDependencies, "auto-deploy-dependencies", true,
 		" When AutoDeployDependencies is set to true, Sveltos will automatically resolve and deploy the prerequisite profiles specified in the DependsOn field")
+
+	fs.IntVar(&luaCallStackSize, "lua-call-stack-size", lua.CallStackSize, "Call stack size. This defaults to lua.CallStackSize")
+
+	fs.IntVar(&luaRegistrySize, "lua-registry-size", lua.RegistrySize, "Call stack size. This defaults to lua.RegistrySize")
 }
 
 func setupIndexes(ctx context.Context, mgr ctrl.Manager) {

--- a/controllers/lua_instantiation.go
+++ b/controllers/lua_instantiation.go
@@ -73,7 +73,10 @@ func instantiateWithLuaScript(ctx context.Context, config *rest.Config, c client
 	}
 
 	// Create a new Lua state
-	l := lua.NewState()
+	l := lua.NewState(lua.Options{
+		CallStackSize: getLuaCallStackSize(),
+		RegistrySize:  getLuaRegistrySize(),
+	})
 	defer l.Close()
 
 	sveltoslua.LoadModulesAndRegisterMethods(l)

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -33,6 +33,8 @@ var (
 	capiOnboardAnnotation   string
 	driftDetectionRegistry  string
 	agentInMgmtCluster      bool
+	luaCallStackSize        int
+	luaRegistrySize         int
 )
 
 func SetManagementClusterAccess(c client.Client, config *rest.Config) {
@@ -46,6 +48,14 @@ func SetDriftdetectionConfigMap(name string) {
 
 func SetLuaConfigMap(name string) {
 	luaConfigMap = name
+}
+
+func SetLuaCallStackSize(callStackSize int) {
+	luaCallStackSize = callStackSize
+}
+
+func SetLuaRegistrySize(registrySize int) {
+	luaRegistrySize = registrySize
 }
 
 func SetCAPIOnboardAnnotation(key string) {
@@ -74,6 +84,14 @@ func getDriftDetectionConfigMap() string {
 
 func getLuaConfigMap() string {
 	return luaConfigMap
+}
+
+func getLuaCallStackSize() int {
+	return luaCallStackSize
+}
+
+func getLuaRegistrySize() int {
+	return luaRegistrySize
 }
 
 func getCAPIOnboardAnnotation() string {


### PR DESCRIPTION
When Lua is used to create the Kubernetes resources to deploy in managed clusters, allows call stack and registry size to be set.

There are two new arguments:
- lua-call-stack-size: defaults to lua.CallStackSize
- lua-registry-size: defaults to lua.RegistrySize