### PR TITLE
(chore) drift detection upgrade

### DIFF
--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -481,7 +481,7 @@ func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctr
 
 	// This is one time operation that upgrades drift detection instances in all managed cluster
 	// where drift detection has been deployed
-	go upgradeDriftDetection(ctx, r.Logger)
+	go upgradeDriftDetection(ctx, r.ShardKey, r.Logger)
 
 	initializeManager(ctrl.Log.WithName("watchers"), mgr.GetConfig(), mgr.GetClient())
 

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -200,5 +200,5 @@ var (
 )
 
 var (
-	GetListOfClustersWithDriftDetection = getListOfClustersWithDriftDetection
+	SkipUpgrading = skipUpgrading
 )


### PR DESCRIPTION
This PR changes how the addon-controller upgrades drift detection deployments.

**Before**: Drift detection was only upgraded on clusters where a matching profile was actively set to ContinuousWithDriftDetection. This meant deployments in clusters that no longer matched any such profile were not being upgraded.

**Now**: The new logic upgrades drift detection deployments in all clusters where it is deployed.

**Exclusions**: Upgrades are skipped only for paused or unready clusters.