### PR TITLE
(feat) ClusterPromotion: add PreHealthCheckDeployment

### DIFF
--- a/api/v1beta1/clusterpromotion_types.go
+++ b/api/v1beta1/clusterpromotion_types.go
@@ -178,6 +178,13 @@ type AutoTrigger struct {
 	// +optional
 	Delay *metav1.Duration `json:"delay,omitempty"`
 
+	// PreHealthCheckDeployment is a slice of resources Sveltos will deploy after the Delay
+	// period has elapsed and before running PostDelayHealthChecks.
+	// This can be used, for example, to deploy a Job that performs validation tasks.
+	// The PostDelayHealthChecks can then validate the successful completion of these resources (e.g., a Job).
+	// +optional
+	PreHealthCheckDeployment []PolicyRef `json:"preHealthCheckDeployment,omitempty"`
+
 	// PostDelayHealthChecks is a slice of health checks Sveltos will run after the delay
 	// period has elapsed.
 	// +optional
@@ -299,6 +306,13 @@ type StageStatus struct {
 	// FailureMessage reports a detailed error message if a failure occurred.
 	// +optional
 	FailureMessage *string `json:"failureMessage,omitempty"`
+
+	// CurrentStatusDescription provides a high-level description of where the stage is
+	// in its progression (e.g., "Waiting for cluster profiles to be created",
+	// "Waiting for all clusters to be Provisioned", "Running post-deployment health checks").
+	// This helps users understand the current blocking state.
+	// +optional
+	CurrentStatusDescription *string `json:"currentStatusDescription,omitempty"`
 }
 
 // ClusterPromotionStatus defines the observed state of ClusterPromotion.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -37,6 +37,11 @@ func (in *AutoTrigger) DeepCopyInto(out *AutoTrigger) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.PreHealthCheckDeployment != nil {
+		in, out := &in.PreHealthCheckDeployment, &out.PreHealthCheckDeployment
+		*out = make([]PolicyRef, len(*in))
+		copy(*out, *in)
+	}
 	if in.PostDelayHealthChecks != nil {
 		in, out := &in.PostDelayHealthChecks, &out.PostDelayHealthChecks
 		*out = make([]apiv1beta1.ValidateHealth, len(*in))
@@ -1294,6 +1299,11 @@ func (in *StageStatus) DeepCopyInto(out *StageStatus) {
 	}
 	if in.FailureMessage != nil {
 		in, out := &in.FailureMessage, &out.FailureMessage
+		*out = new(string)
+		**out = **in
+	}
+	if in.CurrentStatusDescription != nil {
+		in, out := &in.CurrentStatusDescription, &out.CurrentStatusDescription
 		*out = new(string)
 		**out = **in
 	}

--- a/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
@@ -1274,6 +1274,80 @@ spec:
                                 - version
                                 type: object
                               type: array
+                            preHealthCheckDeployment:
+                              description: |-
+                                PreHealthCheckDeployment is a slice of resources Sveltos will deploy after the Delay
+                                period has elapsed and before running PostDelayHealthChecks.
+                                This can be used, for example, to deploy a Job that performs validation tasks.
+                                The PostDelayHealthChecks can then validate the successful completion of these resources (e.g., a Job).
+                              items:
+                                properties:
+                                  deploymentType:
+                                    default: Remote
+                                    description: |-
+                                      DeploymentType indicates whether resources need to be deployed
+                                      into the management cluster (local) or the managed cluster (remote)
+                                    enum:
+                                    - Local
+                                    - Remote
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the resource. Supported kinds are:
+                                      - ConfigMap/Secret
+                                      - flux GitRepository;OCIRepository;Bucket
+                                    enum:
+                                    - GitRepository
+                                    - OCIRepository
+                                    - Bucket
+                                    - ConfigMap
+                                    - Secret
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referenced resource.
+                                      Name can be expressed as a template and instantiate using any cluster field.
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the referenced resource.
+                                      For ClusterProfile namespace can be left empty. In such a case, namespace will
+                                      be implicit set to cluster's namespace.
+                                      For Profile namespace must be left empty. Profile namespace will be used.
+                                      Namespace can be expressed as a template and instantiate using any cluster field.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Optional indicates that the referenced resource is not mandatory.
+                                      If set to true and the resource is not found, the error will be ignored,
+                                      and Sveltos will continue processing other PolicyRefs.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      Path to the directory containing the YAML files.
+                                      Defaults to 'None', which translates to the root path of the SourceRef.
+                                      Used only for GitRepository;OCIRepository;Bucket
+                                    type: string
+                                  tier:
+                                    default: 100
+                                    description: |-
+                                      Tier controls the order of deployment for resources coming from different PolicyRefs
+                                      within the same ClusterProfile or Profile.
+                                      When two PolicyRefs attempt to deploy the same resource, the PolicyRef with the lowest
+                                      Tier value takes priority and deploys/updates the resource.
+                                      This priority mechanism is only checked after the parent ClusterProfile has won
+                                      the primary conflict resolution against other ClusterProfiles.
+                                      Higher Tier values represent lower priority. The default Tier value is 100.
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              type: array
                             promotionWindow:
                               description: |-
                                 PromotionWindow defines the recurring time window during which the
@@ -1363,6 +1437,13 @@ spec:
                   description: StageStatus defines the status for a given stage in
                     a progressive deployment.
                   properties:
+                    currentStatusDescription:
+                      description: |-
+                        CurrentStatusDescription provides a high-level description of where the stage is
+                        in its progression (e.g., "Waiting for cluster profiles to be created",
+                        "Waiting for all clusters to be Provisioned", "Running post-deployment health checks").
+                        This helps users understand the current blocking state.
+                      type: string
                     failureMessage:
                       description: FailureMessage reports a detailed error message
                         if a failure occurred.

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -83,11 +83,11 @@ var (
 	CleanClusterProfiles        = (*ClusterPromotionReconciler).cleanClusterProfiles
 	IsPromotionWindowOpen       = (*ClusterPromotionReconciler).isPromotionWindowOpen
 
-	GetClusterProfileName     = getClusterProfileName
-	ResetStageStatuses        = resetStageStatuses
-	AddStageStatus            = addStageStatus
-	UpdateStageStatus         = updateStageStatus
-	GetClusterPromotionLabels = getClusterPromotionLabels
+	MainDeploymentClusterProfileName      = mainDeploymentClusterProfileName
+	ResetStageStatuses                    = resetStageStatuses
+	AddStageStatus                        = addStageStatus
+	UpdateStageStatus                     = updateStageStatus
+	GetMainDeploymentClusterProfileLabels = getMainDeploymentClusterProfileLabels
 )
 
 var (

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -2982,6 +2982,80 @@ spec:
                                 - version
                                 type: object
                               type: array
+                            preHealthCheckDeployment:
+                              description: |-
+                                PreHealthCheckDeployment is a slice of resources Sveltos will deploy after the Delay
+                                period has elapsed and before running PostDelayHealthChecks.
+                                This can be used, for example, to deploy a Job that performs validation tasks.
+                                The PostDelayHealthChecks can then validate the successful completion of these resources (e.g., a Job).
+                              items:
+                                properties:
+                                  deploymentType:
+                                    default: Remote
+                                    description: |-
+                                      DeploymentType indicates whether resources need to be deployed
+                                      into the management cluster (local) or the managed cluster (remote)
+                                    enum:
+                                    - Local
+                                    - Remote
+                                    type: string
+                                  kind:
+                                    description: |-
+                                      Kind of the resource. Supported kinds are:
+                                      - ConfigMap/Secret
+                                      - flux GitRepository;OCIRepository;Bucket
+                                    enum:
+                                    - GitRepository
+                                    - OCIRepository
+                                    - Bucket
+                                    - ConfigMap
+                                    - Secret
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referenced resource.
+                                      Name can be expressed as a template and instantiate using any cluster field.
+                                    minLength: 1
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace of the referenced resource.
+                                      For ClusterProfile namespace can be left empty. In such a case, namespace will
+                                      be implicit set to cluster's namespace.
+                                      For Profile namespace must be left empty. Profile namespace will be used.
+                                      Namespace can be expressed as a template and instantiate using any cluster field.
+                                    type: string
+                                  optional:
+                                    default: false
+                                    description: |-
+                                      Optional indicates that the referenced resource is not mandatory.
+                                      If set to true and the resource is not found, the error will be ignored,
+                                      and Sveltos will continue processing other PolicyRefs.
+                                    type: boolean
+                                  path:
+                                    description: |-
+                                      Path to the directory containing the YAML files.
+                                      Defaults to 'None', which translates to the root path of the SourceRef.
+                                      Used only for GitRepository;OCIRepository;Bucket
+                                    type: string
+                                  tier:
+                                    default: 100
+                                    description: |-
+                                      Tier controls the order of deployment for resources coming from different PolicyRefs
+                                      within the same ClusterProfile or Profile.
+                                      When two PolicyRefs attempt to deploy the same resource, the PolicyRef with the lowest
+                                      Tier value takes priority and deploys/updates the resource.
+                                      This priority mechanism is only checked after the parent ClusterProfile has won
+                                      the primary conflict resolution against other ClusterProfiles.
+                                      Higher Tier values represent lower priority. The default Tier value is 100.
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              type: array
                             promotionWindow:
                               description: |-
                                 PromotionWindow defines the recurring time window during which the
@@ -3071,6 +3145,13 @@ spec:
                   description: StageStatus defines the status for a given stage in
                     a progressive deployment.
                   properties:
+                    currentStatusDescription:
+                      description: |-
+                        CurrentStatusDescription provides a high-level description of where the stage is
+                        in its progression (e.g., "Waiting for cluster profiles to be created",
+                        "Waiting for all clusters to be Provisioned", "Running post-deployment health checks").
+                        This helps users understand the current blocking state.
+                      type: string
                     failureMessage:
                       description: FailureMessage reports a detailed error message
                         if a failure occurred.

--- a/test/fv/patch_multiple_resources_test.go
+++ b/test/fv/patch_multiple_resources_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Patch with multiple resources in ConfigMap", func() {
 			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
 
 		// install-flux ConfigMap is created by Makefile. Contains all Flux resources
-		cmNamespace := "default"
+		cmNamespace := defaultNamespace
 		cmName := "install-flux"
 
 		cm := &corev1.ConfigMap{}


### PR DESCRIPTION
This PR enhances the progressive deployment workflow by introducing the optional `PreHealthCheckDeployment` field to the AutoTrigger structure.

This new field allows users to specify a set of resources (via PolicyRef) that the controller must deploy and reconcile after the Delay period has elapsed, and before the PostDelayHealthChecks are run.

This enables crucial mid-stage automation, such as:

1. Deploying a Job to run data migration or pre-flight validation tests.
2. Deploying a temporary service to gather metrics needed for the health checks.
3. Running cleanup or preparation tasks unique to the new stage.

This is an example

```yaml
apiVersion: config.projectsveltos.io/v1beta1
kind: ClusterPromotion
metadata:
  name: test-kyverno-rollout
spec:
  profileSpec:
    syncMode: Continuous
    helmCharts:
    - repositoryURL:      https://kyverno.github.io/kyverno/
      repositoryName:   kyverno
      chartName:        kyverno/kyverno
      chartVersion:     3.5.2
      releaseName:      kyverno-latest
      releaseNamespace: kyverno
      helmChartAction:  Install

  # Stages are processed sequentially to roll out the Kyverno Helm chart.
  stages:
  - name: staging # Stage 1: Staging environment
    clusterSelector:
      matchLabels:
        env: staging # Select all clusters labeled 'env: staging'
    trigger:
      auto:
        delay: 5m # Wait 5 minutes after the Kyverno Helm chart is successfully installed on staging clusters.

        # New: Resources to deploy after the delay but BEFORE running health checks.
        # The controller will deploy this ConfigMap and wait for it to be reconciled 
        # before moving to the PostDelayHealthChecks.
        preHealthCheckDeployment:
        - name: pre-validate-deployment
          namespace: default
          kind: ConfigMap
          
        # Health checks to run after the delay AND after preHealthCheckDeployment resources are ready.
        # This check is specifically waiting for a Job named 'minute-counter' to complete successfully.
        postDelayHealthChecks:
        - name: job-completion-check
          featureID: Resources
          group: "batch"
          version: "v1"
          kind: "Job"
          namespace: default
          name: minute-counter
          script: |
            function evaluate()
              local hs = {healthy = false, message = "Job minute-counter is not yet completed successfully"}

              if obj.status and obj.status.succeeded then
                if obj.status.succeeded >= 1 then
                  -- Check the conditions array for the 'Complete' status
                  if obj.status.conditions then
                    for _, condition in ipairs(obj.status.conditions) do
                      if condition.type == "Complete" and condition.status == "True" then
                        hs.healthy = true
                        hs.message = "Job minute-counter completed successfully"
                        return hs
                      end
                    end
                  end
                end
              end

              return hs
            end

  - name: production # Stage 2: Production environment
    clusterSelector:
      matchLabels:
        env: production # Select all clusters labeled 'env: production'
    trigger:
      auto:
        # After Stage 1 (staging) is successfully completed (including health checks), 
        # the promotion to production will occur, followed by a 5-minute wait.
        delay: 5m
```