### PR TITLE
(feat) Per-Cluster Drift Detection Patches

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -171,7 +171,7 @@ var (
 	GetDriftDetectionManagerLabels                   = getDriftDetectionManagerLabels
 	RemoveDriftDetectionManagerFromManagementCluster = removeDriftDetectionManagerFromManagementCluster
 	GetDriftDetectionNamespaceInMgmtCluster          = getDriftDetectionNamespaceInMgmtCluster
-	GetDriftDetectionManagerPatches                  = getDriftDetectionManagerPatches
+	GetGlobalDriftDetectionManagerPatches            = getGlobalDriftDetectionManagerPatches
 )
 
 var (

--- a/controllers/resourcesummary_test.go
+++ b/controllers/resourcesummary_test.go
@@ -155,7 +155,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		}, timeout, pollingInterval).Should(BeTrue())
 	})
 
-	It("getSveltosAgentPatches reads old post render patches from ConfigMap", func() {
+	It("getGlobalDriftDetectionManagerPatches reads old post render patches from ConfigMap", func() {
 		cmYAML := `apiVersion: v1
 data:
   deployment-patch: |-
@@ -189,7 +189,7 @@ metadata:
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		controllers.SetDriftdetectionConfigMap("drift-detection-config-old")
-		patches, err := controllers.GetDriftDetectionManagerPatches(context.TODO(), c, logger)
+		patches, err := controllers.GetGlobalDriftDetectionManagerPatches(context.TODO(), c, logger)
 		Expect(err).To(BeNil())
 		Expect(len(patches)).To(Equal(1))
 		controllers.SetDriftdetectionConfigMap("")
@@ -240,7 +240,7 @@ metadata:
 		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(initObjects...).Build()
 
 		controllers.SetDriftdetectionConfigMap("drift-detection-config")
-		patches, err := controllers.GetDriftDetectionManagerPatches(context.TODO(), c, logger)
+		patches, err := controllers.GetGlobalDriftDetectionManagerPatches(context.TODO(), c, logger)
 		Expect(err).To(BeNil())
 		Expect(len(patches)).To(Equal(2))
 		controllers.SetDriftdetectionConfigMap("")


### PR DESCRIPTION
This update introduces the ability to apply unique configuration patches to the drift detection deployment for individual managed clusters.

Sveltos deploys a drift detection agent in every managed cluster that has a matching ClusterProfile set to ContinuousWithDriftDetection. While patching the default configuration was supported, the same patch was applied uniformly across all managed clusters.

This enhancement addresses scenarios requiring cluster-specific configuration overrides. For example, a cluster located in a specific geographic region might need to pull the drift detection image from a different private container registry than a cluster in another region.

Managed clusters can now define the `driftdetection.projectsveltos.io/config-override-ref` annotation to reference a ConfigMap containing the desired patches.

The ConfigMap reference supports the following formats:

1. `<namespace>/<name>`: Explicitly specifies the namespace and name of the ConfigMap.
2. `<name> (or /<name>)`: Assumes the ConfigMap is in the same namespace as the annotated Cluster instance.

As with global override, the configuration data within the ConfigMap must be a patch of one of the following types:
1. Strategic Merge Patch
2. JSON Patch (RFC6902)