### PR TITLE
(bug) fix delete stuck in pullmode

### DIFF
--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -640,6 +640,9 @@ func (r *ClusterSummaryReconciler) proceesAgentDeploymentStatus(ctx context.Cont
 		}
 		errorMsg := err.Error()
 		clusterSummaryScope.SetFailureMessage(f.id, &errorMsg)
+	} else if pullmode.IsActionNotSetToDeploy(err) {
+		_ = pullmode.TerminateDeploymentTracking(ctx, r.Client, clusterSummary.Spec.ClusterNamespace,
+			clusterSummary.Spec.ClusterName, clusterSummary.Kind, clusterSummary.Name, string(f.id), logger)
 	} else if status.FailureMessage != nil {
 		clusterSummaryScope.SetFailureMessage(f.id, status.FailureMessage)
 	}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.1.1-0.20251203082530-326accb8509d
+	github.com/projectsveltos/libsveltos v1.1.1-0.20251204165035-7be996c61fae
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/cli v29.0.2+incompatible h1:iLuKy2GWOSLXGp8feLYBJQVDv7m/8xoofz6lPq41x6A=
-github.com/docker/cli v29.0.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v29.1.2+incompatible h1:s4QI7drXpIo78OM+CwuthPsO5kCf8cpNsck5PsLVTH8=
 github.com/docker/cli v29.1.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.8.2 h1:bX3YxiGzFP5sOXWc3bTPEXdEaZSeVMrFgOr3T+zrFAo=
@@ -294,8 +292,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.1.1-0.20251203082530-326accb8509d h1:/FSx1qkx/wDGMK2G+aQJhtab+RrIArcislcb95IGMk4=
-github.com/projectsveltos/libsveltos v1.1.1-0.20251203082530-326accb8509d/go.mod h1:NHDtt33ROCIo97eJYG675iC7A2c3y6D4WFEJNzALLIM=
+github.com/projectsveltos/libsveltos v1.1.1-0.20251204165035-7be996c61fae h1:cW7ZiOdT3dI+KIZIdRmbdkYXjUB+BzIEduEdKnrwz8s=
+github.com/projectsveltos/libsveltos v1.1.1-0.20251204165035-7be996c61fae/go.mod h1:m1WELopG734i+7l0SArAIkX16XC2YItmcJ5KeTRbk/I=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250809120506-2b7d4265df58 h1:h1xoUXs0Nihiwlrb4Trj7jpJdHPlEkOoE1L+zBRtJzI=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20250809120506-2b7d4265df58/go.mod h1:E2pgfDai5qVzcXqApq0stJEotw0gON5ibpf6XyRv3qM=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20250809120506-2b7d4265df58 h1:lpEHCcOZj9OkYhlTgvEemzTQ++VJmdEm8ts3WLsfgZM=


### PR DESCRIPTION
When in pull mode, if the profile is deleted (or stops matching a cluster) while it is being deployed, Sveltos remains stuck with addon-controller wanting to delete resources but the corresponding ConfigurationGroup with action set to deploy.

This PR fixes that by deleting the ConfigurationGroup when in that state.

Fixes [51](https://github.com/projectsveltos/sveltos-applier/issues/51)