### PR TITLE
(feat) add takeOwnership

### DIFF
--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -254,6 +254,12 @@ type HelmInstallOptions struct {
 	// +kubebuilder:default:=false
 	// +optional
 	DisableHooks bool `json:"disableHooks,omitempty"`
+
+	// if set, install will ignore the check for helm annotations
+	// and take ownership of the existing resources
+	// +kubebuilder:default:=false
+	// +optional
+	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
 type HelmUpgradeOptions struct {
@@ -317,6 +323,12 @@ type HelmUpgradeOptions struct {
 	// +kubebuilder:default:=false
 	// +optional
 	DisableHooks bool `json:"disableHooks,omitempty"`
+
+	// if set, upgrade will ignore the check for helm annotations
+	// and take ownership of the existing resources
+	// +kubebuilder:default:=false
+	// +optional
+	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
 type HelmUninstallOptions struct {

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -323,6 +323,12 @@ spec:
                               description: Replaces if set indicates to replace an
                                 older release with this one
                               type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, install will ignore the check for helm annotations
+                                and take ownership of the existing resources
+                              type: boolean
                           type: object
                         labels:
                           additionalProperties:
@@ -433,6 +439,12 @@ spec:
                               default: false
                               description: SubNotes determines whether sub-notes are
                                 rendered in the chart.
+                              type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, upgrade will ignore the check for helm annotations
+                                and take ownership of the existing resources
                               type: boolean
                             upgradeCRDs:
                               default: false

--- a/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
@@ -223,6 +223,12 @@ spec:
                                   description: Replaces if set indicates to replace
                                     an older release with this one
                                   type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, install will ignore the check for helm annotations
+                                    and take ownership of the existing resources
+                                  type: boolean
                               type: object
                             labels:
                               additionalProperties:
@@ -334,6 +340,12 @@ spec:
                                   default: false
                                   description: SubNotes determines whether sub-notes
                                     are rendered in the chart.
+                                  type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, upgrade will ignore the check for helm annotations
+                                    and take ownership of the existing resources
                                   type: boolean
                                 upgradeCRDs:
                                   default: false

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -360,6 +360,12 @@ spec:
                                   description: Replaces if set indicates to replace
                                     an older release with this one
                                   type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, install will ignore the check for helm annotations
+                                    and take ownership of the existing resources
+                                  type: boolean
                               type: object
                             labels:
                               additionalProperties:
@@ -471,6 +477,12 @@ spec:
                                   default: false
                                   description: SubNotes determines whether sub-notes
                                     are rendered in the chart.
+                                  type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, upgrade will ignore the check for helm annotations
+                                    and take ownership of the existing resources
                                   type: boolean
                                 upgradeCRDs:
                                   default: false

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -323,6 +323,12 @@ spec:
                               description: Replaces if set indicates to replace an
                                 older release with this one
                               type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, install will ignore the check for helm annotations
+                                and take ownership of the existing resources
+                              type: boolean
                           type: object
                         labels:
                           additionalProperties:
@@ -433,6 +439,12 @@ spec:
                               default: false
                               description: SubNotes determines whether sub-notes are
                                 rendered in the chart.
+                              type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, upgrade will ignore the check for helm annotations
+                                and take ownership of the existing resources
                               type: boolean
                             upgradeCRDs:
                               default: false

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -3126,6 +3126,18 @@ func getWaitForJobsHelmValue(options *configv1beta1.HelmOptions) bool {
 	return false
 }
 
+func getTakeOwnershipHelmValue(options *configv1beta1.HelmOptions, isUpgrade bool) bool {
+	if options == nil {
+		return false
+	}
+
+	if isUpgrade {
+		return options.UpgradeOptions.TakeOwnership
+	}
+
+	return options.InstallOptions.TakeOwnership
+}
+
 func getCreateNamespaceHelmValue(options *configv1beta1.HelmOptions) bool {
 	if options != nil {
 		return options.InstallOptions.CreateNamespace
@@ -3363,6 +3375,7 @@ func getHelmInstallClient(ctx context.Context, requestedChart *configv1beta1.Hel
 	installClient.Labels = getLabelsValue(requestedChart.Options)
 	installClient.Description = getDescriptionValue(requestedChart.Options)
 	installClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
+	installClient.TakeOwnership = getTakeOwnershipHelmValue(requestedChart.Options, false)
 	if actionConfig.RegistryClient != nil {
 		installClient.SetRegistryClient(actionConfig.RegistryClient)
 	}
@@ -3423,6 +3436,7 @@ func getHelmUpgradeClient(requestedChart *configv1beta1.HelmChart, actionConfig 
 	upgradeClient.PlainHTTP = registryOptions.plainHTTP
 	upgradeClient.CaFile = registryOptions.caPath
 	upgradeClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
+	upgradeClient.TakeOwnership = getTakeOwnershipHelmValue(requestedChart.Options, true)
 
 	if actionConfig.RegistryClient != nil {
 		upgradeClient.SetRegistryClient(actionConfig.RegistryClient)

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -632,6 +632,12 @@ spec:
                               description: Replaces if set indicates to replace an
                                 older release with this one
                               type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, install will ignore the check for helm annotations
+                                and take ownership of the existing resources
+                              type: boolean
                           type: object
                         labels:
                           additionalProperties:
@@ -742,6 +748,12 @@ spec:
                               default: false
                               description: SubNotes determines whether sub-notes are
                                 rendered in the chart.
+                              type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, upgrade will ignore the check for helm annotations
+                                and take ownership of the existing resources
                               type: boolean
                             upgradeCRDs:
                               default: false
@@ -1931,6 +1943,12 @@ spec:
                                   description: Replaces if set indicates to replace
                                     an older release with this one
                                   type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, install will ignore the check for helm annotations
+                                    and take ownership of the existing resources
+                                  type: boolean
                               type: object
                             labels:
                               additionalProperties:
@@ -2042,6 +2060,12 @@ spec:
                                   default: false
                                   description: SubNotes determines whether sub-notes
                                     are rendered in the chart.
+                                  type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, upgrade will ignore the check for helm annotations
+                                    and take ownership of the existing resources
                                   type: boolean
                                 upgradeCRDs:
                                   default: false
@@ -3866,6 +3890,12 @@ spec:
                                   description: Replaces if set indicates to replace
                                     an older release with this one
                                   type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, install will ignore the check for helm annotations
+                                    and take ownership of the existing resources
+                                  type: boolean
                               type: object
                             labels:
                               additionalProperties:
@@ -3977,6 +4007,12 @@ spec:
                                   default: false
                                   description: SubNotes determines whether sub-notes
                                     are rendered in the chart.
+                                  type: boolean
+                                takeOwnership:
+                                  default: false
+                                  description: |-
+                                    if set, upgrade will ignore the check for helm annotations
+                                    and take ownership of the existing resources
                                   type: boolean
                                 upgradeCRDs:
                                   default: false
@@ -5249,6 +5285,12 @@ spec:
                               description: Replaces if set indicates to replace an
                                 older release with this one
                               type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, install will ignore the check for helm annotations
+                                and take ownership of the existing resources
+                              type: boolean
                           type: object
                         labels:
                           additionalProperties:
@@ -5359,6 +5401,12 @@ spec:
                               default: false
                               description: SubNotes determines whether sub-notes are
                                 rendered in the chart.
+                              type: boolean
+                            takeOwnership:
+                              default: false
+                              description: |-
+                                if set, upgrade will ignore the check for helm annotations
+                                and take ownership of the existing resources
                               type: boolean
                             upgradeCRDs:
                               default: false

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:036caed08715f4636080721d5009388aa65d71e8a617be45ca8178ebd838d0c2
+        image: docker.io/projectsveltos/sveltos-applier@sha256:939d489585c1bb3c4e9770f125c4416166a516a3af289816e8f333e0fa42f7fb
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
This PR introduces the `TakeOwnership` field to both HelmInstallOptions and HelmUpgradeOptions.

Currently, when Sveltos attempts to deploy a Helm chart, the operation may fail if resources defined in the chart already exist in the target cluster but lack the expected Helm ownership annotations (e.g., meta.helm.sh/release-name). This is standard Helm safety behavior.

By enabling TakeOwnership, Sveltos will instruct the Helm engine to ignore these ownership checks and "adopt" the existing resources into the current release.

Fixes #1546 