### PR TITLE
(chore) improve logs

### DIFF
--- a/controllers/clusterprofile_controller.go
+++ b/controllers/clusterprofile_controller.go
@@ -92,7 +92,7 @@ type ClusterProfileReconciler struct {
 
 func (r *ClusterProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 	// Fecth the ClusterProfile instance
 	clusterProfile := &configv1beta1.ClusterProfile{}
 	if err := r.Get(ctx, req.NamespacedName, clusterProfile); err != nil {
@@ -146,7 +146,7 @@ func (r *ClusterProfileReconciler) reconcileDelete(
 	profileScope *scope.ProfileScope) reconcile.Result {
 
 	logger := profileScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling ClusterProfile delete")
+	logger.V(logs.LogDebug).Info("Reconciling ClusterProfile delete")
 
 	if err := reconcileDeleteCommon(ctx, r.Client, profileScope,
 		configv1beta1.ClusterProfileFinalizer, logger); err != nil {
@@ -155,7 +155,7 @@ func (r *ClusterProfileReconciler) reconcileDelete(
 
 	r.cleanMaps(profileScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile delete success")
+	logger.V(logs.LogDebug).Info("Reconcile delete success")
 	return reconcile.Result{}
 }
 
@@ -164,7 +164,7 @@ func (r *ClusterProfileReconciler) reconcileNormal(
 	profileScope *scope.ProfileScope) reconcile.Result {
 
 	logger := profileScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling ClusterProfile")
+	logger.V(logs.LogDebug).Info("Reconciling ClusterProfile")
 
 	if !controllerutil.ContainsFinalizer(profileScope.Profile, configv1beta1.ClusterProfileFinalizer) {
 		if err := addFinalizer(ctx, profileScope, configv1beta1.ClusterProfileFinalizer); err != nil {
@@ -204,7 +204,7 @@ func (r *ClusterProfileReconciler) reconcileNormal(
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
 	}
 
-	logger.V(logs.LogInfo).Info("Reconcile success")
+	logger.V(logs.LogDebug).Info("Reconcile success")
 	return reconcile.Result{}
 }
 

--- a/controllers/clusterpromotion_controller.go
+++ b/controllers/clusterpromotion_controller.go
@@ -79,7 +79,7 @@ type ClusterPromotionReconciler struct {
 
 func (r *ClusterPromotionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 
 	// Fecth the ClusterPromotion instance
 	clusterPromotion := &configv1beta1.ClusterPromotion{}

--- a/controllers/clusterset_controller.go
+++ b/controllers/clusterset_controller.go
@@ -80,7 +80,7 @@ type ClusterSetReconciler struct {
 
 func (r *ClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 	// Fecth the ClusterSet instance
 	clusterSet := &libsveltosv1beta1.ClusterSet{}
 	if err := r.Get(ctx, req.NamespacedName, clusterSet); err != nil {
@@ -121,11 +121,11 @@ func (r *ClusterSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 func (r *ClusterSetReconciler) reconcileDelete(setScope *scope.SetScope) {
 	logger := setScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Set delete")
+	logger.V(logs.LogDebug).Info("Reconciling Set delete")
 
 	r.cleanMaps(setScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile delete success")
+	logger.V(logs.LogDebug).Info("Reconcile delete success")
 }
 
 func (r *ClusterSetReconciler) reconcileNormal(
@@ -133,7 +133,7 @@ func (r *ClusterSetReconciler) reconcileNormal(
 	setScope *scope.SetScope) reconcile.Result {
 
 	logger := setScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Set")
+	logger.V(logs.LogDebug).Info("Reconciling Set")
 
 	matchingCluster, err := getMatchingClusters(ctx, r.Client, "", setScope.GetSelector(),
 		setScope.GetSpec().ClusterRefs, logger)
@@ -150,7 +150,7 @@ func (r *ClusterSetReconciler) reconcileNormal(
 
 	r.updateMaps(setScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile success")
+	logger.V(logs.LogDebug).Info("Reconcile success")
 	return reconcile.Result{}
 }
 

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -147,7 +147,7 @@ type ClusterSummaryReconciler struct {
 
 func (r *ClusterSummaryReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 
 	// Fecth the clusterSummary instance
 	clusterSummary := &configv1beta1.ClusterSummary{}
@@ -252,7 +252,7 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 	logger logr.Logger,
 ) (reconcile.Result, error) {
 
-	logger.V(logs.LogInfo).Info("Reconciling ClusterSummary delete")
+	logger.V(logs.LogDebug).Info("Reconciling ClusterSummary delete")
 
 	r.updateDeletedInstancs(clusterSummaryScope)
 
@@ -329,7 +329,7 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 	manager := getManager()
 	manager.stopStaleWatchForTemplateResourceRef(ctx, clusterSummaryScope.ClusterSummary, true)
 
-	logger.V(logs.LogInfo).Info("Reconcile delete success")
+	logger.V(logs.LogDebug).Info("Reconcile delete success")
 
 	return reconcile.Result{}, nil
 }
@@ -337,7 +337,7 @@ func (r *ClusterSummaryReconciler) reconcileDelete(
 func (r *ClusterSummaryReconciler) reconcileNormal(ctx context.Context,
 	clusterSummaryScope *scope.ClusterSummaryScope, logger logr.Logger) (reconcile.Result, error) {
 
-	logger.V(logs.LogInfo).Info("Reconciling ClusterSummary")
+	logger.V(logs.LogDebug).Info("Reconciling ClusterSummary")
 
 	if !controllerutil.ContainsFinalizer(clusterSummaryScope.ClusterSummary, configv1beta1.ClusterSummaryFinalizer) {
 		if err := r.addFinalizer(ctx, clusterSummaryScope); err != nil {
@@ -427,7 +427,7 @@ func (r *ClusterSummaryReconciler) proceedDeployingClusterSummary(ctx context.Co
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}, nil
 	}
 
-	logger.V(logs.LogInfo).Info("Reconciling ClusterSummary success")
+	logger.V(logs.LogDebug).Info("Reconciling ClusterSummary success")
 
 	if clusterSummaryScope.IsDryRunSync() {
 		r.resetFeatureStatusToProvisioning(clusterSummaryScope)

--- a/controllers/profile_controller.go
+++ b/controllers/profile_controller.go
@@ -118,7 +118,7 @@ type ProfileReconciler struct {
 
 func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 
 	// Fecth the Profile instance
 	profile := &configv1beta1.Profile{}
@@ -176,7 +176,7 @@ func (r *ProfileReconciler) reconcileDelete(
 	profileScope *scope.ProfileScope) reconcile.Result {
 
 	logger := profileScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Profile delete")
+	logger.V(logs.LogDebug).Info("Reconciling Profile delete")
 
 	if err := reconcileDeleteCommon(ctx, r.Client, profileScope,
 		configv1beta1.ProfileFinalizer, logger); err != nil {
@@ -185,7 +185,7 @@ func (r *ProfileReconciler) reconcileDelete(
 
 	r.cleanMaps(profileScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile delete success")
+	logger.V(logs.LogDebug).Info("Reconcile delete success")
 	return reconcile.Result{}
 }
 
@@ -194,7 +194,7 @@ func (r *ProfileReconciler) reconcileNormal(
 	profileScope *scope.ProfileScope) reconcile.Result {
 
 	logger := profileScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Profile")
+	logger.V(logs.LogDebug).Info("Reconciling Profile")
 
 	if !controllerutil.ContainsFinalizer(profileScope.Profile, configv1beta1.ProfileFinalizer) {
 		if err := addFinalizer(ctx, profileScope, configv1beta1.ProfileFinalizer); err != nil {
@@ -234,7 +234,7 @@ func (r *ProfileReconciler) reconcileNormal(
 		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
 	}
 
-	logger.V(logs.LogInfo).Info("Reconcile success")
+	logger.V(logs.LogDebug).Info("Reconcile success")
 	return reconcile.Result{}
 }
 

--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -51,13 +51,13 @@ func collectAndProcessResourceSummaries(ctx context.Context, c client.Client, sh
 		clusterList, err := clusterproxy.GetListOfClustersForShardKey(ctx, c, "", getCAPIOnboardAnnotation(),
 			shardkey, logger)
 		if err != nil {
-			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get clusters: %v", err))
+			logger.V(logs.LogInfo).Error(err, "failed to get clusters")
 			continue
 		}
 
 		clustersWithDD, err := getListOfClusterWithDriftDetectionDeployed(ctx, c)
 		if err != nil {
-			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to collect clusters with drift detection: %v", err))
+			logger.V(logs.LogInfo).Error(err, "failed to collect clusters with drift detection")
 			continue
 		}
 
@@ -146,7 +146,7 @@ func collectResourceSummariesFromCluster(ctx context.Context, c client.Client, c
 		var installed bool
 		installed, err = isResourceSummaryInstalled(ctx, clusterClient)
 		if err != nil {
-			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to verify if ResourceSummary is installed %v", err))
+			logger.V(logs.LogInfo).Error(err, "failed to verify if ResourceSummary is installed")
 			return err
 		}
 
@@ -318,7 +318,7 @@ func processResourceSummary(ctx context.Context, clusterClient client.Client,
 		}
 
 		if !clusterSummary.DeletionTimestamp.IsZero() {
-			logger.V(logs.LogInfo).Info("clusterSummary is marked for deletion. Nothing to do.")
+			logger.V(logs.LogDebug).Info("clusterSummary is marked for deletion. Nothing to do.")
 			return nil
 		}
 
@@ -354,7 +354,7 @@ func processResourceSummary(ctx context.Context, clusterClient client.Client,
 
 		err = getManagementClusterClient().Status().Update(ctx, clusterSummary)
 		if err != nil {
-			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to update ClusterSummary status: %v", err))
+			logger.V(logs.LogInfo).Error(err, "failed to update ClusterSummary status")
 			return err
 		}
 		return nil

--- a/controllers/set_controller.go
+++ b/controllers/set_controller.go
@@ -81,7 +81,7 @@ type SetReconciler struct {
 
 func (r *SetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := ctrl.LoggerFrom(ctx)
-	logger.V(logs.LogInfo).Info("Reconciling")
+	logger.V(logs.LogDebug).Info("Reconciling")
 
 	// Fecth the Set instance
 	set := &libsveltosv1beta1.Set{}
@@ -129,11 +129,11 @@ func (r *SetReconciler) reconcileDelete(
 	setScope *scope.SetScope) {
 
 	logger := setScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Set delete")
+	logger.V(logs.LogDebug).Info("Reconciling Set delete")
 
 	r.cleanMaps(setScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile delete success")
+	logger.V(logs.LogDebug).Info("Reconcile delete success")
 }
 
 func (r *SetReconciler) reconcileNormal(
@@ -141,7 +141,7 @@ func (r *SetReconciler) reconcileNormal(
 	setScope *scope.SetScope) reconcile.Result {
 
 	logger := setScope.Logger
-	logger.V(logs.LogInfo).Info("Reconciling Set")
+	logger.V(logs.LogDebug).Info("Reconciling Set")
 
 	// Limit the search of matching cluster to the Set namespace
 	matchingCluster, err := getMatchingClusters(ctx, r.Client, setScope.Set.GetNamespace(),
@@ -159,7 +159,7 @@ func (r *SetReconciler) reconcileNormal(
 
 	r.updateMaps(setScope)
 
-	logger.V(logs.LogInfo).Info("Reconcile success")
+	logger.V(logs.LogDebug).Info("Reconcile success")
 	return reconcile.Result{}
 }
 


### PR DESCRIPTION
Remove some logs from info to debug.
All controllers follw same pattern:
1. One log in Reconciliation
2. Two logs for reconcileDelete
3. Two logs for reconcileNormal

Those logs are moved from Info to Debug for any controller.