### PR TITLE
Implement Randomized Backoff for ClusterSummary Deployment Failures

### DIFF
--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -853,6 +853,17 @@ func (r *ClusterSummaryReconciler) maxNumberOfConsecutiveFailureReached(clusterS
 	return false
 }
 
+func (r *ClusterSummaryReconciler) getMaxConsecutiveFailures(clusterSummaryScope *scope.ClusterSummaryScope) uint {
+	maxVal := uint(0)
+	for i := range clusterSummaryScope.ClusterSummary.Status.FeatureSummaries {
+		fs := clusterSummaryScope.ClusterSummary.Status.FeatureSummaries[i]
+		if fs.ConsecutiveFailures > maxVal {
+			maxVal = fs.ConsecutiveFailures
+		}
+	}
+	return maxVal
+}
+
 func logContentSummary(clusterSummary *configv1beta1.ClusterSummary, fID libsveltosv1beta1.FeatureID, logger logr.Logger) {
 	switch fID {
 	case libsveltosv1beta1.FeatureHelm:


### PR DESCRIPTION
This PR introduces a dynamic, randomized backoff mechanism for ClusterSummary reconciliations. Currently, when a deployment fails, the controller retries using a static normalRequeueAfter interval.

The new logic observes the consecutiveFailures count across all features (Helm, Resources, Kustomize) and scales the requeue interval accordingly.