### PR TITLE
(bug) Fix ClusterSummary delete in pull-mode

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -322,7 +322,9 @@ func undeployHelmCharts(ctx context.Context, c client.Client,
 	if isPullMode {
 		mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
 		if err != nil {
-			return err
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
 		}
 
 		return undeployHelmChartsInPullMode(ctx, c, clusterSummary, mgmtResources, logger)


### PR DESCRIPTION
When in pull-mode, do not fail cleanup if one of the referenced resource does not exist anymore