### PR TITLE
(feat) Add PatchesFrom

### DIFF
--- a/api/v1beta1/clusterpromotion_types.go
+++ b/api/v1beta1/clusterpromotion_types.go
@@ -156,6 +156,15 @@ type ProfileSpec struct {
 	// +optional
 	Patches []libsveltosv1beta1.Patch `json:"patches,omitempty"`
 
+	// PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+	// it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+	// These values can be static or leverage Go templates for dynamic customization.
+	// When expressed as templates, the values are filled in using information from
+	// resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+	// +listType=atomic
+	// +optional
+	PatchesFrom []ValueFrom `json:"patchesFrom,omitempty"`
+
 	// DriftExclusions is a list of configuration drift exclusions to be applied when syncMode is
 	// set to ContinuousWithDriftDetection. Each exclusion specifies JSON6902 paths to ignore
 	// when evaluating drift, optionally targeting specific resources and features.

--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -784,6 +784,15 @@ type Spec struct {
 	// +optional
 	Patches []libsveltosv1beta1.Patch `json:"patches,omitempty"`
 
+	// PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+	// it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+	// These values can be static or leverage Go templates for dynamic customization.
+	// When expressed as templates, the values are filled in using information from
+	// resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+	// +listType=atomic
+	// +optional
+	PatchesFrom []ValueFrom `json:"patchesFrom,omitempty"`
+
 	// DriftExclusions is a list of configuration drift exclusions to be applied when syncMode is
 	// set to ContinuousWithDriftDetection. Each exclusion specifies JSON6902 paths to ignore
 	// when evaluating drift, optionally targeting specific resources and features.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1096,6 +1096,11 @@ func (in *ProfileSpec) DeepCopyInto(out *ProfileSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PatchesFrom != nil {
+		in, out := &in.PatchesFrom, &out.PatchesFrom
+		*out = make([]ValueFrom, len(*in))
+		copy(*out, *in)
+	}
 	if in.DriftExclusions != nil {
 		in, out := &in.DriftExclusions, &out.DriftExclusions
 		*out = make([]apiv1beta1.DriftExclusion, len(*in))
@@ -1221,6 +1226,11 @@ func (in *Spec) DeepCopyInto(out *Spec) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.PatchesFrom != nil {
+		in, out := &in.PatchesFrom, &out.PatchesFrom
+		*out = make([]ValueFrom, len(*in))
+		copy(*out, *in)
 	}
 	if in.DriftExclusions != nil {
 		in, out := &in.DriftExclusions, &out.DriftExclusions

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -888,6 +888,50 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              patchesFrom:
+                description: |-
+                  PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                  it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                  These values can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                items:
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the resource. Supported kinds are:
+                        - ConfigMap/Secret
+                      enum:
+                      - ConfigMap
+                      - Secret
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using any cluster field.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced resource.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        For Profile namespace must be left empty. The Profile namespace will be used.
+                        Namespace can be expressed as a template and instantiate using any cluster field.
+                      type: string
+                    optional:
+                      default: false
+                      description: |-
+                        Optional indicates that the referenced resource is not mandatory.
+                        If set to true and the resource is not found, the error will be ignored,
+                        and Sveltos will continue processing other ValueFroms.
+                      type: boolean
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               policyRefs:
                 description: |-
                   PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources

--- a/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
@@ -789,6 +789,50 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  patchesFrom:
+                    description: |-
+                      PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                      it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                      These values can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                          enum:
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. The Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other ValueFroms.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   policyRefs:
                     description: |-
                       PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -926,6 +926,50 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  patchesFrom:
+                    description: |-
+                      PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                      it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                      These values can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                          enum:
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. The Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other ValueFroms.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   policyRefs:
                     description: |-
                       PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -888,6 +888,50 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              patchesFrom:
+                description: |-
+                  PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                  it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                  These values can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                items:
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the resource. Supported kinds are:
+                        - ConfigMap/Secret
+                      enum:
+                      - ConfigMap
+                      - Secret
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using any cluster field.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced resource.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        For Profile namespace must be left empty. The Profile namespace will be used.
+                        Namespace can be expressed as a template and instantiate using any cluster field.
+                      type: string
+                    optional:
+                      default: false
+                      description: |-
+                        Optional indicates that the referenced resource is not mandatory.
+                        If set to true and the resource is not found, the error will be ignored,
+                        and Sveltos will continue processing other ValueFroms.
+                      type: boolean
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               policyRefs:
                 description: |-
                   PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -68,6 +68,8 @@ var (
 	ConvertResultStatus               = (*ClusterSummaryReconciler).convertResultStatus
 	RequeueClusterSummaryForReference = (*ClusterSummaryReconciler).requeueClusterSummaryForReference
 	RequeueClusterSummaryForCluster   = (*ClusterSummaryReconciler).requeueClusterSummaryForCluster
+
+	GetPatchesFrom = getPatchesFrom
 )
 
 var (
@@ -144,7 +146,7 @@ var (
 	GetHelmChartValuesFrom                   = getHelmChartValuesFrom
 
 	InstantiateTemplateValues = instantiateTemplateValues
-	FecthClusterObjects       = fecthClusterObjects
+	FetchClusterObjects       = fetchClusterObjects
 
 	IsCluterSummaryProvisioned = isCluterSummaryProvisioned
 	IsNamespaced               = isNamespaced

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -494,7 +494,7 @@ func pullModeUndeployResources(ctx context.Context, c client.Client, clusterSumm
 func resourcesHash(ctx context.Context, c client.Client, clusterSummary *configv1beta1.ClusterSummary,
 	logger logr.Logger) ([]byte, error) {
 
-	clusterProfileSpecHash, err := getClusterProfileSpecHash(ctx, clusterSummary)
+	clusterProfileSpecHash, err := getClusterProfileSpecHash(ctx, clusterSummary, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -1263,6 +1263,7 @@ status:
 					},
 				},
 			}
+
 			Expect(testEnv.Create(context.TODO(), depl)).To(Succeed())
 			Expect(waitForObject(context.TODO(), testEnv.Client, depl)).To(Succeed())
 

--- a/controllers/lua_instantiation.go
+++ b/controllers/lua_instantiation.go
@@ -58,7 +58,7 @@ func instantiateWithLuaScript(ctx context.Context, config *rest.Config, c client
 
 	luaCode += script
 
-	objects, err := fecthClusterObjects(ctx, config, c, clusterNamespace, clusterName, clusterType, logger)
+	objects, err := fetchClusterObjects(ctx, config, c, clusterNamespace, clusterName, clusterType, logger)
 	if err != nil {
 		return "", err
 	}

--- a/controllers/template_instantiation.go
+++ b/controllers/template_instantiation.go
@@ -72,10 +72,10 @@ func fetchKubeadmControlPlane(ctx context.Context, cluster *clusterv1.Cluster,
 	return kubeadmControlPlane, err
 }
 
-// fecthClusterObjects fetches resources representing a cluster.
+// fetchClusterObjects fetches resources representing a cluster.
 // All fetched objects are in the management cluster.
 // Currently limited to Cluster and Infrastructure Provider
-func fecthClusterObjects(ctx context.Context, config *rest.Config, c client.Client,
+func fetchClusterObjects(ctx context.Context, config *rest.Config, c client.Client,
 	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
 	logger logr.Logger) (*currentClusterObjects, error) {
 

--- a/controllers/template_instantiation_test.go
+++ b/controllers/template_instantiation_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Template instantiation", func() {
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
 
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -139,7 +139,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -176,7 +176,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -256,7 +256,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -297,7 +297,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -338,7 +338,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -394,7 +394,7 @@ var _ = Describe("Template instantiation", func() {
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -424,7 +424,7 @@ var _ = Describe("Template instantiation", func() {
 	  `
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -476,7 +476,7 @@ valuesTemplate: |
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 
@@ -529,7 +529,7 @@ valuesTemplate: |
 		}
 
 		logger := textlogger.NewLogger(textlogger.NewConfig())
-		objects, err := controllers.FecthClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
+		objects, err := controllers.FetchClusterObjects(ctx, testEnv.Config, testEnv.GetClient(),
 			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType, logger)
 		Expect(err).To(BeNil())
 

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1197,6 +1197,50 @@ spec:
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic
+              patchesFrom:
+                description: |-
+                  PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                  it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                  These values can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                items:
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the resource. Supported kinds are:
+                        - ConfigMap/Secret
+                      enum:
+                      - ConfigMap
+                      - Secret
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using any cluster field.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced resource.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        For Profile namespace must be left empty. The Profile namespace will be used.
+                        Namespace can be expressed as a template and instantiate using any cluster field.
+                      type: string
+                    optional:
+                      default: false
+                      description: |-
+                        Optional indicates that the referenced resource is not mandatory.
+                        If set to true and the resource is not found, the error will be ignored,
+                        and Sveltos will continue processing other ValueFroms.
+                      type: boolean
+                  required:
+                  - kind
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
               policyRefs:
                 description: |-
                   PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
@@ -2506,6 +2550,50 @@ spec:
                           type: object
                       required:
                       - patch
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  patchesFrom:
+                    description: |-
+                      PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                      it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                      These values can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                          enum:
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. The Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other ValueFroms.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
@@ -4456,6 +4544,50 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  patchesFrom:
+                    description: |-
+                      PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                      it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                      These values can be static or leverage Go templates for dynamic customization.
+                      When expressed as templates, the values are filled in using information from
+                      resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                    items:
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the resource. Supported kinds are:
+                            - ConfigMap/Secret
+                          enum:
+                          - ConfigMap
+                          - Secret
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referenced resource.
+                            Name can be expressed as a template and instantiate using any cluster field.
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referenced resource.
+                            For ClusterProfile namespace can be left empty. In such a case, namespace will
+                            be implicit set to cluster's namespace.
+                            For Profile namespace must be left empty. The Profile namespace will be used.
+                            Namespace can be expressed as a template and instantiate using any cluster field.
+                          type: string
+                        optional:
+                          default: false
+                          description: |-
+                            Optional indicates that the referenced resource is not mandatory.
+                            If set to true and the resource is not found, the error will be ignored,
+                            and Sveltos will continue processing other ValueFroms.
+                          type: boolean
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
                   policyRefs:
                     description: |-
                       PolicyRefs references all the ConfigMaps/Secrets/Flux Sources containing kubernetes resources
@@ -5848,6 +5980,50 @@ spec:
                       type: object
                   required:
                   - patch
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              patchesFrom:
+                description: |-
+                  PatchesFrom can reference ConfigMap/Secret instances. Within the ConfigMap or Secret data,
+                  it is possible to store additional Kustomize inline Patches applied for all resources on this profile
+                  These values can be static or leverage Go templates for dynamic customization.
+                  When expressed as templates, the values are filled in using information from
+                  resources within the management cluster before deployment (Cluster and TemplateResourceRefs)
+                items:
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the resource. Supported kinds are:
+                        - ConfigMap/Secret
+                      enum:
+                      - ConfigMap
+                      - Secret
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referenced resource.
+                        Name can be expressed as a template and instantiate using any cluster field.
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referenced resource.
+                        For ClusterProfile namespace can be left empty. In such a case, namespace will
+                        be implicit set to cluster's namespace.
+                        For Profile namespace must be left empty. The Profile namespace will be used.
+                        Namespace can be expressed as a template and instantiate using any cluster field.
+                      type: string
+                    optional:
+                      default: false
+                      description: |-
+                        Optional indicates that the referenced resource is not mandatory.
+                        If set to true and the resource is not found, the error will be ignored,
+                        and Sveltos will continue processing other ValueFroms.
+                      type: boolean
+                  required:
+                  - kind
+                  - name
                   type: object
                 type: array
                 x-kubernetes-list-type: atomic

--- a/test/fv/patchesfrom_test.go
+++ b/test/fv/patchesfrom_test.go
@@ -1,0 +1,422 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/lib/clusterops"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+var _ = Describe("ClusterProfile with PatchFrom", func() {
+	const (
+		namePrefix      = "patchesfrom-"
+		labelsKey       = "deployment-labels"
+		annotationsKey  = "deployment-annotations"
+		tolerationKey   = "deployment-tolerations"
+		serviceLabelKey = "service-labels"
+	)
+
+	var (
+		resourcesTemplate = `apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-service-account
+  namespace: %s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: %s
+  labels:
+    app: nginx
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80         # Port exposed by the service
+      targetPort: 80   # Port the container is listening on
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: %s
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      serviceAccountName: nginx-service-account
+      containers:
+      - name: nginx
+        image: nginx:1.25.3   # Using a specific stable version
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+`
+	)
+
+	It("Deploy resources and patch them using PatchesFrom", Label("NEW-FV", "NEW-FV-PULLMODE", "EXTENDED"), func() {
+		Byf("Create a ClusterProfile matching Cluster %s/%s",
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeContinuous
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		verifyClusterSummary(clusterops.ClusterProfileLabelName, clusterProfile.Name, &clusterProfile.Spec,
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
+
+		key := randomString()
+		value := randomString()
+		tolerationKey := randomString()
+
+		deploymentLabelPatch := fmt.Sprintf(`patch: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: not-important
+    labels:
+      %s: %s
+target:
+  kind: Deployment`, key, value)
+
+		serviceLabelPatch := fmt.Sprintf(`patch: |
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: not-important
+    labels:
+      %s: %s
+target:
+  kind: Service`, key, value)
+
+		deploymentAnnotationPatch := fmt.Sprintf(`patch: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: not-important
+    annotations:
+      %s: %s
+target:
+  kind: Deployment`, key, value)
+
+		deploymentTolerationsPatch := fmt.Sprintf(`patch: |
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: not-important
+  spec:
+    template:
+      spec:
+        tolerations:
+        - key: %s
+          operator: Equal
+          value: example-value
+          effect: NoSchedule
+target:
+  kind: Deployment`, tolerationKey)
+
+		jsonPatchKey := randomString()
+		jsonPatchValue := randomString()
+		deploymentJsonPatch := fmt.Sprintf(`patch: |-
+  - op: add
+    path: /metadata/annotations/%s
+    value: %s
+target:
+  kind: Deployment`, jsonPatchKey, jsonPatchValue)
+
+		configMapPatchesFrom := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: kindWorkloadCluster.GetNamespace(),
+				Name:      fmt.Sprintf("%s-patches", kindWorkloadCluster.GetName()),
+			},
+			Data: map[string]string{
+				labelsKey:       deploymentLabelPatch,
+				tolerationKey:   deploymentTolerationsPatch,
+				serviceLabelKey: serviceLabelPatch,
+			},
+		}
+		Byf("Creating ConfigMap with StrategicMerge %s/%s", configMapPatchesFrom.Namespace, configMapPatchesFrom.Name)
+		Expect(k8sClient.Create(context.TODO(), configMapPatchesFrom)).To(Succeed())
+
+		resourceNamespace := randomString()
+		resources := fmt.Sprintf(resourcesTemplate, resourceNamespace, resourceNamespace, resourceNamespace)
+
+		configMapNs := randomString()
+		Byf("Create configMap's namespace %s", configMapNs)
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: configMapNs,
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), ns)).To(Succeed())
+
+		configMapPolicyRef := createConfigMapWithPolicy(configMapNs, namePrefix+randomString(), resources)
+		Byf("Create a configMap %s/%s with a ServiceAccount/Service/Deployment",
+			configMapPolicyRef.Namespace, configMapPolicyRef.Name)
+		Expect(k8sClient.Create(context.TODO(), configMapPolicyRef)).To(Succeed())
+		currentConfigMap := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: configMapPolicyRef.Namespace, Name: configMapPolicyRef.Name},
+			currentConfigMap)).To(Succeed())
+
+		Byf("Update ClusterProfile to reference ConfigMap %s/%s in PolicyRefs",
+			configMapPolicyRef.Namespace, configMapPolicyRef.Name)
+		Byf("Update ClusterProfile to reference ConfigMap %s/%s in PatchesFrom",
+			configMapPatchesFrom.Namespace, configMapPatchesFrom.Name)
+
+		currentClusterProfile := &configv1beta1.ClusterProfile{}
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Expect(k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+			currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
+				{
+					Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+					Namespace: configMapPolicyRef.Namespace,
+					Name:      configMapPolicyRef.Name,
+				},
+			}
+			currentClusterProfile.Spec.PatchesFrom = []configv1beta1.ValueFrom{
+				{
+					Namespace: "{{ .Cluster.metadata.namespace}}",
+					Name:      "{{ .Cluster.metadata.name}}-patches",
+					Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+				},
+			}
+			return k8sClient.Update(context.TODO(), currentClusterProfile)
+		})
+		Expect(err).To(BeNil())
+
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+
+		clusterSummary := verifyClusterSummary(clusterops.ClusterProfileLabelName,
+			currentClusterProfile.Name, &currentClusterProfile.Spec,
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
+
+		Byf("Getting client to access the workload cluster")
+		workloadClient, err := getKindWorkloadClusterKubeconfig()
+		Expect(err).To(BeNil())
+		Expect(workloadClient).ToNot(BeNil())
+
+		Byf("Verifying Deployment %s/nginx-deployment is created in the workload cluster", resourceNamespace)
+		Eventually(func() error {
+			currentDeployment := &appsv1.Deployment{}
+			return workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+				currentDeployment)
+		}, timeout, pollingInterval).Should(BeNil())
+
+		currentDeployment := &appsv1.Deployment{}
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+			currentDeployment)).To(Succeed())
+
+		Byf("Verifying Deployment %s/nginx-deployment has label %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Labels).ToNot(BeNil())
+		Expect(currentDeployment.Labels[key]).To(Equal(value))
+
+		Byf("Verifying Deployment %s/nginx-deployment does not have annotation %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Annotations).ToNot(BeNil())
+		Expect(currentDeployment.Annotations[key]).To(Equal(""))
+
+		Byf("Verifying Deployment %s/nginx-deployment has toleration %s", resourceNamespace, tolerationKey)
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations).ToNot(BeNil())
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations[0].Key).To(Equal(tolerationKey))
+
+		currentService := &corev1.Service{}
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-service"},
+			currentService)).To(Succeed())
+
+		Byf("Verifying Service %s/nginx-service has label %s:%s", resourceNamespace, key, value)
+		Expect(currentService.Labels).ToNot(BeNil())
+		Expect(currentService.Labels[key]).To(Equal(value))
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Resources feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name, libsveltosv1beta1.FeatureResources)
+
+		Byf("Modyfing ConfigMap %s/%s with patches", configMapPatchesFrom.Namespace, configMapPatchesFrom.Name)
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: configMapPatchesFrom.Namespace, Name: configMapPatchesFrom.Name},
+			currentConfigMap)).To(Succeed())
+
+		currentConfigMap.Data = map[string]string{
+			labelsKey:       deploymentLabelPatch,
+			annotationsKey:  deploymentAnnotationPatch,
+			tolerationKey:   deploymentTolerationsPatch,
+			serviceLabelKey: serviceLabelPatch,
+		}
+		Byf("Updating ConfigMap with StrategicMerge %s/%s", currentConfigMap.Namespace, currentConfigMap.Name)
+		Expect(k8sClient.Update(context.TODO(), currentConfigMap)).To(Succeed())
+
+		Byf("Verifying Deployment %s/nginx-deployment is updated in the workload cluster", resourceNamespace)
+		Eventually(func() bool {
+			currentDeployment := &appsv1.Deployment{}
+			err = workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+				currentDeployment)
+			if err != nil {
+				return false
+			}
+			if len(currentDeployment.Annotations) == 0 {
+				return false
+			}
+			v := currentDeployment.Annotations[key]
+			return v == value
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+			currentDeployment)).To(Succeed())
+
+		Byf("Verifying Deployment %s/nginx-deployment has label %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Labels).ToNot(BeNil())
+		Expect(currentDeployment.Labels[key]).To(Equal(value))
+
+		Byf("Verifying Deployment %s/nginx-deployment has annotation %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Annotations).ToNot(BeNil())
+		Expect(currentDeployment.Annotations[key]).To(Equal(value))
+
+		Byf("Verifying Deployment %s/nginx-deployment has toleration %s", resourceNamespace, tolerationKey)
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations).ToNot(BeNil())
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations[0].Key).To(Equal(tolerationKey))
+
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-service"},
+			currentService)).To(Succeed())
+
+		Byf("Verifying Service %s/nginx-service has label %s:%s", resourceNamespace, key, value)
+		Expect(currentService.Labels).ToNot(BeNil())
+		Expect(currentService.Labels[key]).To(Equal(value))
+
+		configMapJsonPatch := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: kindWorkloadCluster.GetNamespace(),
+				Name:      fmt.Sprintf("%s-jsonpatch", kindWorkloadCluster.GetName()),
+			},
+			Data: map[string]string{
+				randomString(): deploymentJsonPatch,
+			},
+		}
+		Byf("Creating ConfigMap with JsonPatch %s/%s", configMapJsonPatch.Namespace, configMapJsonPatch.Name)
+		Expect(k8sClient.Create(context.TODO(), configMapJsonPatch)).To(Succeed())
+
+		Byf("Update ClusterProfile to also reference ConfigMap %s/%s in PatchesFrom",
+			configMapJsonPatch.Namespace, configMapJsonPatch.Name)
+
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Expect(k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+			currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
+				{
+					Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+					Namespace: configMapPolicyRef.Namespace,
+					Name:      configMapPolicyRef.Name,
+				},
+			}
+			currentClusterProfile.Spec.PatchesFrom = []configv1beta1.ValueFrom{
+				{
+					Namespace: "{{ .Cluster.metadata.namespace}}",
+					Name:      "{{ .Cluster.metadata.name}}-patches",
+					Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+				},
+				{
+					Namespace: "{{ .Cluster.metadata.namespace}}",
+					Name:      "{{ .Cluster.metadata.name}}-jsonpatch",
+					Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+				},
+			}
+			return k8sClient.Update(context.TODO(), currentClusterProfile)
+		})
+		Expect(err).To(BeNil())
+
+		Byf("Verifying Deployment %s/nginx-deployment is updated in the workload cluster", resourceNamespace)
+		Eventually(func() bool {
+			currentDeployment := &appsv1.Deployment{}
+			err = workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+				currentDeployment)
+			if err != nil {
+				return false
+			}
+			if len(currentDeployment.Annotations) == 0 {
+				return false
+			}
+			v := currentDeployment.Annotations[jsonPatchKey]
+			return v == jsonPatchValue
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		Expect(workloadClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: resourceNamespace, Name: "nginx-deployment"},
+			currentDeployment)).To(Succeed())
+
+		Byf("Verifying Deployment %s/nginx-deployment has label %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Labels).ToNot(BeNil())
+		Expect(currentDeployment.Labels[key]).To(Equal(value))
+
+		Byf("Verifying Deployment %s/nginx-deployment has annotation %s:%s", resourceNamespace, key, value)
+		Expect(currentDeployment.Annotations).ToNot(BeNil())
+		Expect(currentDeployment.Annotations[key]).To(Equal(value))
+
+		Byf("Verifying Deployment %s/nginx-deployment has toleration %s", resourceNamespace, tolerationKey)
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations).ToNot(BeNil())
+		Expect(currentDeployment.Spec.Template.Spec.Tolerations[0].Key).To(Equal(tolerationKey))
+
+		deleteClusterProfile(clusterProfile)
+
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: configMapPatchesFrom.Namespace, Name: configMapPatchesFrom.Name},
+			currentConfigMap)).To(Succeed())
+		Expect(k8sClient.Delete(context.TODO(), currentConfigMap))
+
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Namespace: configMapJsonPatch.Namespace, Name: configMapJsonPatch.Name},
+			currentConfigMap)).To(Succeed())
+		Expect(k8sClient.Delete(context.TODO(), currentConfigMap))
+	})
+})


### PR DESCRIPTION
Profiles can now references ConfigMap/Secret instances containing
StrategicMerge or JSON Patch.

The namespace/name of the referenced ConfigMap/Secret can be expressed
as template.

Here is an example of a ClusterProfile Spec using PatchesFrom:

```yaml
    patchesFrom:
    - kind: ConfigMap
      name: '{{ .Cluster.metadata.name}}-patches'
      namespace: '{{ .Cluster.metadata.namespace}}'
      optional: true
    - kind: ConfigMap
      name: '{{ .Cluster.metadata.name}}-jsonpatch'
      namespace: '{{ .Cluster.metadata.namespace}}'
      optional: true
```

and here are the ConfigMap one with StrategicMerge and one with JSON Patch

```yaml
apiVersion: v1
data:
  deployment-labels: |-
    patch: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: not-important
        labels:
          fv-5z5y6jvl78: fv-tawxs7qu93
    target:
      kind: Deployment
  fv-kwoqx4usiv: |-
    patch: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: not-important
      spec:
        template:
          spec:
            tolerations:
            - key: fv-kwoqx4usiv
              operator: Equal
              value: example-value
              effect: NoSchedule
    target:
      kind: Deployment
  service-labels: |-
    patch: |
      apiVersion: v1
      kind: Service
      metadata:
        name: not-important
        labels:
          fv-5z5y6jvl78: fv-tawxs7qu93
    target:
      kind: Service
kind: ConfigMap
metadata:
  name: clusterapi-workload-patches
  namespace: default
```

```yaml
apiVersion: v1
data:
  fv-kukz6aqz2x: |-
    patch: |-
      - op: add
        path: /metadata/annotations/fv-wfkjbenge9
        value: fv-mrxtndu2kx
    target:
      kind: Deployment
kind: ConfigMap
metadata:
  name: clusterapi-workload-jsonpatch
  namespace: default
```

