### PR TITLE
Instantiate ValuesFrom before evaluating hash

### DIFF
--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -579,6 +579,13 @@ type TemplateResourceRef struct {
 	// +kubebuilder:default:=false
 	// +optional
 	Optional bool `json:"optional,omitempty"`
+
+	// IgnoreStatusChanges indicates whether changes to the status of the referenced
+	// resource should be ignored. If set to true, only changes to the spec or
+	// metadata (generation change) will trigger a reconciliation.
+	// +kubebuilder:default:=false
+	// +optional
+	IgnoreStatusChanges bool `json:"ignoreStatusChanges,omitempty"`
 }
 
 type PolicyRef struct {

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -1069,6 +1069,13 @@ spec:
                         Identifier is how the resource will be referred to in the
                         template
                       type: string
+                    ignoreStatusChanges:
+                      default: false
+                      description: |-
+                        IgnoreStatusChanges indicates whether changes to the status of the referenced
+                        resource should be ignored. If set to true, only changes to the spec or
+                        metadata (generation change) will trigger a reconciliation.
+                      type: boolean
                     optional:
                       default: false
                       description: |-

--- a/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
@@ -962,6 +962,13 @@ spec:
                             Identifier is how the resource will be referred to in the
                             template
                           type: string
+                        ignoreStatusChanges:
+                          default: false
+                          description: |-
+                            IgnoreStatusChanges indicates whether changes to the status of the referenced
+                            resource should be ignored. If set to true, only changes to the spec or
+                            metadata (generation change) will trigger a reconciliation.
+                          type: boolean
                         optional:
                           default: false
                           description: |-

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -1107,6 +1107,13 @@ spec:
                             Identifier is how the resource will be referred to in the
                             template
                           type: string
+                        ignoreStatusChanges:
+                          default: false
+                          description: |-
+                            IgnoreStatusChanges indicates whether changes to the status of the referenced
+                            resource should be ignored. If set to true, only changes to the spec or
+                            metadata (generation change) will trigger a reconciliation.
+                          type: boolean
                         optional:
                           default: false
                           description: |-

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -1069,6 +1069,13 @@ spec:
                         Identifier is how the resource will be referred to in the
                         template
                       type: string
+                    ignoreStatusChanges:
+                      default: false
+                      description: |-
+                        IgnoreStatusChanges indicates whether changes to the status of the referenced
+                        resource should be ignored. If set to true, only changes to the spec or
+                        metadata (generation change) will trigger a reconciliation.
+                      type: boolean
                     optional:
                       default: false
                       description: |-

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -517,7 +517,10 @@ func (r *ClusterSummaryReconciler) proceedDeployingClusterSummary(ctx context.Co
 // SetupWithManager sets up the controller with the Manager.
 func (r *ClusterSummaryReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
-		For(&configv1beta1.ClusterSummary{}, builder.WithPredicates(ClusterSummaryPredicate{Logger: r.Logger.WithName("clusterSummaryPredicate")})).
+		For(&configv1beta1.ClusterSummary{},
+			builder.WithPredicates(
+				ClusterSummaryPredicate{Logger: r.Logger.WithName("clusterSummaryPredicate")}),
+		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.ConcurrentReconciles,
 		}).

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -118,6 +118,7 @@ var (
 	KustomizationHash                 = kustomizationHash
 	GetKustomizeReferenceResourceHash = getKustomizeReferenceResourceHash
 	ExtractTarGz                      = extractTarGz
+	GetHelmChartHash                  = getHelmChartHash
 	//nolint: gocritic // getDataSectionHash is generic and needs instantiation
 	GetStringDataSectionHash = func(aMap map[string]string) string { return getDataSectionHash(aMap) }
 	//nolint: gocritic // getDataSectionHash is generic and needs instantiation
@@ -137,11 +138,11 @@ var (
 	CreateReportForUnmanagedHelmRelease      = createReportForUnmanagedHelmRelease
 	UpdateClusterReportWithHelmReports       = updateClusterReportWithHelmReports
 	HandleCharts                             = handleCharts
-	GetHelmReferenceResourceHash             = getHelmReferenceResourceHash
 	GetHelmChartValuesHash                   = getHelmChartValuesHash
 	GetCredentialsAndCAFiles                 = getCredentialsAndCAFiles
 	GetInstantiatedChart                     = getInstantiatedChart
 	GetHelmChartValuesFrom                   = getHelmChartValuesFrom
+	GetHelmChartInstantiatedValues           = getHelmChartInstantiatedValues
 
 	InstantiateTemplateValues = instantiateTemplateValues
 	FetchClusterObjects       = fetchClusterObjects
@@ -201,4 +202,8 @@ var (
 
 var (
 	SkipUpgrading = skipUpgrading
+)
+
+var (
+	GetSortedKeys = getSortedKeys
 )

--- a/controllers/sort.go
+++ b/controllers/sort.go
@@ -164,3 +164,21 @@ func getSortedDriftExclusions(driftExclusions []libsveltosv1beta1.DriftExclusion
 	sort.Sort(SortedDriftExclusions(sortedDriftExclusions))
 	return sortedDriftExclusions
 }
+
+func getSortedKeys(m interface{}) []string {
+	var keys []string
+	switch v := m.(type) {
+	case map[string]string:
+		keys = make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+	case map[string][]byte:
+		keys = make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -85,6 +85,10 @@ func collectTemplateResourceRefs(ctx context.Context, clusterSummary *configv1be
 			return nil, err
 		}
 
+		if ref.IgnoreStatusChanges {
+			unstructured.RemoveNestedField(u.Object, "status")
+		}
+
 		result[ref.Identifier] = u
 	}
 

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -269,17 +268,11 @@ func getSecretHash(secret *corev1.Secret) string {
 
 // getDataSectionHash sorts map and return the hash
 func getDataSectionHash[T any](data map[string]T) string {
-	var keys []string
-	for k := range data {
-		keys = append(keys, k)
-	}
-
-	// Sort keys (ascending order)
-	sort.Strings(keys)
+	sortedKey := getSortedKeys(data)
 
 	var config string
-	for i := range keys {
-		config += render.AsCode(data[keys[i]])
+	for i := range sortedKey {
+		config += render.AsCode(data[sortedKey[i]])
 	}
 
 	return config

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1378,6 +1378,13 @@ spec:
                         Identifier is how the resource will be referred to in the
                         template
                       type: string
+                    ignoreStatusChanges:
+                      default: false
+                      description: |-
+                        IgnoreStatusChanges indicates whether changes to the status of the referenced
+                        resource should be ignored. If set to true, only changes to the spec or
+                        metadata (generation change) will trigger a reconciliation.
+                      type: boolean
                     optional:
                       default: false
                       description: |-
@@ -2726,6 +2733,13 @@ spec:
                             Identifier is how the resource will be referred to in the
                             template
                           type: string
+                        ignoreStatusChanges:
+                          default: false
+                          description: |-
+                            IgnoreStatusChanges indicates whether changes to the status of the referenced
+                            resource should be ignored. If set to true, only changes to the spec or
+                            metadata (generation change) will trigger a reconciliation.
+                          type: boolean
                         optional:
                           default: false
                           description: |-
@@ -4725,6 +4739,13 @@ spec:
                             Identifier is how the resource will be referred to in the
                             template
                           type: string
+                        ignoreStatusChanges:
+                          default: false
+                          description: |-
+                            IgnoreStatusChanges indicates whether changes to the status of the referenced
+                            resource should be ignored. If set to true, only changes to the spec or
+                            metadata (generation change) will trigger a reconciliation.
+                          type: boolean
                         optional:
                           default: false
                           description: |-
@@ -6164,6 +6185,13 @@ spec:
                         Identifier is how the resource will be referred to in the
                         template
                       type: string
+                    ignoreStatusChanges:
+                      default: false
+                      description: |-
+                        IgnoreStatusChanges indicates whether changes to the status of the referenced
+                        resource should be ignored. If set to true, only changes to the spec or
+                        metadata (generation change) will trigger a reconciliation.
+                      type: boolean
                     optional:
                       default: false
                       description: |-

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -47,7 +47,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:3548dcac021da842cded7c2fa7bd8cee832861d71aac771ab9c82720eb857e54
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:071ca9c6e0b31d7a544ee14d09c5cc12ab2aeae90db37376d824445c3055c6c3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -29,7 +29,7 @@ spec:
         - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:3548dcac021da842cded7c2fa7bd8cee832861d71aac771ab9c82720eb857e54
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:071ca9c6e0b31d7a544ee14d09c5cc12ab2aeae90db37376d824445c3055c6c3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -158,7 +158,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:3548dcac021da842cded7c2fa7bd8cee832861d71aac771ab9c82720eb857e54
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:071ca9c6e0b31d7a544ee14d09c5cc12ab2aeae90db37376d824445c3055c6c3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -140,7 +140,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:3548dcac021da842cded7c2fa7bd8cee832861d71aac771ab9c82720eb857e54
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:071ca9c6e0b31d7a544ee14d09c5cc12ab2aeae90db37376d824445c3055c6c3
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/fv/kustomize_with_configmap_test.go
+++ b/test/fv/kustomize_with_configmap_test.go
@@ -46,6 +46,11 @@ var _ = Describe("Kustomize with ConfigMap", func() {
 		kustomizeConfigMapName = "kustomize"
 	)
 
+	var (
+		labelsValues = `customLabels:
+  %s: "{{ .Cluster.metadata.name }}"`
+	)
+
 	It("Deploy Kustomize resources with ConfigMap", Label("FV", "PULLMODE", "EXTENDED"), func() {
 		Byf("Verifying ConfigMap kustomize exists. It is created by Makefile")
 		kustomizeConfigMap := &corev1.ConfigMap{}

--- a/test/fv/templated_valuesfrom_test.go
+++ b/test/fv/templated_valuesfrom_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/lib/clusterops"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+var _ = Describe("Helm", func() {
+	const (
+		namePrefix = "template-valuesfrom-"
+	)
+
+	var (
+		authMethod = `defaultAuthMethod:
+  allowedNamespaces:
+  - fraud-dev
+  gcp:
+    role: "{{ index .Cluster.metadata.annotations.cluster_vso_role }}"
+    workloadIdentityServiceAccount: "{{ index .Cluster.metadata.annotations.cluster_vso_wif }}"`
+	)
+
+	It("Express ValuesFrom as Template. When instantiated value changes, Sveltos redeploys.",
+		Label("NEW-FV", "NEW-FV-PULLMODE", "EXTENDED"), func() {
+			vsoRoleTagKey := "cluster_vso_role"
+			vsoRoleTagValue := randomString()
+
+			vsoWifTagKey := "cluster_vso_wif"
+			vsoWifTagValue := randomString()
+
+			// Annotation is used to instantiate ConfigMap with labelsValues used in ValuesFrom
+			Byf("Add annotation %s: %s on cluster %s/%s",
+				vsoRoleTagKey, vsoRoleTagValue, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+			setAnnotationOnCluster(vsoRoleTagKey, vsoRoleTagValue)
+
+			// Annotation is used to instantiate ConfigMap with labelsValues used in ValuesFrom
+			Byf("Add annotation %s: %s on cluster %s/%s",
+				vsoWifTagKey, vsoWifTagValue, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+			setAnnotationOnCluster(vsoWifTagKey, vsoWifTagValue)
+
+			namespace := randomString()
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), ns))
+
+			Byf("Creating ConfigMap to hold helm values")
+			authMethodConfigMap := createConfigMapWithPolicy(namespace, fmt.Sprintf("%s-vso-ns-values", kindWorkloadCluster.GetName()),
+				authMethod)
+			authMethodConfigMap.Annotations = map[string]string{
+				libsveltosv1beta1.PolicyTemplateAnnotation: "ok",
+			}
+			Expect(k8sClient.Create(context.TODO(), authMethodConfigMap)).To(Succeed())
+
+			Byf("Create a ClusterProfile matching Cluster %s/%s",
+				kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+			clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+			clusterProfile.Spec.SyncMode = configv1beta1.SyncModeContinuousWithDriftDetection
+			Byf("Update ClusterProfile %s to reference cluster in templateResourceRefs", clusterProfile.Name)
+			clusterProfile.Spec.TemplateResourceRefs = []configv1beta1.TemplateResourceRef{
+				{
+					Resource: corev1.ObjectReference{
+						Kind:       kindWorkloadCluster.GetKind(),
+						APIVersion: kindWorkloadCluster.GetAPIVersion(),
+						Name:       "{{ .Cluster.metadata.name }}",
+						Namespace:  "{{ .Cluster.metadata.namespace }}",
+					},
+					IgnoreStatusChanges: true,
+				},
+			}
+			clusterProfile.Spec.HelmCharts = []configv1beta1.HelmChart{
+				{
+					ChartName:        "hashicorp/vault-secrets-operator",
+					ChartVersion:     "1.2.0",
+					ReleaseName:      "vso",
+					ReleaseNamespace: randomString(),
+					RepositoryName:   "hashicorp",
+					RepositoryURL:    "https://helm.releases.hashicorp.com",
+					ValuesFrom: []configv1beta1.ValueFrom{
+						{
+							Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+							Name:      `{{ .Cluster.metadata.name }}-vso-ns-values`,
+							Namespace: namespace,
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+			verifyClusterProfileMatches(clusterProfile)
+
+			clusterSummary := verifyClusterSummary(clusterops.ClusterProfileLabelName,
+				clusterProfile.Name, &clusterProfile.Spec,
+				kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
+
+			Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+			verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name, libsveltosv1beta1.FeatureHelm)
+
+			// Get Helm Value Hash
+			currentClusterSummary := &configv1beta1.ClusterSummary{}
+			Expect(k8sClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+				currentClusterSummary)).To(Succeed())
+			Expect(len(currentClusterSummary.Status.HelmReleaseSummaries)).To(Equal(1))
+			valueHash := currentClusterSummary.Status.HelmReleaseSummaries[0].ValuesHash
+
+			vsoWifTagValue = randomString()
+			Byf("Update annotation %s: %s on cluster %s/%s",
+				vsoWifTagKey, vsoWifTagValue, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+			setAnnotationOnCluster(vsoWifTagKey, vsoWifTagValue)
+
+			Byf("Verifying Helm Chart is redeployed")
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(),
+					types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+					currentClusterSummary)
+				if err != nil {
+					return false
+				}
+				if len(currentClusterSummary.Status.HelmReleaseSummaries) != 1 {
+					return false
+				}
+				return !reflect.DeepEqual(currentClusterSummary.Status.HelmReleaseSummaries[0].ValuesHash,
+					valueHash)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+			verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name, libsveltosv1beta1.FeatureHelm)
+
+			deleteClusterProfile(clusterProfile)
+
+			currentNs := &corev1.Namespace{}
+			Expect(k8sClient.Get(context.TODO(), types.NamespacedName{Name: namespace}, currentNs)).To(Succeed())
+			Expect(k8sClient.Delete(context.TODO(), currentNs)).To(Succeed())
+		})
+})

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -83,7 +83,7 @@ spec:
         - --cluster-type=sveltos
         - --secret-with-kubeconfig=clusterapi-workload-sveltos-kubeconfig
         - --v=5
-        - --version=v1.4.0
+        - --version=main
         command:
         - /manager
         env:
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier:v1.4.0
+        image: docker.io/projectsveltos/sveltos-applier@sha256:63f1b91a85a285d07e220fd083d10eb38aff976516a486becd9842a34fbef50a
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Ensures valuesFrom resources are fully instantiated/templated before calculating the hash used for change detection.

When a Helm chart utilizes valuesFrom (referencing a ConfigMap or Secret) and those resources contain Sveltos templates, Sveltos was previously calculating the hash based on the raw resource content rather than the instantiated content.

**Example Scenario**: A ConfigMap is used in valuesFrom with template annotations:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-values
  annotations:
    projectsveltos.io/template: ok
data:
  values.yaml: |-
    role: "{{ index .Cluster.metadata.annotations.role }}"
```

If the Cluster annotation `role` changed, the ConfigMap content itself remained the same (the template string didn't change), causing Sveltos to erroneously conclude that the Helm values were unchanged. Consequently, the Helm release was not updated to reflect the new metadata.

This was visible in the ClusterSummary Status.HelmReleaseSummaries valuesHash not changing:

```yaml
status:
    dependencies: no dependencies
    featureSummaries:
    - featureID: Helm
      hash: kXmMfsd2tNKNIFA6xxnL+aq7XvIgSa4p36IuMpIRGcs=
      lastAppliedTime: "2026-01-21T07:33:42Z"
      status: Provisioned
    helmReleaseSummaries:
    - releaseName: vso
      releaseNamespace: hashicorp
      status: Managing
      valuesHash: jyi3q9pXIPMP4u7VlrPlq2ByKttMEPsuVW8tZQbl0KI=
```

This PR modifies the evaluation logic to:

1. Identify all resources referenced in the valuesFrom section.
2. Instantiate the content of those resources (resolving any templates) if necessary.
3. Evaluate the hash based on the final, instantiated values.

This ensures that any change in the underlying data (like Cluster metadata or referenced Secrets) changing the helm values, correctly triggers a Helm reconciliation.

Fixes #1591 