### PR TITLE
Advance libsveltos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.4.1-0.20260130204733-fe2b5557bc98
+	github.com/projectsveltos/libsveltos v1.4.1-0.20260131124754-dd6ff263bbb9
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -279,8 +279,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.4.1-0.20260130204733-fe2b5557bc98 h1:EWYha0rddaGcVbAgVrAltyBsq4EHkMDaK8zPYzaJZCo=
-github.com/projectsveltos/libsveltos v1.4.1-0.20260130204733-fe2b5557bc98/go.mod h1:Zr20iLkXujukoB9x1zjmYVULonScKUu1d7XIMU3Z5tU=
+github.com/projectsveltos/libsveltos v1.4.1-0.20260131124754-dd6ff263bbb9 h1:5ldqgGt5IAg/HNZlzom6/WCugQfUIRheCdxjwmpq6ds=
+github.com/projectsveltos/libsveltos v1.4.1-0.20260131124754-dd6ff263bbb9/go.mod h1:Zr20iLkXujukoB9x1zjmYVULonScKUu1d7XIMU3Z5tU=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=


### PR DESCRIPTION
If a request for the same key is already in the dirty queue, discard the current result. This prevents the requester from receiving an outdated result when a newer request is already pending.

While logs are not enough to prove it, this is what might have happened in #1596 