### PR TITLE
(feat) Introduce init container

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -6,7 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - image: docker.io/projectsveltos/addon-controller:main
+        name: initialization
       containers:
-      # Change the value of image field below to your controller image URL
       - image: docker.io/projectsveltos/addon-controller:main
         name: controller

--- a/config/default/manager_pull_policy.yaml
+++ b/config/default/manager_pull_policy.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: initialization
+        imagePullPolicy: 
       containers:
       - name: controller
         imagePullPolicy: 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,7 +17,7 @@ spec:
     port: 80
     targetPort: 8443
     name: metrics
-  type: ClusterIP  
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -27,6 +27,8 @@ metadata:
   labels:
     control-plane: addon-controller
 spec:
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       control-plane: addon-controller
@@ -40,20 +42,20 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        # TODO(user): For common cases that do not require escalating privileges
-        # it is recommended to ensure that all your Pods/Containers are restrictive.
-        # More info: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-        # Please uncomment the following code if your project does NOT have to work on old Kubernetes
-        # versions < 1.19 or on vendors versions which do NOT support this field by default (i.e. Openshift < 4.11 ).
-        # seccompProfile:
-        #   type: RuntimeDefault
+      initContainers:
+      - env:
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: controller:latest
+        imagePullPolicy: IfNotPresent
+        name: initialization
       containers:
       - command:
         - /manager
         args:
         - --v=5
         image: controller:latest
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: controller
         ports:
         - containerPort: 8443

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -180,7 +180,7 @@ func (r *ClusterSummaryReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	var isMatch bool
-	isMatch, err = r.isClusterAShardMatch(ctx, clusterSummary, logger)
+	isMatch, err = isClusterAShardMatch(ctx, r.Client, r.ShardKey, clusterSummary, logger)
 	if err != nil {
 		msg := err.Error()
 		logger.Error(err, msg)
@@ -1385,10 +1385,10 @@ func (r *ClusterSummaryReconciler) updateClusterShardPair(ctx context.Context,
 }
 
 // isClusterAShardMatch checks if cluster is matching this addon-controller deployment shard.
-func (r *ClusterSummaryReconciler) isClusterAShardMatch(ctx context.Context,
+func isClusterAShardMatch(ctx context.Context, c client.Client, shardKey string,
 	clusterSummary *configv1beta1.ClusterSummary, logger logr.Logger) (bool, error) {
 
-	cluster, err := clusterproxy.GetCluster(ctx, r.Client, clusterSummary.Spec.ClusterNamespace,
+	cluster, err := clusterproxy.GetCluster(ctx, c, clusterSummary.Spec.ClusterNamespace,
 		clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType)
 	if err != nil {
 		// If Cluster does not exist anymore, make it match any shard
@@ -1400,7 +1400,7 @@ func (r *ClusterSummaryReconciler) isClusterAShardMatch(ctx context.Context,
 		return false, err
 	}
 
-	if !sharding.IsShardAMatch(r.ShardKey, cluster) {
+	if !sharding.IsShardAMatch(shardKey, cluster) {
 		logger.V(logs.LogDebug).Info("not a shard match")
 		return false, nil
 	}

--- a/controllers/init_container_work.go
+++ b/controllers/init_container_work.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+)
+
+func Initialization(ctx context.Context, config *rest.Config,
+	scheme *runtime.Scheme, shardKey string, logger logr.Logger) {
+
+	logger.V(logs.LogInfo).Info("perform init work")
+	directClient, err := client.New(config, client.Options{Scheme: scheme})
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to get client")
+		return
+	}
+
+	updateHelmHashes(ctx, directClient, shardKey, logger)
+}
+
+func updateHelmHashes(ctx context.Context, directClient client.Client,
+	shardKey string, logger logr.Logger) {
+
+	clusterSummaries := &configv1beta1.ClusterSummaryList{}
+	for {
+		err := directClient.List(ctx, clusterSummaries)
+		if err == nil {
+			break
+		}
+
+		logger.V(logs.LogInfo).Error(err, "failed to get clusterSummary instances, retrying...")
+
+		select {
+		case <-ctx.Done():
+			logger.Info("stopping updateHelmHashes: context canceled during retry")
+			return
+		case <-time.After(time.Second):
+			continue
+		}
+	}
+
+	for i := range clusterSummaries.Items {
+		cs := &clusterSummaries.Items[i]
+		l := logger.WithValues("clusterSummary", fmt.Sprintf("%s/%s", cs.Namespace, cs.Name))
+		err := updateClusterSummaryHelmHashes(ctx, directClient, shardKey, cs, l)
+		if err != nil {
+			l.V(logs.LogInfo).Error(err, "failed to update helm and helm value hashes")
+		} else {
+			l.V(logs.LogInfo).Info("updated helm and helm value hashes")
+		}
+	}
+}
+
+func updateClusterSummaryHelmHashes(ctx context.Context, directClient client.Client,
+	shardKey string, clusterSummary *configv1beta1.ClusterSummary, logger logr.Logger) error {
+
+	if len(clusterSummary.Spec.ClusterProfileSpec.HelmCharts) == 0 {
+		return nil
+	}
+
+	isMatch, err := isClusterAShardMatch(ctx, directClient, shardKey, clusterSummary, logger)
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to verify is shard is a match")
+		isMatch = true
+	}
+	if !isMatch {
+		return nil
+	}
+
+	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to collect templateResourceRefs")
+		return err
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		currentClusterSummary := &configv1beta1.ClusterSummary{}
+		err := directClient.Get(ctx,
+			types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+			currentClusterSummary)
+		if err != nil {
+			return err
+		}
+
+		helmHash, err := helmHash(ctx, directClient, currentClusterSummary, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Error(err, "failed to get helm configuration hash")
+			return err
+		}
+		setHelmHash(currentClusterSummary, helmHash)
+
+		for i := range currentClusterSummary.Spec.ClusterProfileSpec.HelmCharts {
+			helmChart := &currentClusterSummary.Spec.ClusterProfileSpec.HelmCharts[i]
+			instantiatedChart, err := getInstantiatedChart(ctx, currentClusterSummary, helmChart,
+				mgmtResources, logger)
+			if err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to get instantiated chart")
+				return err
+			}
+			helmChartValueHash, err := getHelmChartValuesHash(ctx, directClient, instantiatedChart,
+				currentClusterSummary, mgmtResources, logger)
+			if err != nil {
+				logger.V(logs.LogInfo).Error(err, "failed to get helm chart value hash")
+				return err
+			}
+			setHelmChartValueHash(currentClusterSummary, instantiatedChart, helmChartValueHash)
+		}
+
+		return directClient.Status().Update(ctx, currentClusterSummary)
+	})
+
+	return err
+}
+
+func setHelmHash(clusterSummary *configv1beta1.ClusterSummary, helmHash []byte) {
+	for i := range clusterSummary.Status.FeatureSummaries {
+		if clusterSummary.Status.FeatureSummaries[i].FeatureID == libsveltosv1beta1.FeatureHelm {
+			clusterSummary.Status.FeatureSummaries[i].Hash = helmHash
+		}
+	}
+}
+
+func setHelmChartValueHash(clusterSummary *configv1beta1.ClusterSummary, helmChart *configv1beta1.HelmChart,
+	helmChartValueHash []byte) {
+
+	for i := range clusterSummary.Status.HelmReleaseSummaries {
+		rs := &clusterSummary.Status.HelmReleaseSummaries[i]
+		if rs.ReleaseName == helmChart.ReleaseName &&
+			rs.ReleaseNamespace == helmChart.ReleaseNamespace {
+
+			rs.ValuesHash = helmChartValueHash
+		}
+	}
+}

--- a/controllers/template_instantiation.go
+++ b/controllers/template_instantiation.go
@@ -79,7 +79,7 @@ func fetchClusterObjects(ctx context.Context, config *rest.Config, c client.Clie
 	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
 	logger logr.Logger) (*currentClusterObjects, error) {
 
-	logger.V(logs.LogInfo).Info(fmt.Sprintf("Fetch cluster %s: %s/%s",
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("Fetch cluster %s: %s/%s",
 		clusterType, clusterNamespace, clusterName))
 
 	genericCluster, err := clusterproxy.GetCluster(ctx, c, clusterNamespace, clusterName, clusterType)

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       control-plane: addon-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -75,6 +77,12 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+      initContainers:
+      - env:
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/addon-controller:main
+        name: initialization
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       control-plane: addon-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -75,6 +77,12 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+      initContainers:
+      - env:
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/addon-controller:main
+        name: initialization
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8002,6 +8002,8 @@ spec:
   selector:
     matchLabels:
       control-plane: addon-controller
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:
@@ -8067,6 +8069,12 @@ spec:
         volumeMounts:
         - mountPath: /tmp
           name: tmp
+      initContainers:
+      - env:
+        - name: IS_INITIALIZATION
+          value: "true"
+        image: docker.io/projectsveltos/addon-controller:main
+        name: initialization
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller


### PR DESCRIPTION
Hash functions have changed since release v1.4.0.
When Sveltos detects a hash change, it triggers a redeployment of the resources listed in the profile (Helm charts or raw Kubernetes resources).

This PR introduces an initialization phase to handle this transition gracefully. By pre-calculating and updating these hashes before the main controller starts, we ensure the controller does not misinterpret the new hashing logic as a configuration change. This prevents unnecessary, redeployments across all managed clusters that would otherwise occur when the controller detects a mismatch between the stored and newly calculated hashes.