### PR TITLE
(bug) Pass argurments to init containers

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -139,6 +139,14 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
+	controllers.SetDriftdetectionConfigMap(driftDetectionConfigMap)
+	controllers.SetLuaConfigMap(luaConfigMap)
+	controllers.SetLuaCallStackSize(luaCallStackSize)
+	controllers.SetLuaRegistrySize(luaRegistrySize)
+	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
+	controllers.SetDriftDetectionRegistry(registry)
+	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
+
 	if isInitContainer() {
 		runInitContainerWork(ctx, restConfig, scheme)
 		os.Exit(0)
@@ -152,13 +160,6 @@ func main() {
 
 	// Setup the context that's going to be used in controllers and for the manager.
 	controllers.SetManagementClusterAccess(mgr.GetClient(), mgr.GetConfig())
-	controllers.SetDriftdetectionConfigMap(driftDetectionConfigMap)
-	controllers.SetLuaConfigMap(luaConfigMap)
-	controllers.SetLuaCallStackSize(luaCallStackSize)
-	controllers.SetLuaRegistrySize(luaRegistrySize)
-	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
-	controllers.SetDriftDetectionRegistry(registry)
-	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
 
 	// Start dependency manager
 	dependencymanager.InitializeManagerInstance(ctx, mgr.GetClient(), autoDeployDependencies, ctrl.Log.WithName("dependency_manager"))

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,12 @@ metadata:
 spec:
   template:
     spec:
+      initContainers:
+      - name: initialization
+        args:
+        - "--report-mode=0"
+        - --shard-key=
+        - "--agent-in-mgmt-cluster=false"
       containers:
       - name: controller
         args:

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -78,7 +78,11 @@ spec:
         - mountPath: /tmp
           name: tmp
       initContainers:
-      - env:
+      - args:
+        - --report-mode=0
+        - --shard-key=
+        - --agent-in-mgmt-cluster=true
+        env:
         - name: IS_INITIALIZATION
           value: "true"
         image: docker.io/projectsveltos/addon-controller:v1.5.0

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -78,7 +78,11 @@ spec:
         - mountPath: /tmp
           name: tmp
       initContainers:
-      - env:
+      - args:
+        - --report-mode=0
+        - --shard-key={{.SHARD}}
+        - --agent-in-mgmt-cluster=false
+        env:
         - name: IS_INITIALIZATION
           value: "true"
         image: docker.io/projectsveltos/addon-controller:v1.5.0

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8070,7 +8070,11 @@ spec:
         - mountPath: /tmp
           name: tmp
       initContainers:
-      - env:
+      - args:
+        - --report-mode=0
+        - --shard-key=
+        - --agent-in-mgmt-cluster=false
+        env:
         - name: IS_INITIALIZATION
           value: "true"
         image: docker.io/projectsveltos/addon-controller:v1.5.0


### PR DESCRIPTION
Some of those arguments are used to evaluate the hash, i.e __agent-in-mgmt-cluster__

__shard-key__ is used to understand which clusters are a match for a given addon-controller instance