### PR TITLE
(bug) Ignore missing resources in templateResourceRefs

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -344,7 +344,9 @@ func undeployHelmCharts(ctx context.Context, c client.Client,
 
 	mgmtResources, err := collectTemplateResourceRefs(ctx, clusterSummary)
 	if err != nil {
-		return err
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	err = undeployHelmChartResources(ctx, c, clusterSummary, kubeconfig, mgmtResources, logger)


### PR DESCRIPTION
When undeploying a Helm chart, the process should no longer fail if resources listed in templateResourceRefs are missing. The system will now skip these errors and proceed with the undeployment.