### PR TITLE
(opt) cache managed cluster DiscoveryClient and RESTMapper

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,7 @@ import (
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -154,8 +155,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		setupLog.Error(err, "unable to get discovery client")
+		os.Exit(1)
+	}
 	// Setup the context that's going to be used in controllers and for the manager.
-	controllers.SetManagementClusterAccess(mgr.GetClient(), mgr.GetConfig())
+	controllers.SetManagementClusterAccess(mgr.GetClient(), mgr.GetConfig(), dc)
 
 	// Start dependency manager
 	dependencymanager.InitializeManagerInstance(ctx, mgr.GetClient(), autoDeployDependencies, ctrl.Log.WithName("dependency_manager"))
@@ -761,7 +767,14 @@ func runInitContainerWork(ctx context.Context, config *rest.Config,
 	if err != nil {
 		return
 	}
-	controllers.SetManagementClusterAccess(directClient, config)
+
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		setupLog.Error(err, "unable to get discovery client")
+		os.Exit(1)
+	}
+
+	controllers.SetManagementClusterAccess(directClient, config, dc)
 	controllers.Initialization(ctx, config, scheme, shardKey,
 		ctrl.Log.WithName("initialization"))
 }

--- a/controllers/clustercache/cluster_cache.go
+++ b/controllers/clustercache/cluster_cache.go
@@ -23,7 +23,10 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/klog/v2/textlogger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util/secret"
@@ -45,6 +48,9 @@ type clusterCache struct {
 	// Keeps cache of rest.Config for existing clusters
 	configs map[corev1.ObjectReference]*rest.Config
 
+	mappers               map[corev1.ObjectReference]*restmapper.DeferredDiscoveryRESTMapper
+	cachedDiscoveryClient map[corev1.ObjectReference]discovery.CachedDiscoveryInterface
+
 	// key: cluster, value: Secret with kubeconfig
 	clusters map[corev1.ObjectReference]*corev1.ObjectReference
 
@@ -60,10 +66,12 @@ func GetManager() *clusterCache {
 		defer lock.Unlock()
 		if managerInstance == nil {
 			managerInstance = &clusterCache{
-				configs:  make(map[corev1.ObjectReference]*rest.Config),
-				clusters: make(map[corev1.ObjectReference]*corev1.ObjectReference),
-				secrets:  make(map[corev1.ObjectReference]*libsveltosset.Set),
-				rwMux:    sync.RWMutex{},
+				configs:               make(map[corev1.ObjectReference]*rest.Config),
+				clusters:              make(map[corev1.ObjectReference]*corev1.ObjectReference),
+				mappers:               make(map[corev1.ObjectReference]*restmapper.DeferredDiscoveryRESTMapper),
+				cachedDiscoveryClient: make(map[corev1.ObjectReference]discovery.CachedDiscoveryInterface),
+				secrets:               make(map[corev1.ObjectReference]*libsveltosset.Set),
+				rwMux:                 sync.RWMutex{},
 			}
 		}
 	}
@@ -89,6 +97,9 @@ func (m *clusterCache) RemoveCluster(clusterNamespace, clusterName string,
 
 	// Do not track this cluster anymore
 	delete(m.clusters, *cluster)
+
+	delete(m.mappers, *cluster)
+	delete(m.cachedDiscoveryClient, *cluster)
 }
 
 // RemoveSecret removes any in-memory data related to secret
@@ -105,6 +116,8 @@ func (m *clusterCache) RemoveSecret(sec *corev1.ObjectReference) {
 	for i := range clusters {
 		delete(m.configs, clusters[i])
 		delete(m.clusters, clusters[i])
+		delete(m.cachedDiscoveryClient, clusters[i])
+		delete(m.mappers, clusters[i])
 	}
 }
 
@@ -144,11 +157,25 @@ func (m *clusterCache) GetKubernetesRestConfig(ctx context.Context, mgmtClient c
 		return nil, err
 	}
 
+	var cachedDiscoveryClient discovery.CachedDiscoveryInterface
+	var mapper *restmapper.DeferredDiscoveryRESTMapper
+	if remoteRestConfig != nil {
+		dc, err := discovery.NewDiscoveryClientForConfig(remoteRestConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		cachedDiscoveryClient = memory.NewMemCacheClient(dc)
+		mapper = restmapper.NewDeferredDiscoveryRESTMapper(cachedDiscoveryClient)
+	}
+
 	secretInfo, err := getSecretObjectReference(ctx, mgmtClient, clusterNamespace, clusterName, clusterType)
 	if err == nil {
 		// Either all internal structures are updated or none is
 		m.configs[*cluster] = remoteRestConfig
 		m.clusters[*cluster] = secretInfo
+		m.cachedDiscoveryClient[*cluster] = cachedDiscoveryClient
+		m.mappers[*cluster] = mapper
 		v, ok := m.secrets[*secretInfo]
 		if !ok {
 			v = &libsveltosset.Set{}
@@ -158,6 +185,101 @@ func (m *clusterCache) GetKubernetesRestConfig(ctx context.Context, mgmtClient c
 	}
 
 	return remoteRestConfig, nil
+}
+
+func (m *clusterCache) GetMapper(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) (*restmapper.DeferredDiscoveryRESTMapper, error) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	// 1. Use a Read Lock to check if it's already cached
+	m.rwMux.RLock()
+	mapper, ok := m.mappers[*cluster]
+	m.rwMux.RUnlock()
+
+	if ok {
+		return mapper, nil
+	}
+
+	// 2. Cache Miss: We need to initialize the config and mapper.
+	// Calling GetKubernetesRestConfig will populate m.mappers via the logic you wrote.
+	logger.V(logs.LogInfo).Info("mapper cache miss, initializing cluster config")
+	_, err := m.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		"", "", clusterType, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cluster config for mapper: %w", err)
+	}
+
+	// 3. Lock again to retrieve the newly created mapper
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	if v, ok := m.mappers[*cluster]; ok {
+		return v, nil
+	}
+
+	return nil, fmt.Errorf("mapper not found for cluster %s/%s after initialization", clusterNamespace, clusterName)
+}
+
+func (m *clusterCache) GetCachedDiscoveryClient(ctx context.Context, mgmtClient client.Client,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) (discovery.CachedDiscoveryInterface, error) {
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+
+	// 1. Thread-safe check for existing cached client
+	m.rwMux.RLock()
+	dc, ok := m.cachedDiscoveryClient[*cluster]
+	m.rwMux.RUnlock()
+
+	if ok {
+		return dc, nil
+	}
+
+	// 2. Cache Miss: Initialize the cluster configuration
+	// This will populate m.cachedDiscoveryClient via GetKubernetesRestConfig
+	logger.V(logs.LogInfo).Info("discovery client cache miss, initializing cluster config")
+	_, err := m.GetKubernetesRestConfig(ctx, mgmtClient, clusterNamespace, clusterName,
+		"", "", clusterType, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize cluster config for discovery client: %w", err)
+	}
+
+	// 3. Retrieve the newly created client
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	if dc, ok := m.cachedDiscoveryClient[*cluster]; ok {
+		return dc, nil
+	}
+
+	return nil, fmt.Errorf("cached discovery client not found for cluster %s/%s after initialization",
+		clusterNamespace, clusterName)
+}
+
+func (m *clusterCache) ResetMapper(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) {
+
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+	if mapper, ok := m.mappers[*cluster]; ok {
+		mapper.Reset()
+	}
+}
+
+func (m *clusterCache) InvalidateDiscoveryClient(clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType) {
+
+	m.rwMux.RLock()
+	defer m.rwMux.RUnlock()
+
+	cluster := getClusterObjectReference(clusterNamespace, clusterName, clusterType)
+	if dc, ok := m.cachedDiscoveryClient[*cluster]; ok {
+		dc.Invalidate()
+	}
 }
 
 func (m *clusterCache) GetKubernetesClient(ctx context.Context, mgmtClient client.Client,

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -80,7 +81,12 @@ var _ = BeforeSuite(func() {
 		panic(err)
 	}
 
-	controllers.SetManagementClusterAccess(testEnv.Client, testEnv.Config)
+	dc, err := discovery.NewDiscoveryClientForConfig(testEnv.Config)
+	if err != nil {
+		panic(err)
+	}
+
+	controllers.SetManagementClusterAccess(testEnv.Client, testEnv.Config, dc)
 	controllers.CreatFeatureHandlerMaps()
 
 	Expect(index.AddDefaultIndexes(ctx, testEnv.Manager)).To(Succeed())

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -65,7 +65,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2/textlogger"
@@ -3649,7 +3648,9 @@ func addExtraMetadata(ctx context.Context, requestedChart *configv1beta1.HelmCha
 
 		// For some helm charts, collectHelmContent returns an empty namespace for namespaced resources
 		// If resource is a namespaced one and namespace is empty, set namespace to release namespace.
-		namespace, err := getResourceNamespace(r, requestedChart.ReleaseNamespace, config)
+		namespace, err := getResourceNamespace(ctx, r, requestedChart.ReleaseNamespace,
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			clusterSummary.Spec.ClusterType, logger)
 		if err != nil {
 			return err
 		}
@@ -3677,10 +3678,14 @@ func addExtraMetadata(ctx context.Context, requestedChart *configv1beta1.HelmCha
 	return nil
 }
 
-func getResourceNamespace(r *unstructured.Unstructured, releaseNamespace string, config *rest.Config) (string, error) {
+func getResourceNamespace(ctx context.Context, r *unstructured.Unstructured, releaseNamespace string,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) (string, error) {
+
 	namespace := r.GetNamespace()
 	if namespace == "" {
-		namespacedResource, err := isNamespaced(r, config)
+		namespacedResource, err := isNamespaced(ctx, r, clusterNamespace, clusterName, clusterType,
+			false, logger)
 		if err != nil {
 			return "", err
 		}

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -52,7 +52,7 @@ var _ = Describe("HandlersHelm", func() {
 	var clusterProfile *configv1beta1.ClusterProfile
 	var clusterSummary *configv1beta1.ClusterSummary
 
-	const defaulNamespace = "default"
+	const defaultNamespace = "default"
 
 	BeforeEach(func() {
 		clusterNamespace := randomString()
@@ -188,8 +188,8 @@ var _ = Describe("HandlersHelm", func() {
 			HelmCharts: []configv1beta1.HelmChart{*calicoChart},
 		}
 
-		clusterSummary.Namespace = defaulNamespace
-		clusterSummary.Spec.ClusterNamespace = defaulNamespace
+		clusterSummary.Namespace = defaultNamespace
+		clusterSummary.Spec.ClusterNamespace = defaultNamespace
 
 		Expect(testEnv.Create(context.TODO(), clusterSummary)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv.Client, clusterSummary)).To(Succeed())
@@ -483,8 +483,8 @@ var _ = Describe("HandlersHelm", func() {
 			HelmChartAction: configv1beta1.HelmChartActionInstall,
 		}
 
-		clusterSummary.Namespace = defaulNamespace
-		clusterSummary.Spec.ClusterNamespace = defaulNamespace
+		clusterSummary.Namespace = defaultNamespace
+		clusterSummary.Spec.ClusterNamespace = defaultNamespace
 
 		cluster := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -524,8 +524,8 @@ var _ = Describe("HandlersHelm", func() {
 {{- else }}23.4.0
 {{- end}}`
 
-		clusterSummary.Namespace = defaulNamespace
-		clusterSummary.Spec.ClusterNamespace = defaulNamespace
+		clusterSummary.Namespace = defaultNamespace
+		clusterSummary.Spec.ClusterNamespace = defaultNamespace
 		clusterSummary.Spec.ClusterType = libsveltosv1beta1.ClusterTypeSveltos
 
 		cluster := &libsveltosv1beta1.SveltosCluster{

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -305,8 +305,12 @@ func deployContent(ctx context.Context, deployingToMgmtCluster bool, destConfig 
 // adjustNamespace fixes namespace.
 // - sets namespace to "default" for namespaced resource with unset namespace
 // - unsets namespace for cluster-wide resources with namespace set
-func adjustNamespace(policy *unstructured.Unstructured, destConfig *rest.Config) error {
-	isResourceNamespaced, err := isNamespaced(policy, destConfig)
+func adjustNamespace(ctx context.Context, policy *unstructured.Unstructured,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	deployingToMgmtCluster bool, logger logr.Logger) error {
+
+	isResourceNamespaced, err := isNamespaced(ctx, policy, clusterNamespace, clusterName, clusterType,
+		deployingToMgmtCluster, logger)
 	if err != nil {
 		return err
 	}
@@ -384,7 +388,8 @@ func deployUnstructured(ctx context.Context, deployingToMgmtCluster bool, destCo
 		errorPrefix := fmt.Sprintf("deploying resource %s %s/%s (deploy to management cluster: %v) failed",
 			policy.GetKind(), policy.GetNamespace(), policy.GetName(), deployingToMgmtCluster)
 
-		err := adjustNamespace(policy, destConfig)
+		err := adjustNamespace(ctx, policy, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			clusterSummary.Spec.ClusterType, deployingToMgmtCluster, logger)
 		if err != nil {
 			if clusterSummary.Spec.ClusterProfileSpec.ContinueOnError {
 				errorMsg += fmt.Sprintf("%v", err)

--- a/controllers/handlers_utils_test.go
+++ b/controllers/handlers_utils_test.go
@@ -43,6 +43,7 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers"
+	"github.com/projectsveltos/addon-controller/controllers/clustercache"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/deployer"
@@ -983,6 +984,37 @@ var _ = Describe("HandlersUtils", func() {
 	})
 
 	It("adjustNamespace adjusts namespace for both namespaced and cluster wide resources", func() {
+		logger := textlogger.NewLogger(textlogger.NewConfig())
+
+		const defaultNamespace = "default"
+		clusterName := randomString()
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: defaultNamespace,
+				Name:      clusterName,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv, cluster)).To(Succeed())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: defaultNamespace,
+				Name:      clusterName + kubeconfigPostfix,
+			},
+			Data: map[string][]byte{
+				"value": testEnv.Kubeconfig,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv, secret)).To(Succeed())
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv, defaultNamespace,
+			clusterName, "", "", libsveltosv1beta1.ClusterTypeCapi, logger)
+		Expect(err).To(BeNil())
+
 		deployment := `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -991,7 +1023,9 @@ metadata:
 		u, err := k8s_utils.GetUnstructured([]byte(deployment))
 		Expect(err).To(BeNil())
 
-		Expect(controllers.AdjustNamespace(u, testEnv.Config)).To(BeNil())
+		Expect(controllers.AdjustNamespace(context.TODO(), u, defaultNamespace, clusterName,
+			libsveltosv1beta1.ClusterTypeCapi, false,
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 		// For namespaced resources if namespace is not set, namespace gets set to default
 		Expect(u.GetNamespace()).To(Equal("default"))
 
@@ -1004,7 +1038,9 @@ metadata:
 		u, err = k8s_utils.GetUnstructured([]byte(clusterIssuer))
 		Expect(err).To(BeNil())
 
-		Expect(controllers.AdjustNamespace(u, testEnv.Config)).To(BeNil())
+		Expect(controllers.AdjustNamespace(context.TODO(), u, defaultNamespace, clusterName,
+			libsveltosv1beta1.ClusterTypeCapi, false,
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeNil())
 		// For cluster wide resources if namespace is set, namespace gets reset
 		Expect(u.GetNamespace()).To(Equal(""))
 	})

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -21,13 +21,19 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
-	managementClusterClient client.Client
-	managementClusterConfig *rest.Config
+	managementClusterClient          client.Client
+	managementClusterConfig          *rest.Config
+	managementClusterMapper          *restmapper.DeferredDiscoveryRESTMapper
+	managementClusterCachedDiscovery discovery.CachedDiscoveryInterface
+
 	driftdetectionConfigMap string
 	luaConfigMap            string
 	capiOnboardAnnotation   string
@@ -37,9 +43,12 @@ var (
 	luaRegistrySize         int
 )
 
-func SetManagementClusterAccess(c client.Client, config *rest.Config) {
+func SetManagementClusterAccess(c client.Client, config *rest.Config, dc *discovery.DiscoveryClient) {
 	managementClusterClient = c
 	managementClusterConfig = config
+
+	managementClusterCachedDiscovery = memory.NewMemCacheClient(dc)
+	managementClusterMapper = restmapper.NewDeferredDiscoveryRESTMapper(managementClusterCachedDiscovery)
 }
 
 func SetDriftdetectionConfigMap(name string) {
@@ -78,6 +87,10 @@ func getManagementClusterClient() client.Client {
 	return managementClusterClient
 }
 
+func getManagementClusterMapper() *restmapper.DeferredDiscoveryRESTMapper {
+	return managementClusterMapper
+}
+
 func getDriftDetectionConfigMap() string {
 	return driftdetectionConfigMap
 }
@@ -104,6 +117,14 @@ func getDriftDetectionRegistry() string {
 
 func getAgentInMgmtCluster() bool {
 	return agentInMgmtCluster
+}
+
+func resetManagementClusterMapper() {
+	managementClusterMapper.Reset()
+}
+
+func invalidateManagementClusterCachedDiscover() {
+	managementClusterCachedDiscovery.Invalidate()
 }
 
 func collectDriftDetectionConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -34,18 +34,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
-	memory "k8s.io/client-go/discovery/cached"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/controllers/clustercache"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/clusterproxy"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
@@ -210,26 +207,70 @@ func isCluterSummaryProvisioned(clusterSumary *configv1beta1.ClusterSummary) boo
 	return true
 }
 
-func isNamespaced(r *unstructured.Unstructured, config *rest.Config) (bool, error) {
-	gvk := schema.GroupVersionKind{
-		Group:   r.GroupVersionKind().Group,
-		Kind:    r.GetKind(),
-		Version: r.GroupVersionKind().Version,
+func isNamespaced(ctx context.Context, r *unstructured.Unstructured, clusterNamespace, clusterName string,
+	clusterType libsveltosv1beta1.ClusterType, deployingToMgmtCluster bool, logger logr.Logger,
+) (bool, error) {
+
+	gvk := r.GroupVersionKind()
+	var mapper *restmapper.DeferredDiscoveryRESTMapper
+	var err error
+	if deployingToMgmtCluster {
+		mapper = getManagementClusterMapper()
+	} else {
+		cacheMgr := clustercache.GetManager()
+		mapper, err = cacheMgr.GetMapper(ctx, getManagementClusterClient(), clusterNamespace,
+			clusterName, clusterType, logger)
+		if err != nil {
+			return false, err
+		}
 	}
 
-	dc, err := discovery.NewDiscoveryClientForConfig(config)
-	if err != nil {
+	// 1. Initial Attempt
+	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err == nil && mapping != nil {
+		return mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
+	}
+
+	// Only retry if the GVK is actually missing.
+	// If it's a timeout or RBAC error, don't bother retrying discovery.
+	if !meta.IsNoMatchError(err) {
 		return false, err
 	}
 
-	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+	// 2. RETRY LOOP: Give it 3 attempts with increasing wait times
+	// Total wait time: 1s + 2s + 3s = 6 seconds.
+	for i := range 3 {
+		// Log that we are attempting a refresh (MGIANLUC style)
+		logger.V(logs.LogInfo).Info(fmt.Sprintf("GVK %s not found, refreshing discovery (attempt %d)", gvk.String(), i+1))
 
-	var mapping *meta.RESTMapping
-	mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return false, err
+		// IMPORTANT: Invalidate the Discovery Client FIRST, then Reset the Mapper
+		if deployingToMgmtCluster {
+			invalidateManagementClusterCachedDiscover()
+			resetManagementClusterMapper()
+		} else {
+			cacheMgr := clustercache.GetManager()
+			cacheMgr.InvalidateDiscoveryClient(clusterNamespace, clusterName, clusterType)
+			cacheMgr.ResetMapper(clusterNamespace, clusterName, clusterType)
+		}
+
+		// Try again after the reset
+		mapping, err = mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+		if err == nil && mapping != nil {
+			return mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
+		}
+
+		// If we still get a "NoMatch" error, wait for API server aggregation
+		if meta.IsNoMatchError(err) {
+			time.Sleep(time.Duration(i+1) * time.Second)
+			continue
+		}
+
+		// If we get a different error during retry, exit early
+		break
 	}
-	return mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
+
+	logger.Error(err, fmt.Sprintf("GVK %s not found after local retries", gvk.String()))
+	return false, fmt.Errorf("GVK %s not found on remote cluster: %w", gvk.String(), err)
 }
 
 // removeDuplicates removes duplicates entries in the references slice

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -42,6 +42,7 @@ import (
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	"github.com/projectsveltos/addon-controller/controllers"
+	"github.com/projectsveltos/addon-controller/controllers/clustercache"
 	"github.com/projectsveltos/addon-controller/lib/clusterops"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
@@ -283,15 +284,47 @@ var _ = Describe("getClusterProfileOwner ", func() {
 	})
 
 	It("isNamespaced returns true for namespaced resources", func() {
+		logger := textlogger.NewLogger(textlogger.NewConfig())
+		clusterNamespace := "default"
+		clusterName := randomString()
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv, cluster)).To(Succeed())
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: clusterNamespace,
+				Name:      clusterName + kubeconfigPostfix,
+			},
+			Data: map[string][]byte{
+				"value": testEnv.Kubeconfig,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv, secret)).To(Succeed())
+
+		cacheMgr := clustercache.GetManager()
+		_, err := cacheMgr.GetKubernetesRestConfig(context.TODO(), testEnv, clusterNamespace,
+			clusterName, "", "", libsveltosv1beta1.ClusterTypeCapi, logger)
+		Expect(err).To(BeNil())
+
 		clusterRole, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(viewClusterRole, randomString())))
 		Expect(err).To(BeNil())
-		isNamespaced, err := controllers.IsNamespaced(clusterRole, testEnv.Config)
+		isNamespaced, err := controllers.IsNamespaced(context.TODO(), clusterRole, clusterNamespace, clusterName,
+			libsveltosv1beta1.ClusterTypeCapi, false, logger)
 		Expect(err).To(BeNil())
 		Expect(isNamespaced).To(BeFalse())
 
 		deployment, err := k8s_utils.GetUnstructured([]byte(fmt.Sprintf(deplTemplate, randomString())))
 		Expect(err).To(BeNil())
-		isNamespaced, err = controllers.IsNamespaced(deployment, testEnv.Config)
+		isNamespaced, err = controllers.IsNamespaced(context.TODO(), deployment, clusterNamespace, clusterName,
+			libsveltosv1beta1.ClusterTypeCapi, false, logger)
 		Expect(err).To(BeNil())
 		Expect(isNamespaced).To(BeTrue())
 	})


### PR DESCRIPTION
Instead of creating a new DiscoveryClient and RESTMapper every time a resource is deployed, do it once and re-use it.

When a "Kind Not Found" (NoMatchError) occurs, code performs a targeted invalidation. We explicitly call Invalidate() on the DiscoveryClient and Reset() on the RESTMapper to force a fresh fetch from the remote cluster, ensuring newly created CRDs are discovered without requiring a controller restart.