### PR TITLE
feat: improve IgnoreStatusChanges by stripping metadata side-effects

### DIFF
--- a/controllers/templateresourcedef_utils.go
+++ b/controllers/templateresourcedef_utils.go
@@ -87,6 +87,10 @@ func collectTemplateResourceRefs(ctx context.Context, clusterSummary *configv1be
 
 		if ref.IgnoreStatusChanges {
 			unstructured.RemoveNestedField(u.Object, "status")
+			// Status update changes resourceVersion and managedFields. Since the goal
+			// is to ignore status changes, implicitly remove those fields
+			unstructured.RemoveNestedField(u.Object, "metadata", "resourceVersion")
+			unstructured.RemoveNestedField(u.Object, "metadata", "managedFields")
 		}
 
 		result[ref.Identifier] = u


### PR DESCRIPTION
When IgnoreStatusChanges is enabled, the intention is to treat the resource as unchanged even if the status subresource is updated. However, Kubernetes updates the resourceVersion and managedFields in the metadata whenever a status change occurs.

This PR ensures that when status changes are ignored, these specific metadata fields are also stripped. This prevents clusterSummary controllers from incorrectly triggering a reconciliation based on metadata noise that originated from a status update.