### PR TITLE
fix: enable ServerSideApply when ForceConflicts is set for Helm v4 compatibility

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -3568,6 +3568,7 @@ func getHelmInstallClient(ctx context.Context, requestedChart *configv1beta1.Hel
 	installClient.Description = getDescriptionValue(requestedChart.Options)
 	installClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
 	installClient.TakeOwnership = getTakeOwnershipHelmValue(requestedChart.Options, false)
+	installClient.ServerSideApply = true
 	installClient.ForceConflicts = true
 	if actionConfig.RegistryClient != nil {
 		installClient.SetRegistryClient(actionConfig.RegistryClient)
@@ -3631,6 +3632,7 @@ func getHelmUpgradeClient(requestedChart *configv1beta1.HelmChart, actionConfig 
 	upgradeClient.CaFile = registryOptions.caPath
 	upgradeClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
 	upgradeClient.TakeOwnership = getTakeOwnershipHelmValue(requestedChart.Options, true)
+	upgradeClient.ServerSideApply = "true"
 	upgradeClient.ForceConflicts = true
 
 	if actionConfig.RegistryClient != nil {


### PR DESCRIPTION
Helm v4 introduced a validation that rejects ForceConflicts = true when ServerSideApply is disabled, returning:

`invalid client update option(s): forceConflicts enabled when serverSideApply disabled`

Both getHelmInstallClient and getHelmUpgradeClient were setting ForceConflicts = true unconditionally without enabling ServerSideApply, causing all Helm chart installs and upgrades to fail when running against Helm v4.

Fix: set ServerSideApply = true alongside ForceConflicts = true in both client builders.