### PR TITLE
fix: reduce flaky test by avoiding redundant Cluster updates

### DIFF
--- a/test/fv/fv_suite_test.go
+++ b/test/fv/fv_suite_test.go
@@ -190,6 +190,13 @@ func verifyCAPICluster() {
 		if currentLabels == nil {
 			currentLabels = make(map[string]string)
 		}
+
+		// Early return only if BOTH conditions are already satisfied
+		val, exists := currentCluster.Labels[key]
+		if exists && val == value && !isTrue(currentCluster.Spec.Paused) {
+			return nil
+		}
+
 		currentLabels[key] = value
 		currentCluster.Labels = currentLabels
 		paused := false
@@ -198,6 +205,10 @@ func verifyCAPICluster() {
 		return k8sClient.Update(context.TODO(), currentCluster)
 	})
 	Expect(err).To(BeNil())
+}
+
+func isTrue(b *bool) bool {
+	return b != nil && *b
 }
 
 func verifySveltosCluster() {

--- a/test/fv/stale_resource_test.go
+++ b/test/fv/stale_resource_test.go
@@ -202,6 +202,14 @@ var _ = Describe("Stale Resources", func() {
 			return false
 		}, timeout, pollingInterval).Should(BeTrue())
 
+		Byf("Verifying Service %s is not created the workload cluster", incorrectServiceName)
+		Consistently(func() bool {
+			currentService := &corev1.Service{}
+			err = workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: configMapNs, Name: incorrectServiceName}, currentService)
+			return err != nil && apierrors.IsNotFound(err)
+		}, time.Minute, pollingInterval).ShouldNot(BeNil())
+
 		for _, serviceName := range []string{service1, service2, service3} {
 			Byf("Verifying Service %s is still in the workload cluster", serviceName)
 			Consistently(func() error {
@@ -210,14 +218,6 @@ var _ = Describe("Stale Resources", func() {
 					types.NamespacedName{Namespace: configMapNs, Name: serviceName}, currentService)
 			}, time.Minute, pollingInterval).Should(BeNil())
 		}
-
-		Byf("Verifying Service %s is not created the workload cluster", incorrectServiceName)
-		Consistently(func() bool {
-			currentService := &corev1.Service{}
-			err = workloadClient.Get(context.TODO(),
-				types.NamespacedName{Namespace: configMapNs, Name: incorrectServiceName}, currentService)
-			return err != nil && apierrors.IsNotFound(err)
-		}, time.Minute, pollingInterval).ShouldNot(BeNil())
 
 		By("Updating ConfigMap to reference also a fourth Service")
 		service4 := randomString()


### PR DESCRIPTION
The suite test was experiencing flakiness due to intermittent Conflict errors. Added an early-return check within the RetryOnConflict loop. The logic now verifies both the label existence/value and the Spec.Paused status before attempting an update.