### PR TITLE
(bug) licence checks

### DIFF
--- a/controllers/clusterpromotion_controller.go
+++ b/controllers/clusterpromotion_controller.go
@@ -172,7 +172,7 @@ func (r *ClusterPromotionReconciler) reconcileNormal(
 
 	isEligible, err := r.verifyStageEligibility(ctx, promotionScope, logger)
 	if err != nil {
-		return reconcile.Result{Requeue: true, RequeueAfter: normalRequeueAfter}
+		return reconcile.Result{Requeue: true, RequeueAfter: licenseRequeueAfter}
 	}
 
 	if !isEligible {

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -79,6 +79,9 @@ const (
 
 	// dryRunRequeueAfter is how long to wait before reconciling a ClusterSummary in DryRun mode
 	dryRunRequeueAfter = 60 * time.Second
+
+	// licenseRequeueAfter is how long to wait before retrying after a license fetch error
+	licenseRequeueAfter = 60 * time.Second
 )
 
 type ReportMode int
@@ -417,7 +420,7 @@ func (r *ClusterSummaryReconciler) reconcileNormal(ctx context.Context,
 
 	if !isEligible {
 		r.updateStatusWithMissingLicenseError(clusterSummaryScope, logger)
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true, RequeueAfter: licenseRequeueAfter}, nil
 	}
 
 	updateMapErrs := r.updateMaps(ctx, clusterSummaryScope, logger)


### PR DESCRIPTION
Previously, if an error occurred while verifying Sveltos License, the code would default to marking the license as Invalid. In the Sveltos reconciliation logic, an "Invalid" status causes the controller to stop processing, requiring manual intervention to restart (create the Secret with valid License and restart addon-controller)

This PR updates the validation logic to retry if any such error happens.

Fixes #1667 