### PR TITLE
(chore): harden initialization container

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -49,6 +49,13 @@ spec:
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: initialization
+        securityContext:
+          seccompProfile:
+            type: RuntimeDefault
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - "ALL"
       containers:
       - command:
         - /manager

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -87,6 +87,13 @@ spec:
           value: "true"
         image: docker.io/projectsveltos/addon-controller:main
         name: initialization
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -87,6 +87,13 @@ spec:
           value: "true"
         image: docker.io/projectsveltos/addon-controller:main
         name: initialization
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -8178,6 +8178,13 @@ spec:
           value: "true"
         image: docker.io/projectsveltos/addon-controller:main
         name: initialization
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
       securityContext:
         runAsNonRoot: true
       serviceAccountName: addon-controller


### PR DESCRIPTION
1. Privilege Escalation: Explicitly set `allowPrivilegeEscalation: false` to prevent the container process from gaining more privileges than its parent.
2. Capabilities Drop: Added `capabilities.drop: ["ALL"]` to strip all default Linux capabilities.

Part of [175](https://github.com/projectsveltos/helm-charts/issues/175)