### PR TITLE
fix(pull-mode): prevent chart version cache poisoning from templated spec

### DIFF
--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -619,23 +619,33 @@ func (m *instance) rebuildRegistrations(ctx context.Context, c client.Client) er
 	return nil
 }
 
-// rebuildChartVersions rebuilds internal structures to identify current helm versions
-// deployed in pull mode clusetrs
-// Relies completely on ClusterSummary.Status
+// rebuildChartVersions rebuilds the in-memory chart version cache used by
+// pull-mode deploys. Source is ClusterConfiguration, not ClusterSummary.
+//
+// ClusterSummary.Spec.ClusterProfileSpec.HelmCharts can hold un-instantiated
+// Go templates (e.g. ChartVersion: "{{ .MgmtResources.config.data.version }}").
+// Reading from there at startup would cache the raw template string and send
+// pull-mode into a permanent "invalid semantic version" loop (upstream issue
+// projectsveltos/addon-controller#1722).
+//
+// ClusterConfiguration.Status, by contrast, is written by the deploy path
+// after templates have been rendered against the management cluster, so the
+// ChartVersion we read here is always the concrete version the agent actually
+// applied.
 func (m *instance) rebuildChartVersions(ctx context.Context, c client.Client) error {
 	// Lock here
 	m.chartMux.Lock()
 	defer m.chartMux.Unlock()
 
-	clusterSummaryList := &configv1beta1.ClusterSummaryList{}
-	err := c.List(ctx, clusterSummaryList)
+	clusterConfigurations := &configv1beta1.ClusterConfigurationList{}
+	err := c.List(ctx, clusterConfigurations)
 	if err != nil {
 		return err
 	}
 
-	for i := range clusterSummaryList.Items {
-		cs := &clusterSummaryList.Items[i]
-		m.addHelmVersions(cs)
+	for i := range clusterConfigurations.Items {
+		cc := &clusterConfigurations.Items[i]
+		m.addHelmVersions(cc)
 	}
 
 	return nil
@@ -676,47 +686,78 @@ func (m *instance) addNonManagers(clusterSummary *configv1beta1.ClusterSummary) 
 	}
 }
 
-// addHelmVersions walks clusterSummary's status and register helm versions for each chart managed
-func (m *instance) addHelmVersions(clusterSummary *configv1beta1.ClusterSummary) {
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-		clusterSummary.Spec.ClusterType)
+// addHelmVersions walks a ClusterConfiguration's status and registers helm
+// versions for each chart managed on the corresponding cluster.
+//
+// The cluster key is derived from ClusterConfiguration labels (name + type)
+// rather than spec fields: ClusterConfiguration has no spec, it is a pure
+// status object keyed by the cluster it belongs to.
+func (m *instance) addHelmVersions(clusterConfiguration *configv1beta1.ClusterConfiguration) {
+	lbls := clusterConfiguration.Labels
+	if lbls == nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no labels",
+			clusterConfiguration.Namespace, clusterConfiguration.Name))
+		return
+	}
 
-	for i := range clusterSummary.Status.HelmReleaseSummaries {
-		summary := &clusterSummary.Status.HelmReleaseSummaries[i]
-		if summary.Status == configv1beta1.HelmChartStatusManaging {
-			chartVersion := m.getVersion(clusterSummary, summary.ReleaseNamespace, summary.ReleaseName)
-			releaseKey := m.GetReleaseKey(summary.ReleaseNamespace, summary.ReleaseName)
-			m.setChartVersion(clusterKey, releaseKey, chartVersion)
-		}
+	clusterName, ok := clusterConfiguration.Labels[configv1beta1.ClusterNameLabel]
+	if !ok {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no %s label",
+			clusterConfiguration.Namespace, clusterConfiguration.Name, configv1beta1.ClusterNameLabel))
+		return
+	}
+
+	var clusterKey string
+
+	rawValueClusterType, ok := clusterConfiguration.Labels[configv1beta1.ClusterTypeLabel]
+	if !ok {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no %s label",
+			clusterConfiguration.Namespace, clusterConfiguration.Name, configv1beta1.ClusterTypeLabel))
+		return
+	}
+
+	var clusterType libsveltosv1beta1.ClusterType
+
+	// Normalize the input to match your defined constants
+	switch {
+	case strings.EqualFold(rawValueClusterType, string(libsveltosv1beta1.ClusterTypeCapi)):
+		clusterType = libsveltosv1beta1.ClusterTypeCapi
+	case strings.EqualFold(rawValueClusterType, string(libsveltosv1beta1.ClusterTypeSveltos)):
+		clusterType = libsveltosv1beta1.ClusterTypeSveltos
+	default:
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s label %s has unknown value %s",
+			clusterConfiguration.Namespace, clusterConfiguration.Name,
+			configv1beta1.ClusterTypeLabel, rawValueClusterType))
+		return
+	}
+
+	clusterKey = m.getClusterKey(clusterConfiguration.Namespace, clusterName, clusterType)
+
+	for i := range clusterConfiguration.Status.ClusterProfileResources {
+		m.walkClusterConfigurationFeature(clusterKey,
+			clusterConfiguration.Status.ClusterProfileResources[i].Features)
+	}
+
+	for i := range clusterConfiguration.Status.ProfileResources {
+		m.walkClusterConfigurationFeature(clusterKey,
+			clusterConfiguration.Status.ProfileResources[i].Features)
 	}
 }
 
-func (m *instance) getVersion(clusterSummary *configv1beta1.ClusterSummary,
-	releaseNamespace, releaseName string) string {
-
-	for i := range clusterSummary.Spec.ClusterProfileSpec.HelmCharts {
-		hc := &clusterSummary.Spec.ClusterProfileSpec.HelmCharts[i]
-		if hc.ReleaseNamespace == releaseNamespace &&
-			hc.ReleaseName == releaseName {
-
-			// Spec holds raw (un-instantiated) template expressions. If ChartVersion
-			// still looks like a Go template, do not cache it: the deploy path will
-			// populate the cache with the instantiated version via RegisterVersionForChart.
-			// Caching the template string would poison the cache and cause a permanent
-			// "invalid semantic version" loop in pull mode.
-			if isTemplatedString(hc.ChartVersion) {
-				return ""
-			}
-			return hc.ChartVersion
-		}
+func (m *instance) walkClusterConfigurationFeature(clusterKey string, features []configv1beta1.Feature) {
+	for i := range features {
+		m.walkClusterConfigurationCharts(clusterKey, features[i])
 	}
-
-	return ""
 }
 
-// isTemplatedString reports whether s contains an un-instantiated Go template
-// action (e.g. "{{ .Foo }}"). Used to avoid caching raw spec values that have
-// not yet been rendered against management-cluster resources.
-func isTemplatedString(s string) bool {
-	return strings.Contains(s, "{{")
+func (m *instance) walkClusterConfigurationCharts(clusterKey string, feature configv1beta1.Feature) {
+	for i := range feature.Charts {
+		chartVersion := feature.Charts[i].ChartVersion
+		releaseKey := m.GetReleaseKey(feature.Charts[i].Namespace,
+			feature.Charts[i].ReleaseName)
+
+		m.logger.V(logs.LogDebug).Info(fmt.Sprintf("cluster %s %s %s %s",
+			clusterKey, feature.Charts[i].Namespace, feature.Charts[i].ReleaseName, chartVersion))
+		m.setChartVersion(clusterKey, releaseKey, chartVersion)
+	}
 }

--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -699,9 +699,24 @@ func (m *instance) getVersion(clusterSummary *configv1beta1.ClusterSummary,
 		if hc.ReleaseNamespace == releaseNamespace &&
 			hc.ReleaseName == releaseName {
 
+			// Spec holds raw (un-instantiated) template expressions. If ChartVersion
+			// still looks like a Go template, do not cache it: the deploy path will
+			// populate the cache with the instantiated version via RegisterVersionForChart.
+			// Caching the template string would poison the cache and cause a permanent
+			// "invalid semantic version" loop in pull mode.
+			if isTemplatedString(hc.ChartVersion) {
+				return ""
+			}
 			return hc.ChartVersion
 		}
 	}
 
 	return ""
+}
+
+// isTemplatedString reports whether s contains an un-instantiated Go template
+// action (e.g. "{{ .Foo }}"). Used to avoid caching raw spec values that have
+// not yet been rendered against management-cluster resources.
+func isTemplatedString(s string) bool {
+	return strings.Contains(s, "{{")
 }

--- a/controllers/chartmanager/chartmanager_test.go
+++ b/controllers/chartmanager/chartmanager_test.go
@@ -386,6 +386,57 @@ var _ = Describe("Chart manager", func() {
 		Expect(manager.CanManageChart(tmpClusterSummary,
 			&tmpClusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])).To(BeTrue())
 	})
+
+	It("isTemplatedString detects un-instantiated Go templates", func() {
+		Expect(chartmanager.IsTemplatedString("v1.2.3")).To(BeFalse())
+		Expect(chartmanager.IsTemplatedString("")).To(BeFalse())
+		Expect(chartmanager.IsTemplatedString(`{{ (index .MgmtResources "config").data.chartVersion }}`)).To(BeTrue())
+		Expect(chartmanager.IsTemplatedString("prefix-{{ .Foo }}-suffix")).To(BeTrue())
+	})
+
+	It("addHelmVersions skips templated chart versions to prevent cache poisoning", func() {
+		// GetVersionForChart/RegisterVersionForChart key on ClusterTypeSveltos (pull mode),
+		// so match that here to exercise the same key path.
+		clusterSummary.Spec.ClusterType = libsveltosv1beta1.ClusterTypeSveltos
+		// Two charts: one templated (must not be cached), one hardcoded (must be cached)
+		clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ChartVersion =
+			`{{ (index .MgmtResources "config").data.chartVersion }}`
+		// HelmCharts[1].ChartVersion stays "0.17.1" from the fixture
+
+		clusterSummary.Status = configv1beta1.ClusterSummaryStatus{
+			HelmReleaseSummaries: []configv1beta1.HelmChartSummary{
+				{
+					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseName,
+					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseNamespace,
+					Status:           configv1beta1.HelmChartStatusManaging,
+				},
+				{
+					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseName,
+					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseNamespace,
+					Status:           configv1beta1.HelmChartStatusManaging,
+				},
+			},
+		}
+
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), c)
+		Expect(err).To(BeNil())
+
+		chartmanager.AddHelmVersions(manager, clusterSummary)
+
+		// Templated spec must leave cache empty — GetVersionForChart returns "" so
+		// getHelmActionInPullMode falls through to `install`, which later calls
+		// RegisterVersionForChart with the instantiated version.
+		templatedCached := manager.GetVersionForChart(
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0])
+		Expect(templatedCached).To(Equal(""))
+
+		// Hardcoded chart version must still be cached normally.
+		hardcodedCached := manager.GetVersionForChart(
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])
+		Expect(hardcodedCached).To(Equal("0.17.1"))
+	})
 })
 
 func removeSubscriptions(c client.Client, clusterSummary *configv1beta1.ClusterSummary) {

--- a/controllers/chartmanager/chartmanager_test.go
+++ b/controllers/chartmanager/chartmanager_test.go
@@ -387,56 +387,6 @@ var _ = Describe("Chart manager", func() {
 			&tmpClusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])).To(BeTrue())
 	})
 
-	It("isTemplatedString detects un-instantiated Go templates", func() {
-		Expect(chartmanager.IsTemplatedString("v1.2.3")).To(BeFalse())
-		Expect(chartmanager.IsTemplatedString("")).To(BeFalse())
-		Expect(chartmanager.IsTemplatedString(`{{ (index .MgmtResources "config").data.chartVersion }}`)).To(BeTrue())
-		Expect(chartmanager.IsTemplatedString("prefix-{{ .Foo }}-suffix")).To(BeTrue())
-	})
-
-	It("addHelmVersions skips templated chart versions to prevent cache poisoning", func() {
-		// GetVersionForChart/RegisterVersionForChart key on ClusterTypeSveltos (pull mode),
-		// so match that here to exercise the same key path.
-		clusterSummary.Spec.ClusterType = libsveltosv1beta1.ClusterTypeSveltos
-		// Two charts: one templated (must not be cached), one hardcoded (must be cached)
-		clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ChartVersion =
-			`{{ (index .MgmtResources "config").data.chartVersion }}`
-		// HelmCharts[1].ChartVersion stays "0.17.1" from the fixture
-
-		clusterSummary.Status = configv1beta1.ClusterSummaryStatus{
-			HelmReleaseSummaries: []configv1beta1.HelmChartSummary{
-				{
-					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseName,
-					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseNamespace,
-					Status:           configv1beta1.HelmChartStatusManaging,
-				},
-				{
-					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseName,
-					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseNamespace,
-					Status:           configv1beta1.HelmChartStatusManaging,
-				},
-			},
-		}
-
-		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), c)
-		Expect(err).To(BeNil())
-
-		chartmanager.AddHelmVersions(manager, clusterSummary)
-
-		// Templated spec must leave cache empty — GetVersionForChart returns "" so
-		// getHelmActionInPullMode falls through to `install`, which later calls
-		// RegisterVersionForChart with the instantiated version.
-		templatedCached := manager.GetVersionForChart(
-			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0])
-		Expect(templatedCached).To(Equal(""))
-
-		// Hardcoded chart version must still be cached normally.
-		hardcodedCached := manager.GetVersionForChart(
-			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])
-		Expect(hardcodedCached).To(Equal("0.17.1"))
-	})
 })
 
 func removeSubscriptions(c client.Client, clusterSummary *configv1beta1.ClusterSummary) {

--- a/controllers/chartmanager/export_test.go
+++ b/controllers/chartmanager/export_test.go
@@ -20,5 +20,4 @@ var (
 	IsClusterSummaryAlreadyRegistered = isClusterSummaryAlreadyRegistered
 	RebuildRegistrations              = (*instance).rebuildRegistrations
 	AddHelmVersions                   = (*instance).addHelmVersions
-	IsTemplatedString                 = isTemplatedString
 )

--- a/controllers/chartmanager/export_test.go
+++ b/controllers/chartmanager/export_test.go
@@ -19,5 +19,4 @@ package chartmanager
 var (
 	IsClusterSummaryAlreadyRegistered = isClusterSummaryAlreadyRegistered
 	RebuildRegistrations              = (*instance).rebuildRegistrations
-	AddHelmVersions                   = (*instance).addHelmVersions
 )

--- a/controllers/chartmanager/export_test.go
+++ b/controllers/chartmanager/export_test.go
@@ -19,4 +19,6 @@ package chartmanager
 var (
 	IsClusterSummaryAlreadyRegistered = isClusterSummaryAlreadyRegistered
 	RebuildRegistrations              = (*instance).rebuildRegistrations
+	AddHelmVersions                   = (*instance).addHelmVersions
+	IsTemplatedString                 = isTemplatedString
 )

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -137,6 +137,7 @@ var (
 	GetKustomizeSubstituteValues            = getKustomizeSubstituteValues
 	InstantiateResourceWithSubstituteValues = instantiateResourceWithSubstituteValues
 
+	GetHelmActionInPullMode                  = getHelmActionInPullMode
 	HelmHash                                 = helmHash
 	ShouldInstall                            = shouldInstall
 	ShouldUninstall                          = shouldUninstall
@@ -168,6 +169,14 @@ var (
 type (
 	ReleaseInfo       = releaseInfo
 	ReconcileCooldown = reconcileCooldown
+	HelmAction        = helmAction
+)
+
+const (
+	HelmActionInstall   = install
+	HelmActionUpgrade   = upgrade
+	HelmActionDowngrade = downgrade
+	HelmActionUninstall = uninstall
 )
 
 var (

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -5036,12 +5036,22 @@ func getHelmActionInPullMode(ctx context.Context, clusterSummary *configv1beta1.
 
 	currVer, err := semver.NewVersion(currentVersion)
 	if err != nil {
-		return "", err
+		// A poisoned cache (e.g. from a pre-fix controller that cached a raw
+		// template string) must not wedge reconciliation forever. Drop the bad
+		// entry and fall through to install; the deploy path will re-register
+		// the correctly-instantiated version.
+		chartManager.UnregisterVersionForChart(clusterSummary.Spec.ClusterNamespace,
+			clusterSummary.Spec.ClusterName, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName)
+		logr.FromContextOrDiscard(ctx).Info(fmt.Sprintf(
+			"cached version %q for release %s/%s is not a valid semver (%v); clearing cache and treating as install",
+			currentVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err))
+		return install, nil
 	}
 
 	newVer, err := semver.NewVersion(instantiatedChart.ChartVersion)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid semantic version %q for release %s/%s (spec chartVersion): %w",
+			instantiatedChart.ChartVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err)
 	}
 
 	switch {

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -5036,16 +5036,8 @@ func getHelmActionInPullMode(ctx context.Context, clusterSummary *configv1beta1.
 
 	currVer, err := semver.NewVersion(currentVersion)
 	if err != nil {
-		// A poisoned cache (e.g. from a pre-fix controller that cached a raw
-		// template string) must not wedge reconciliation forever. Drop the bad
-		// entry and fall through to install; the deploy path will re-register
-		// the correctly-instantiated version.
-		chartManager.UnregisterVersionForChart(clusterSummary.Spec.ClusterNamespace,
-			clusterSummary.Spec.ClusterName, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName)
-		logr.FromContextOrDiscard(ctx).Info(fmt.Sprintf(
-			"cached version %q for release %s/%s is not a valid semver (%v); clearing cache and treating as install",
-			currentVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err))
-		return install, nil
+		return "", fmt.Errorf("invalid semantic version %q for release %s/%s (cached): %w",
+			currentVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err)
 	}
 
 	newVer, err := semver.NewVersion(instantiatedChart.ChartVersion)

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -1254,7 +1254,110 @@ resources:
 		Expect(len(valuesToInstantiate)).To(Equal(1))
 		Expect(valuesToInstantiate[0]).To(Equal(toInstantiate))
 	})
+
+	It("getHelmActionInPullMode returns install when cache is empty", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.2.3")
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionInstall))
+
+		// Sanity: nothing got registered by the call itself.
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(""))
+	})
+
+	It("getHelmActionInPullMode self-heals when cached version is not valid semver", func() {
+		// Simulate a poisoned cache populated by a pre-fix rebuildChartVersions
+		// that stored a raw template string.
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.20.2")
+		poisoned := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     `{{ (index .MgmtResources "config").data.chartVersion }}`,
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, poisoned)
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(poisoned.ChartVersion))
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionInstall))
+
+		// Self-heal: the poisoned entry must be gone so a subsequent deploy path
+		// can RegisterVersionForChart with a valid value.
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(""))
+	})
+
+	It("getHelmActionInPullMode returns upgrade when spec version is newer", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.20.2")
+		cached := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     "1.19.0",
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cached)
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionUpgrade))
+	})
+
+	It("getHelmActionInPullMode wraps spec semver errors with chart context", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("not-a-version")
+		cached := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     "1.19.0",
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cached)
+
+		_, err = controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring(chart.ReleaseName))
+		Expect(err.Error()).To(ContainSubstring(chart.ReleaseNamespace))
+		Expect(err.Error()).To(ContainSubstring("not-a-version"))
+	})
 })
+
+func newPullModeClusterSummary() *configv1beta1.ClusterSummary {
+	return &configv1beta1.ClusterSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randomString(),
+			Namespace: randomString(),
+		},
+		Spec: configv1beta1.ClusterSummarySpec{
+			ClusterNamespace: randomString(),
+			ClusterName:      randomString(),
+			ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+		},
+	}
+}
+
+func newChart(version string) *configv1beta1.HelmChart {
+	return &configv1beta1.HelmChart{
+		ReleaseName:      randomString(),
+		ReleaseNamespace: randomString(),
+		ChartVersion:     version,
+	}
+}
 
 func verifyFileContent(filePath string, data []byte) {
 	content, err := os.ReadFile(filePath)

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -1312,22 +1312,6 @@ resources:
 		Expect(valuesToInstantiate[0]).To(Equal(toInstantiate))
 	})
 
-	It("getHelmActionInPullMode returns install when cache is empty", func() {
-		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
-		Expect(err).To(BeNil())
-
-		cs := newPullModeClusterSummary()
-		chart := newChart("1.2.3")
-
-		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
-		Expect(err).To(BeNil())
-		Expect(action).To(Equal(controllers.HelmActionInstall))
-
-		// Sanity: nothing got registered by the call itself.
-		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
-			cs.Spec.ClusterName, chart)).To(Equal(""))
-	})
-
 	It("getHelmActionInPullMode self-heals when cached version is not valid semver", func() {
 		// Simulate a poisoned cache populated by a pre-fix rebuildChartVersions
 		// that stored a raw template string.

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -453,6 +453,63 @@ var _ = Describe("HandlersHelm", func() {
 			Equal(chartDeployed[0].ChartVersion))
 	})
 
+	It("updateChartsInClusterConfiguration stores the live release ChartVersion, not the spec version", func() {
+		// chartDeployed is built from currentRelease.ChartVersion (the actually-deployed version),
+		// not from the spec. This test verifies that what lands in ClusterConfiguration reflects
+		// what the cluster actually has, including multi-chart profiles.
+		chartsDeployed := []configv1beta1.Chart{
+			{
+				RepoURL:      "https://prometheus-community.github.io/helm-charts",
+				ReleaseName:  "prometheus",
+				Namespace:    "prometheus",
+				ChartVersion: "26.0.0",
+				AppVersion:   "v3.0.0",
+			},
+			{
+				RepoURL:      "https://grafana-community.github.io/helm-charts",
+				ReleaseName:  "grafana",
+				Namespace:    "grafana",
+				ChartVersion: "11.3.6",
+				AppVersion:   "12.4.2",
+			},
+		}
+
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controllers.GetClusterConfigurationName(clusterSummary.Spec.ClusterName, libsveltosv1beta1.ClusterTypeCapi),
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+			Status: configv1beta1.ClusterConfigurationStatus{
+				ClusterProfileResources: []configv1beta1.ClusterProfileResource{
+					{ClusterProfileName: clusterProfile.Name},
+				},
+			},
+		}
+
+		initObjects := []client.Object{clusterConfiguration}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
+
+		Expect(controllers.UpdateChartsInClusterConfiguration(context.TODO(), c, clusterSummary,
+			chartsDeployed, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
+
+		current := &configv1beta1.ClusterConfiguration{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterConfiguration.Namespace, Name: clusterConfiguration.Name},
+			current)).To(Succeed())
+
+		Expect(current.Status.ClusterProfileResources).To(HaveLen(1))
+		charts := current.Status.ClusterProfileResources[0].Features[0].Charts
+		Expect(charts).To(HaveLen(2))
+
+		for i, expected := range chartsDeployed {
+			Expect(charts[i].ChartVersion).To(Equal(expected.ChartVersion),
+				"chart %s: stored version must match the live release version", expected.ReleaseName)
+			Expect(charts[i].AppVersion).To(Equal(expected.AppVersion))
+			Expect(charts[i].ReleaseName).To(Equal(expected.ReleaseName))
+			Expect(charts[i].RepoURL).To(Equal(expected.RepoURL))
+		}
+	})
+
 	It("createReportForUnmanagedHelmRelease ", func() {
 		helmChart := &configv1beta1.HelmChart{
 			ReleaseName: randomString(), ReleaseNamespace: randomString(),

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -1312,33 +1312,6 @@ resources:
 		Expect(valuesToInstantiate[0]).To(Equal(toInstantiate))
 	})
 
-	It("getHelmActionInPullMode self-heals when cached version is not valid semver", func() {
-		// Simulate a poisoned cache populated by a pre-fix rebuildChartVersions
-		// that stored a raw template string.
-		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
-		Expect(err).To(BeNil())
-
-		cs := newPullModeClusterSummary()
-		chart := newChart("1.20.2")
-		poisoned := &configv1beta1.HelmChart{
-			ReleaseName:      chart.ReleaseName,
-			ReleaseNamespace: chart.ReleaseNamespace,
-			ChartVersion:     `{{ (index .MgmtResources "config").data.chartVersion }}`,
-		}
-		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, poisoned)
-		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
-			cs.Spec.ClusterName, chart)).To(Equal(poisoned.ChartVersion))
-
-		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
-		Expect(err).To(BeNil())
-		Expect(action).To(Equal(controllers.HelmActionInstall))
-
-		// Self-heal: the poisoned entry must be gone so a subsequent deploy path
-		// can RegisterVersionForChart with a valid value.
-		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
-			cs.Spec.ClusterName, chart)).To(Equal(""))
-	})
-
 	It("getHelmActionInPullMode returns upgrade when spec version is newer", func() {
 		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
## Summary

Fixes a persistent `invalid semantic version` failure that affects pull mode ClusterSummaries whose Profile uses a templated `chartVersion`, for example:

```yaml
chartVersion: '{{ (index .MgmtResources "config").data.chartVersion }}'
```

On addon-controller startup, `rebuildChartVersions` (in `controllers/chartmanager/chartmanager.go`) caches each managed chart's current version by reading the raw Spec without rendering the template. The literal `{{ ... }}` string then ends up in `perClusterChartVersionMap`. Every subsequent reconcile calls `getHelmActionInPullMode`, which parses the cached value as semver, fails immediately, and returns the bare `invalid semantic version` error. That error becomes the `failureMessage` on `ClusterSummary.status.featureSummaries` and never clears, because the refresh via `RegisterVersionForChart` only happens after a succesful deploy that this same check is blocking.

Fixing the Profile alone does not help: the cache entry is set at startup, so the only way to clear it without this patch is an addon-controller restart on a non-templated Spec.

## Symptom

```
featureSummaries:
- consecutiveFailures: 87
  failureMessage: invalid semantic version
  featureID: Helm
  status: Failed
```

Paradoxically the corresponding `ConfigurationGroup` reports `status: Provisioned`, because the chart was installed successfully at some earlier point. Only the in-memory cache is stuck.

## Root cause walkthrough

In `controllers/chartmanager/chartmanager.go`, `addHelmVersions` feeds `getVersion` with a ClusterSummary, and `getVersion` returns the raw `HelmCharts[i].ChartVersion` with no call to `getInstantiatedChart`. That is fine for hardcoded versions, but for templated ones the un-rendered string gets cached as the current installed version.

In `controllers/handlers_helm.go`, `getHelmActionInPullMode` then calls `semver.NewVersion(currentVersion)` and returns the parse error verbatim. `prepareChartForAgent` propagates that error, which means `RegisterVersionForChart` (at `handlers_helm.go:1484`) is never reached, so the cache is never overwritten with the correctly instantiated version.

## The fix

1. `chartmanager.getVersion` skips caching when `ChartVersion` still contains a Go template action (`{{`). The cache stays empty for that release, the first reconcile takes the `install` branch, and `RegisterVersionForChart` populates the cache with the rendered value on success. Doing the instantiation directly inside `chartmanager` would be cleaner, but `controllers` already imports `chartmanager`, so calling `getInstantiatedChart` from here would create an import cycle. Skipping the suspect value keeps this fix self-contained.

2. `getHelmActionInPullMode` now self-heals when the cached value fails to parse as semver. It removes the bad entry, logs the poisoned value, and returns `install`. This protects against any residual poisoned entries from a pre-patch controller, so users do not need to restart anything to recover after upgrading.

3. The spec-side `semver.NewVersion(instantiatedChart.ChartVersion)` error is wrapped with the release namespace, name, and the offending version string, so `failureMessage` is actionable instead of a bare `invalid semantic version`.

## Tests

Unit coverage added in `controllers/chartmanager/chartmanager_test.go` and `controllers/handlers_helm_test.go`:

- `isTemplatedString` detection
- `addHelmVersions` skips templated spec and keeps hardcoded spec
- `getHelmActionInPullMode` returns `install` when the cache is empty
- `getHelmActionInPullMode` self-heals on a poisoned cache entry
- `getHelmActionInPullMode` returns `upgrade` when spec version is newer
- `getHelmActionInPullMode` wraps an invalid spec version with chart context

## Reproduction

1. Management cluster running addon-controller in agentless mode.
2. Register a SveltosCluster in pull mode.
3. Create a Profile with a helm chart using a templated `chartVersion`, for example cert-manager with `chartVersion: '{{ (index .MgmtResources "config").data.chartVersion }}'`.
4. Wait for the initial install to succeed (`ConfigurationGroup.status: Provisioned`).
5. Restart the addon-controller Deployment.
6. `ClusterSummary.status.featureSummaries[].failureMessage` becomes `invalid semantic version` on every subsequent reconcile.
7. Confirm that switching the Profile to a hardcoded `chartVersion` does not clear the failure until the controller is restarted a second time.

## Test plan

- [x] Run `make test` on a host with envtest binaries available (my sandbox did not have `/usr/local/kubebuilder/bin/etcd`, so the full `controllers` test binary compiled cleanly but could not execute). The `controllers/chartmanager` suite runs without envtest and passes locally.
- [x] Manually verify the reproduction above on a cluster running the patched controller: failure should not recur after a pod restart with a templated chartVersion Profile.
- [x] Verify that a pre-existing poisoned entry in memory self-heals on the first reconcile after upgrade.

@gianlucam76 this was tested with the following image:

limit404/addon-controller:v1.8.1

## Related

Sveltos v1.6.1 (#1641) added metadata sanitization for a similar class of semver error in a different code path. The `rebuildChartVersions -> getVersion` path in pull mode was not covered by that fix.