### PR TITLE
fix(pull-mode): do not commit helm stage when a chart failed in the cycle

### DIFF
--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -699,9 +699,24 @@ func (m *instance) getVersion(clusterSummary *configv1beta1.ClusterSummary,
 		if hc.ReleaseNamespace == releaseNamespace &&
 			hc.ReleaseName == releaseName {
 
+			// Spec holds raw (un-instantiated) template expressions. If ChartVersion
+			// still looks like a Go template, do not cache it: the deploy path will
+			// populate the cache with the instantiated version via RegisterVersionForChart.
+			// Caching the template string would poison the cache and cause a permanent
+			// "invalid semantic version" loop in pull mode.
+			if isTemplatedString(hc.ChartVersion) {
+				return ""
+			}
 			return hc.ChartVersion
 		}
 	}
 
 	return ""
+}
+
+// isTemplatedString reports whether s contains an un-instantiated Go template
+// action (e.g. "{{ .Foo }}"). Used to avoid caching raw spec values that have
+// not yet been rendered against management-cluster resources.
+func isTemplatedString(s string) bool {
+	return strings.Contains(s, "{{")
 }

--- a/controllers/chartmanager/chartmanager_test.go
+++ b/controllers/chartmanager/chartmanager_test.go
@@ -386,6 +386,57 @@ var _ = Describe("Chart manager", func() {
 		Expect(manager.CanManageChart(tmpClusterSummary,
 			&tmpClusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])).To(BeTrue())
 	})
+
+	It("isTemplatedString detects un-instantiated Go templates", func() {
+		Expect(chartmanager.IsTemplatedString("v1.2.3")).To(BeFalse())
+		Expect(chartmanager.IsTemplatedString("")).To(BeFalse())
+		Expect(chartmanager.IsTemplatedString(`{{ (index .MgmtResources "config").data.chartVersion }}`)).To(BeTrue())
+		Expect(chartmanager.IsTemplatedString("prefix-{{ .Foo }}-suffix")).To(BeTrue())
+	})
+
+	It("addHelmVersions skips templated chart versions to prevent cache poisoning", func() {
+		// GetVersionForChart/RegisterVersionForChart key on ClusterTypeSveltos (pull mode),
+		// so match that here to exercise the same key path.
+		clusterSummary.Spec.ClusterType = libsveltosv1beta1.ClusterTypeSveltos
+		// Two charts: one templated (must not be cached), one hardcoded (must be cached)
+		clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ChartVersion =
+			`{{ (index .MgmtResources "config").data.chartVersion }}`
+		// HelmCharts[1].ChartVersion stays "0.17.1" from the fixture
+
+		clusterSummary.Status = configv1beta1.ClusterSummaryStatus{
+			HelmReleaseSummaries: []configv1beta1.HelmChartSummary{
+				{
+					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseName,
+					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0].ReleaseNamespace,
+					Status:           configv1beta1.HelmChartStatusManaging,
+				},
+				{
+					ReleaseName:      clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseName,
+					ReleaseNamespace: clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1].ReleaseNamespace,
+					Status:           configv1beta1.HelmChartStatusManaging,
+				},
+			},
+		}
+
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), c)
+		Expect(err).To(BeNil())
+
+		chartmanager.AddHelmVersions(manager, clusterSummary)
+
+		// Templated spec must leave cache empty — GetVersionForChart returns "" so
+		// getHelmActionInPullMode falls through to `install`, which later calls
+		// RegisterVersionForChart with the instantiated version.
+		templatedCached := manager.GetVersionForChart(
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[0])
+		Expect(templatedCached).To(Equal(""))
+
+		// Hardcoded chart version must still be cached normally.
+		hardcodedCached := manager.GetVersionForChart(
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			&clusterSummary.Spec.ClusterProfileSpec.HelmCharts[1])
+		Expect(hardcodedCached).To(Equal("0.17.1"))
+	})
 })
 
 func removeSubscriptions(c client.Client, clusterSummary *configv1beta1.ClusterSummary) {

--- a/controllers/chartmanager/export_test.go
+++ b/controllers/chartmanager/export_test.go
@@ -19,4 +19,6 @@ package chartmanager
 var (
 	IsClusterSummaryAlreadyRegistered = isClusterSummaryAlreadyRegistered
 	RebuildRegistrations              = (*instance).rebuildRegistrations
+	AddHelmVersions                   = (*instance).addHelmVersions
+	IsTemplatedString                 = isTemplatedString
 )

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -137,6 +137,7 @@ var (
 	GetKustomizeSubstituteValues            = getKustomizeSubstituteValues
 	InstantiateResourceWithSubstituteValues = instantiateResourceWithSubstituteValues
 
+	GetHelmActionInPullMode                  = getHelmActionInPullMode
 	HelmHash                                 = helmHash
 	ShouldInstall                            = shouldInstall
 	ShouldUninstall                          = shouldUninstall
@@ -168,6 +169,14 @@ var (
 type (
 	ReleaseInfo       = releaseInfo
 	ReconcileCooldown = reconcileCooldown
+	HelmAction        = helmAction
+)
+
+const (
+	HelmActionInstall   = install
+	HelmActionUpgrade   = upgrade
+	HelmActionDowngrade = downgrade
+	HelmActionUninstall = uninstall
 )
 
 var (

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -5036,12 +5036,22 @@ func getHelmActionInPullMode(ctx context.Context, clusterSummary *configv1beta1.
 
 	currVer, err := semver.NewVersion(currentVersion)
 	if err != nil {
-		return "", err
+		// A poisoned cache (e.g. from a pre-fix controller that cached a raw
+		// template string) must not wedge reconciliation forever. Drop the bad
+		// entry and fall through to install; the deploy path will re-register
+		// the correctly-instantiated version.
+		chartManager.UnregisterVersionForChart(clusterSummary.Spec.ClusterNamespace,
+			clusterSummary.Spec.ClusterName, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName)
+		logr.FromContextOrDiscard(ctx).Info(fmt.Sprintf(
+			"cached version %q for release %s/%s is not a valid semver (%v); clearing cache and treating as install",
+			currentVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err))
+		return install, nil
 	}
 
 	newVer, err := semver.NewVersion(instantiatedChart.ChartVersion)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("invalid semantic version %q for release %s/%s (spec chartVersion): %w",
+			instantiatedChart.ChartVersion, instantiatedChart.ReleaseNamespace, instantiatedChart.ReleaseName, err)
 	}
 
 	switch {

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -928,6 +928,21 @@ func handleCharts(ctx context.Context, clusterSummary *configv1beta1.ClusterSumm
 	}
 
 	if isPullMode {
+		// If any chart in this reconcile failed to stage (helm values schema
+		// error, template instantiation failure, unreachable repo, etc.),
+		// do not commit. Committing a partial staged set produces a
+		// ConfigurationGroup with missing bundles for the failed charts,
+		// which the agent in the managed cluster interprets as "these
+		// releases were removed from the profile" and uninstalls them.
+		// Returning early leaves the previously-committed ConfigurationGroup
+		// in place so the agent continues to run the last known good state
+		// until the reconcile can complete cleanly. This mirrors the
+		// deployError-before-commit pattern already used in
+		// handlers_resources.go and handlers_kustomize.go.
+		if deployError != nil {
+			return deployError
+		}
+
 		err = commitStagedResourcesForDeployment(ctx, clusterSummary, configurationHash, mgmtResources, logger)
 		if err != nil {
 			return err
@@ -936,10 +951,6 @@ func handleCharts(ctx context.Context, clusterSummary *configv1beta1.ClusterSumm
 		err = updateClusterReportWithHelmReports(ctx, c, clusterSummary, releaseReports)
 		if err != nil {
 			return err
-		}
-
-		if deployError != nil {
-			return deployError
 		}
 	} else {
 		// First get the helm releases currently managed and uninstall all the ones

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -1254,7 +1254,110 @@ resources:
 		Expect(len(valuesToInstantiate)).To(Equal(1))
 		Expect(valuesToInstantiate[0]).To(Equal(toInstantiate))
 	})
+
+	It("getHelmActionInPullMode returns install when cache is empty", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.2.3")
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionInstall))
+
+		// Sanity: nothing got registered by the call itself.
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(""))
+	})
+
+	It("getHelmActionInPullMode self-heals when cached version is not valid semver", func() {
+		// Simulate a poisoned cache populated by a pre-fix rebuildChartVersions
+		// that stored a raw template string.
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.20.2")
+		poisoned := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     `{{ (index .MgmtResources "config").data.chartVersion }}`,
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, poisoned)
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(poisoned.ChartVersion))
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionInstall))
+
+		// Self-heal: the poisoned entry must be gone so a subsequent deploy path
+		// can RegisterVersionForChart with a valid value.
+		Expect(manager.GetVersionForChart(cs.Spec.ClusterNamespace,
+			cs.Spec.ClusterName, chart)).To(Equal(""))
+	})
+
+	It("getHelmActionInPullMode returns upgrade when spec version is newer", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("1.20.2")
+		cached := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     "1.19.0",
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cached)
+
+		action, err := controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).To(BeNil())
+		Expect(action).To(Equal(controllers.HelmActionUpgrade))
+	})
+
+	It("getHelmActionInPullMode wraps spec semver errors with chart context", func() {
+		manager, err := chartmanager.GetChartManagerInstance(context.TODO(), testEnv.Client)
+		Expect(err).To(BeNil())
+
+		cs := newPullModeClusterSummary()
+		chart := newChart("not-a-version")
+		cached := &configv1beta1.HelmChart{
+			ReleaseName:      chart.ReleaseName,
+			ReleaseNamespace: chart.ReleaseNamespace,
+			ChartVersion:     "1.19.0",
+		}
+		manager.RegisterVersionForChart(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cached)
+
+		_, err = controllers.GetHelmActionInPullMode(context.TODO(), cs, chart)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring(chart.ReleaseName))
+		Expect(err.Error()).To(ContainSubstring(chart.ReleaseNamespace))
+		Expect(err.Error()).To(ContainSubstring("not-a-version"))
+	})
 })
+
+func newPullModeClusterSummary() *configv1beta1.ClusterSummary {
+	return &configv1beta1.ClusterSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      randomString(),
+			Namespace: randomString(),
+		},
+		Spec: configv1beta1.ClusterSummarySpec{
+			ClusterNamespace: randomString(),
+			ClusterName:      randomString(),
+			ClusterType:      libsveltosv1beta1.ClusterTypeSveltos,
+		},
+	}
+}
+
+func newChart(version string) *configv1beta1.HelmChart {
+	return &configv1beta1.HelmChart{
+		ReleaseName:      randomString(),
+		ReleaseNamespace: randomString(),
+		ChartVersion:     version,
+	}
+}
 
 func verifyFileContent(filePath string, data []byte) {
 	content, err := os.ReadFile(filePath)


### PR DESCRIPTION
Fixes #1724.

## The problem reported in #1724

A pull-mode ClusterSummary was deploying cert-manager via a Profile that pulled its values from a ConfigMap. The user updated that ConfigMap with a values document that had wrong indentation (`replicaCount` nested under `crds` instead of at the top level). Helm correctly rejected the new values at install time with:

```
values don't meet the specifications of the schema(s) in the following chart(s):
cert-manager:
- at '/crds': additional properties 'replicaCount' not allowed
```

The user expected the reconcile to fail in place and leave the previously deployed cert-manager untouched on the managed cluster. Instead, every resource cert-manager had deployed (`ServiceAccount`, `CustomResourceDefinition`, `ClusterRole`, `ClusterRoleBinding`, `Role`, `RoleBinding`, `Service`, `Deployment`, `MutatingWebhookConfiguration`, `ValidatingWebhookConfiguration`, `Job`) was completely removed from the managed cluster. The ClusterSummary kept listing cert-manager as `Managing` with `Status: Failed`, but the workloads were gone.

## Root cause

In `controllers/handlers_helm.go`, `handleCharts` runs `walkChartsAndDeploy` to stage each helm chart's rendered resources into the in-memory pullmode staging manager, then commits the staged set for the agent to consume:

```go
releaseReports, chartDeployed, deployError := walkChartsAndDeploy(ctx, c, dCtx, kubeconfig, isPullMode, logger)
// Even if there is a deployment error do not return just yet. Update various status and clean stale resources.

clusterSummary, err = updateStatusForNonReferencedHelmReleases(ctx, c, dCtx, logger)
if err != nil {
    return err
}

if isPullMode {
    err = commitStagedResourcesForDeployment(ctx, clusterSummary, configurationHash, mgmtResources, logger)
    ...
    if deployError != nil {
        return deployError
    }
}
```

When any chart fails inside `walkChartsAndDeploy` (in the reporter's case `handleInstall` returned a helm schema-validation error), that chart never reaches `stageHelmResourcesForDeployment`. For a single-chart profile like theirs, the in-memory staging manager ends this reconcile with zero helm bundles.

`commitStagedResourcesForDeployment` then publishes a ConfigurationGroup that references only the bundles currently in memory. Because the in-memory set is empty, the ConfigurationGroup no longer references the bundles that were published by the previous successful reconcile. The applier-manager on the managed cluster watches the ConfigurationGroup, sees those bundles as removed from the profile, and deletes the resources they previously deployed. The entire cert-manager release is uninstalled.

Anything that prevents a chart from reaching `stageHelmResourcesForDeployment` produces the same outcome. Examples observed in production logs for the same cluster:

- `invalid semantic version` from the pull-mode chart-version cache bug fixed in #1726.
- `failed to instantiated template: ... map has no entry for key "data"` when a `templateResourceRefs` ConfigMap was renamed or had a key removed.
- Unreachable chart repository.

Each of these silently tears down the healthy deployment that was running until the reconcile failed.

## The fix

The two sibling handlers already handle this correctly:

- `controllers/handlers_resources.go:151-155` returns on `deployError` before calling `pullmode.CommitStagedResourcesForDeployment`.
- `controllers/handlers_kustomize.go:196-197` does the same.

`handlers_helm.go` was the only handler still committing a partial staged set on error. This PR moves the `deployError` check ahead of `commitStagedResourcesForDeployment`, matching the existing pattern:

```go
if isPullMode {
    if deployError != nil {
        return deployError
    }

    err = commitStagedResourcesForDeployment(ctx, clusterSummary, configurationHash, mgmtResources, logger)
    ...
}
```

When any chart in the cycle fails to stage, the reconcile returns the error without touching the ConfigurationGroup. The previously committed ConfigurationGroup continues to reference the last known good bundles, so the agent keeps running the current deployment instead of tearing it down.

`updateClusterReportWithHelmReports` is a no-op outside `SyncModeDryRun`, so moving the `deployError` check ahead of it has no effect on non-DryRun reconciles. The in-memory partial staged bundles are cleared by `pullmode.DiscardStagedResourcesForDeployment` at the top of the next `deployHelmCharts` invocation (`handlers_helm.go:159`), so there is no in-memory leak across reconciles.

## Scope and behavior

- Applies only to the pull-mode branch of `handleCharts`. Non pull-mode behavior is unchanged.
- Does not reorder or change the non-error path. Successful reconciles stage, commit, and report exactly as before.
- Does not recover clusters that were already wiped by a prior partial commit. Those need a clean reconcile (for example by fixing the values document, or by the cache-poison fix in #1726 landing) before the agent will redeploy. This change prevents further occurrences.
- For profiles with `continueOnError: true`, any chart failing to stage still blocks the commit for this cycle. The safer trade is to pause all updates until the failing chart is healthy, rather than risk removing a healthy chart because its sibling failed mid-cycle. This can be revisited if there is demand for per-chart staging granularity, which would require API changes in `libsveltos/lib/pullmode`.

## Test plan

- [ ] Run `make test` with envtest set up. The existing `handlers_helm_test.go` suite should continue to pass; there is no behavior change on the success path.
- [ ] Manually reproduce the report from #1724 against a cluster running the patched controller: write an invalid values document into the referenced ConfigMap, observe that the ClusterSummary reports the helm schema error on `featureSummaries`, and confirm the cert-manager deployment on the managed cluster is still present.
- [ ] Verify the same protection for the other two failure modes observed in the same report: a templated `chartVersion` whose referenced ConfigMap key is missing, and an unreachable chart repository.

## Related

- #1724 Original report describing the removal.
- #1726 Related pull-mode fix for `invalid semantic version` cache poisoning, which is one of the upstream triggers of the removal behavior addressed here.