### PR TITLE
(bug) Rebuild chart versions

### DIFF
--- a/controllers/chartmanager/chartmanager.go
+++ b/controllers/chartmanager/chartmanager.go
@@ -627,15 +627,15 @@ func (m *instance) rebuildChartVersions(ctx context.Context, c client.Client) er
 	m.chartMux.Lock()
 	defer m.chartMux.Unlock()
 
-	clusterSummaryList := &configv1beta1.ClusterSummaryList{}
-	err := c.List(ctx, clusterSummaryList)
+	clusterConfigurations := &configv1beta1.ClusterConfigurationList{}
+	err := c.List(ctx, clusterConfigurations)
 	if err != nil {
 		return err
 	}
 
-	for i := range clusterSummaryList.Items {
-		cs := &clusterSummaryList.Items[i]
-		m.addHelmVersions(cs)
+	for i := range clusterConfigurations.Items {
+		cc := &clusterConfigurations.Items[i]
+		m.addHelmVersions(cc)
 	}
 
 	return nil
@@ -676,32 +676,73 @@ func (m *instance) addNonManagers(clusterSummary *configv1beta1.ClusterSummary) 
 	}
 }
 
-// addHelmVersions walks clusterSummary's status and register helm versions for each chart managed
-func (m *instance) addHelmVersions(clusterSummary *configv1beta1.ClusterSummary) {
-	clusterKey := m.getClusterKey(clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-		clusterSummary.Spec.ClusterType)
+// addHelmVersions walks clusterConfigurations's status and register helm versions for each chart managed
+func (m *instance) addHelmVersions(clusterConfiguration *configv1beta1.ClusterConfiguration) {
+	lbls := clusterConfiguration.Labels
+	if lbls == nil {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no labels",
+			clusterConfiguration.Namespace, clusterConfiguration.Name))
+		return
+	}
 
-	for i := range clusterSummary.Status.HelmReleaseSummaries {
-		summary := &clusterSummary.Status.HelmReleaseSummaries[i]
-		if summary.Status == configv1beta1.HelmChartStatusManaging {
-			chartVersion := m.getVersion(clusterSummary, summary.ReleaseNamespace, summary.ReleaseName)
-			releaseKey := m.GetReleaseKey(summary.ReleaseNamespace, summary.ReleaseName)
-			m.setChartVersion(clusterKey, releaseKey, chartVersion)
-		}
+	clusterName, ok := clusterConfiguration.Labels[configv1beta1.ClusterNameLabel]
+	if !ok {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no %s label",
+			clusterConfiguration.Namespace, clusterConfiguration.Name, configv1beta1.ClusterNameLabel))
+		return
+	}
+
+	var clusterKey string
+
+	rawValueClusterType, ok := clusterConfiguration.Labels[configv1beta1.ClusterTypeLabel]
+	if !ok {
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s has no %s label",
+			clusterConfiguration.Namespace, clusterConfiguration.Name, configv1beta1.ClusterTypeLabel))
+		return
+	}
+
+	var clusterType libsveltosv1beta1.ClusterType
+
+	// Normalize the input to match your defined constants
+	switch {
+	case strings.EqualFold(rawValueClusterType, string(libsveltosv1beta1.ClusterTypeCapi)):
+		clusterType = libsveltosv1beta1.ClusterTypeCapi
+	case strings.EqualFold(rawValueClusterType, string(libsveltosv1beta1.ClusterTypeSveltos)):
+		clusterType = libsveltosv1beta1.ClusterTypeSveltos
+	default:
+		m.logger.V(logs.LogInfo).Info(fmt.Sprintf("ClusterConfiguration %s/%s label %s has unknown value %s",
+			clusterConfiguration.Namespace, clusterConfiguration.Name,
+			configv1beta1.ClusterTypeLabel, rawValueClusterType))
+		return
+	}
+
+	clusterKey = m.getClusterKey(clusterConfiguration.Namespace, clusterName, clusterType)
+
+	for i := range clusterConfiguration.Status.ClusterProfileResources {
+		m.walkClusterConfigurationFeature(clusterKey,
+			clusterConfiguration.Status.ClusterProfileResources[i].Features)
+	}
+
+	for i := range clusterConfiguration.Status.ProfileResources {
+		m.walkClusterConfigurationFeature(clusterKey,
+			clusterConfiguration.Status.ProfileResources[i].Features)
 	}
 }
 
-func (m *instance) getVersion(clusterSummary *configv1beta1.ClusterSummary,
-	releaseNamespace, releaseName string) string {
-
-	for i := range clusterSummary.Spec.ClusterProfileSpec.HelmCharts {
-		hc := &clusterSummary.Spec.ClusterProfileSpec.HelmCharts[i]
-		if hc.ReleaseNamespace == releaseNamespace &&
-			hc.ReleaseName == releaseName {
-
-			return hc.ChartVersion
-		}
+func (m *instance) walkClusterConfigurationFeature(clusterKey string, features []configv1beta1.Feature) {
+	for i := range features {
+		m.walkClusterConfigurationCharts(clusterKey, features[i])
 	}
+}
 
-	return ""
+func (m *instance) walkClusterConfigurationCharts(clusterKey string, feature configv1beta1.Feature) {
+	for i := range feature.Charts {
+		chartVersion := feature.Charts[i].ChartVersion
+		releaseKey := m.GetReleaseKey(feature.Charts[i].Namespace,
+			feature.Charts[i].ReleaseName)
+
+		m.logger.V(logs.LogDebug).Info(fmt.Sprintf("cluster %s %s %s %s",
+			clusterKey, feature.Charts[i].Namespace, feature.Charts[i].ReleaseName, chartVersion))
+		m.setChartVersion(clusterKey, releaseKey, chartVersion)
+	}
 }

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -453,6 +453,63 @@ var _ = Describe("HandlersHelm", func() {
 			Equal(chartDeployed[0].ChartVersion))
 	})
 
+	It("updateChartsInClusterConfiguration stores the live release ChartVersion, not the spec version", func() {
+		// chartDeployed is built from currentRelease.ChartVersion (the actually-deployed version),
+		// not from the spec. This test verifies that what lands in ClusterConfiguration reflects
+		// what the cluster actually has, including multi-chart profiles.
+		chartsDeployed := []configv1beta1.Chart{
+			{
+				RepoURL:      "https://prometheus-community.github.io/helm-charts",
+				ReleaseName:  "prometheus",
+				Namespace:    "prometheus",
+				ChartVersion: "26.0.0",
+				AppVersion:   "v3.0.0",
+			},
+			{
+				RepoURL:      "https://grafana-community.github.io/helm-charts",
+				ReleaseName:  "grafana",
+				Namespace:    "grafana",
+				ChartVersion: "11.3.6",
+				AppVersion:   "12.4.2",
+			},
+		}
+
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controllers.GetClusterConfigurationName(clusterSummary.Spec.ClusterName, libsveltosv1beta1.ClusterTypeCapi),
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+			Status: configv1beta1.ClusterConfigurationStatus{
+				ClusterProfileResources: []configv1beta1.ClusterProfileResource{
+					{ClusterProfileName: clusterProfile.Name},
+				},
+			},
+		}
+
+		initObjects := []client.Object{clusterConfiguration}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
+
+		Expect(controllers.UpdateChartsInClusterConfiguration(context.TODO(), c, clusterSummary,
+			chartsDeployed, textlogger.NewLogger(textlogger.NewConfig()))).To(Succeed())
+
+		current := &configv1beta1.ClusterConfiguration{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterConfiguration.Namespace, Name: clusterConfiguration.Name},
+			current)).To(Succeed())
+
+		Expect(current.Status.ClusterProfileResources).To(HaveLen(1))
+		charts := current.Status.ClusterProfileResources[0].Features[0].Charts
+		Expect(charts).To(HaveLen(2))
+
+		for i, expected := range chartsDeployed {
+			Expect(charts[i].ChartVersion).To(Equal(expected.ChartVersion),
+				"chart %s: stored version must match the live release version", expected.ReleaseName)
+			Expect(charts[i].AppVersion).To(Equal(expected.AppVersion))
+			Expect(charts[i].ReleaseName).To(Equal(expected.ReleaseName))
+			Expect(charts[i].RepoURL).To(Equal(expected.RepoURL))
+		}
+	})
+
 	It("createReportForUnmanagedHelmRelease ", func() {
 		helmChart := &configv1beta1.HelmChart{
 			ReleaseName: randomString(), ReleaseNamespace: randomString(),


### PR DESCRIPTION
When addon-controller starts, it builds an in-memory map keeping track of which helm release and version is already deployed on a managed cluster.

Before this PR, addon-controller used to walk all clusterSummary instances. The problem with that approach is that ClusterSummary can be expressed as a template (release namespace, release name and chart version). Instantiated values are needed.
Instead of instantiating the template, this PR switches to use ClusterConfiguration data.