### PR TITLE
Helm spurious install

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -148,6 +148,7 @@ var (
 	UpdateClusterReportWithHelmReports       = updateClusterReportWithHelmReports
 	HandleCharts                             = handleCharts
 	GetHelmChartValuesHash                   = getHelmChartValuesHash
+	DesiredValuesAreSubset                   = desiredValuesAreSubset
 	GetCredentialsAndCAFiles                 = getCredentialsAndCAFiles
 	GetInstantiatedChart                     = getInstantiatedChart
 	GetHelmChartValuesFrom                   = getHelmChartValuesFrom

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -124,6 +124,9 @@ type releaseInfo struct {
 	ReleaseLabels    map[string]string      `json:"release_labels"`
 	Icon             string                 `json:"icon"`
 	Values           map[string]interface{} `json:"values"`
+	// FullValues is the coalesced result of chart defaults and user-supplied Config values.
+	// Used to check whether Sveltos's desired values are already reflected in the deployed release.
+	FullValues map[string]interface{} `json:"-"`
 }
 
 func deployHelmCharts(ctx context.Context, c client.Client,
@@ -944,10 +947,6 @@ func handleCharts(ctx context.Context, clusterSummary *configv1beta1.ClusterSumm
 		// deployError might contain conflicts so continue. So create clusterReports irrespective
 		if err := updateClusterReportWithHelmReports(ctx, c, clusterSummary, releaseReports); err != nil {
 			return err
-		}
-
-		if deployError != nil {
-			return deployError
 		}
 	} else {
 		// First get the helm releases currently managed and uninstall all the ones
@@ -2286,6 +2285,16 @@ func getReleaseInfo(releaseName, releaseNamespace, kubeconfig string, registryOp
 		return nil, err
 	}
 
+	// Coalesce chart defaults with user-supplied Config so FullValues represents
+	// everything the chart is actually running with.
+	fullValues := make(map[string]interface{})
+	for k, v := range currentRelease.Chart.Values {
+		fullValues[k] = v
+	}
+	if err := mergo.Merge(&fullValues, currentRelease.Config, mergo.WithOverride); err != nil {
+		fullValues = currentRelease.Config
+	}
+
 	element := &releaseInfo{
 		ReleaseName:      currentRelease.Name,
 		ReleaseNamespace: currentRelease.Namespace,
@@ -2297,6 +2306,7 @@ func getReleaseInfo(releaseName, releaseNamespace, kubeconfig string, registryOp
 		ReleaseLabels:    currentRelease.Labels,
 		Icon:             currentRelease.Chart.Metadata.Icon,
 		Values:           currentRelease.Config,
+		FullValues:       fullValues,
 	}
 
 	var t metav1.Time
@@ -2412,47 +2422,110 @@ func shouldUpgrade(ctx context.Context, currentRelease *releaseInfo, instantiate
 	}
 
 	if dCtx.clusterSummary.Spec.ClusterProfileSpec.SyncMode != configv1beta1.SyncModeContinuousWithDriftDetection {
-		if dCtx.clusterSummary.Spec.ClusterProfileSpec.SyncMode != configv1beta1.SyncModeDryRun {
-			oldValueHash := getValuesHashFromHelmChartSummary(instantiatedChart, dCtx.clusterSummary)
-			oldPatchesHash := getPatchesHashFromHelmChartSummary(instantiatedChart, dCtx.clusterSummary)
+		return shouldUpgradeForContinuousMode(ctx, currentRelease, instantiatedChart, dCtx, currentPatchesHash, logger)
+	}
 
-			// Compare Values
-			c := getManagementClusterClient()
-			currentValueHash, err := getHelmChartValuesHash(ctx, c, instantiatedChart, dCtx.clusterSummary, dCtx.mgmtResources, logger)
-			if err != nil {
-				logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get current values hash: %v", err))
-				currentValueHash = []byte("")
-			}
-			if !reflect.DeepEqual(oldValueHash, currentValueHash) {
-				return true
-			}
+	// ContinuousWithDriftDetection: always upgrade except on the very first reconciliation
+	// when the live release already matches desired state (no stored ValuesHash yet).
+	// Subsequent reconciliations always upgrade so the drift-detection agent can repair drift.
+	// ResourceSummary is deployed by postProcessDeployedHelmCharts regardless of this decision.
+	if driftDetectionFirstReconciliationCanSkip(ctx, currentRelease, instantiatedChart, dCtx, currentPatchesHash, logger) {
+		return false
+	}
+	return true
+}
 
-			// Compare patches
-			if !reflect.DeepEqual(oldPatchesHash, currentPatchesHash) {
-				return true
+// shouldUpgradeForContinuousMode handles the upgrade decision for Continuous and DryRun modes.
+func shouldUpgradeForContinuousMode(ctx context.Context, currentRelease *releaseInfo,
+	instantiatedChart *configv1beta1.HelmChart, dCtx *deploymentContext,
+	currentPatchesHash []byte, logger logr.Logger) bool {
+
+	if dCtx.clusterSummary.Spec.ClusterProfileSpec.SyncMode != configv1beta1.SyncModeDryRun {
+		oldValueHash := getValuesHashFromHelmChartSummary(instantiatedChart, dCtx.clusterSummary)
+		oldPatchesHash := getPatchesHashFromHelmChartSummary(instantiatedChart, dCtx.clusterSummary)
+
+		c := getManagementClusterClient()
+		currentValueHash, err := getHelmChartValuesHash(ctx, c, instantiatedChart, dCtx.clusterSummary, dCtx.mgmtResources, logger)
+		if err != nil {
+			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get current values hash: %v", err))
+			currentValueHash = []byte("")
+		}
+
+		// No stored state yet (first reconciliation or controller restart). Avoid a
+		// spurious upgrade by checking whether the desired values are already reflected
+		// in the deployed release. Compare against FullValues (chart defaults + Config)
+		// so values that match chart defaults are not missed — helm stores no Config
+		// entry when the desired value equals the default.
+		// We cannot infer whether patches were previously applied from the release
+		// alone, so only skip when no patches are configured now.
+		if oldValueHash == nil && currentRelease != nil &&
+			currentRelease.Status == releasecommon.StatusDeployed.String() {
+
+			desiredValues, desiredErr := getHelmChartInstantiatedValues(ctx, dCtx.clusterSummary,
+				dCtx.mgmtResources, instantiatedChart, logger)
+			if desiredErr == nil && desiredValuesAreSubset(desiredValues, currentRelease.FullValues) {
+				oldValueHash = currentValueHash
+			}
+		}
+		if oldPatchesHash == nil {
+			emptyHash := sha256.Sum256([]byte(""))
+			if reflect.DeepEqual(currentPatchesHash, emptyHash[:]) {
+				oldPatchesHash = currentPatchesHash
 			}
 		}
 
-		if currentRelease != nil {
-			if currentRelease.Status != releasecommon.StatusDeployed.String() {
-				return true
-			}
-
-			current, err := semver.NewVersion(currentRelease.ChartVersion)
-			if err != nil {
-				return true
-			}
-
-			expected, err := semver.NewVersion(instantiatedChart.ChartVersion)
-			if err != nil {
-				return true
-			}
-
-			return !current.Equal(expected)
+		if !reflect.DeepEqual(oldValueHash, currentValueHash) {
+			return true
+		}
+		if !reflect.DeepEqual(oldPatchesHash, currentPatchesHash) {
+			return true
 		}
 	}
 
-	return true
+	if currentRelease != nil {
+		if currentRelease.Status != releasecommon.StatusDeployed.String() {
+			return true
+		}
+		current, err := semver.NewVersion(currentRelease.ChartVersion)
+		if err != nil {
+			return true
+		}
+		expected, err := semver.NewVersion(instantiatedChart.ChartVersion)
+		if err != nil {
+			return true
+		}
+		return !current.Equal(expected)
+	}
+	return false
+}
+
+// driftDetectionFirstReconciliationCanSkip returns true when the live release already
+// reflects the desired state and this is the first reconciliation (no stored ValuesHash).
+// Conditions: no stored state, release deployed, same version, desired values are a subset
+// of the coalesced release values, and no patches configured.
+// Patches are not skipped: we cannot infer from the release whether they were applied before.
+func driftDetectionFirstReconciliationCanSkip(ctx context.Context, currentRelease *releaseInfo,
+	instantiatedChart *configv1beta1.HelmChart, dCtx *deploymentContext,
+	currentPatchesHash []byte, logger logr.Logger) bool {
+
+	if getValuesHashFromHelmChartSummary(instantiatedChart, dCtx.clusterSummary) != nil {
+		return false
+	}
+	if currentRelease == nil || currentRelease.Status != releasecommon.StatusDeployed.String() {
+		return false
+	}
+	emptyPatchesHash := sha256.Sum256([]byte(""))
+	if !reflect.DeepEqual(currentPatchesHash, emptyPatchesHash[:]) {
+		return false
+	}
+	current, err1 := semver.NewVersion(currentRelease.ChartVersion)
+	expected, err2 := semver.NewVersion(instantiatedChart.ChartVersion)
+	if err1 != nil || err2 != nil || !current.Equal(expected) {
+		return false
+	}
+	desiredValues, err := getHelmChartInstantiatedValues(ctx, dCtx.clusterSummary,
+		dCtx.mgmtResources, instantiatedChart, logger)
+	return err == nil && desiredValuesAreSubset(desiredValues, currentRelease.FullValues)
 }
 
 // shouldUninstall returns true if action is uninstall there is a release installed currently
@@ -4096,6 +4169,29 @@ func getResourceNamespace(ctx context.Context, r *unstructured.Unstructured, rel
 	}
 
 	return namespace, nil
+}
+
+// desiredValuesAreSubset returns true when every key-value pair in desired is present
+// with an equal value in full. Nested maps are checked recursively. This lets Sveltos
+// confirm that the values it would set are already reflected in the deployed release's
+// coalesced values (chart defaults + user Config) without requiring an exact full match.
+func desiredValuesAreSubset(desired, full map[string]interface{}) bool {
+	for k, dv := range desired {
+		fv, ok := full[k]
+		if !ok {
+			return false
+		}
+		dm, desiredIsMap := dv.(map[string]interface{})
+		fm, fullIsMap := fv.(map[string]interface{})
+		if desiredIsMap && fullIsMap {
+			if !desiredValuesAreSubset(dm, fm) {
+				return false
+			}
+		} else if !reflect.DeepEqual(dv, fv) {
+			return false
+		}
+	}
+	return true
 }
 
 func getHelmChartValuesHash(ctx context.Context, c client.Client, instantiatedChart *configv1beta1.HelmChart,

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -168,6 +168,294 @@ var _ = Describe("HandlersHelm", func() {
 			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
 	})
 
+	It("desiredValuesAreSubset returns true when desired is a subset of full values", func() {
+		full := map[string]interface{}{
+			"replicaCount": 2,
+			"image": map[string]interface{}{
+				"repository": "nginx",
+				"tag":        "1.21",
+				"pullPolicy": "IfNotPresent",
+			},
+			"service": map[string]interface{}{
+				"port": 80,
+			},
+		}
+		// Desired only sets a subset — tag and pullPolicy come from chart defaults.
+		desired := map[string]interface{}{
+			"replicaCount": 2,
+			"image": map[string]interface{}{
+				"repository": "nginx",
+			},
+		}
+		Expect(controllers.DesiredValuesAreSubset(desired, full)).To(BeTrue())
+	})
+
+	It("desiredValuesAreSubset returns false when a desired value differs from full", func() {
+		full := map[string]interface{}{
+			"replicaCount": 2,
+		}
+		desired := map[string]interface{}{
+			"replicaCount": 3,
+		}
+		Expect(controllers.DesiredValuesAreSubset(desired, full)).To(BeFalse())
+	})
+
+	It("desiredValuesAreSubset returns false when a desired key is absent from full", func() {
+		full := map[string]interface{}{
+			"replicaCount": 2,
+		}
+		desired := map[string]interface{}{
+			"replicaCount": 2,
+			"extraKey":     "value",
+		}
+		Expect(controllers.DesiredValuesAreSubset(desired, full)).To(BeFalse())
+	})
+
+	It("desiredValuesAreSubset returns false when desired value is a map but full value is a scalar", func() {
+		full := map[string]interface{}{
+			"image": "nginx:latest", // scalar, not a map
+		}
+		desired := map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": "nginx",
+			},
+		}
+		Expect(controllers.DesiredValuesAreSubset(desired, full)).To(BeFalse())
+	})
+
+	It("desiredValuesAreSubset returns false when desired value is a scalar but full value is a map", func() {
+		full := map[string]interface{}{
+			"image": map[string]interface{}{
+				"repository": "nginx",
+			},
+		}
+		desired := map[string]interface{}{
+			"image": "nginx:latest", // scalar, not a map
+		}
+		Expect(controllers.DesiredValuesAreSubset(desired, full)).To(BeFalse())
+	})
+
+	It("shouldUpgrade returns false when no stored state and desired values are subset of live release", func() {
+		// When ClusterSummary has no stored hash (first reconciliation), shouldUpgrade must
+		// not trigger a spurious upgrade if the desired values are already reflected in the
+		// deployed release's full values (chart defaults + Config).
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		// Live release: deployed, same version, FullValues includes chart defaults.
+		// Sveltos desires no values (empty), which is a subset of anything.
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			Values:       map[string]interface{}{},
+			FullValues:   map[string]interface{}{"replicaCount": 1, "service": map[string]interface{}{"port": 80}},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ChartVersion:    "v1.0.0",
+			HelmChartAction: configv1beta1.HelmChartActionInstall,
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
+	})
+
+	It("shouldUpgrade returns true when no stored state and desired values are not a subset of live release", func() {
+		// Same version, but the desired values include a key that differs from what is
+		// deployed — upgrade must be triggered even with no stored state.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			FullValues:   map[string]interface{}{"replicaCount": 1},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ChartVersion:    "v1.0.0",
+			HelmChartAction: configv1beta1.HelmChartActionInstall,
+			Values:          "replicaCount: 3\n", // desired differs from live
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
+	})
+
+	It("shouldUpgrade returns true when no stored state but live release version differs", func() {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			FullValues:   map[string]interface{}{},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ChartVersion:    "v1.1.0",
+			HelmChartAction: configv1beta1.HelmChartActionInstall,
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
+	})
+
+	It("shouldUpgrade returns false on first reconciliation with ContinuousWithDriftDetection when version and values already match", func() {
+		// When a new mgmt cluster takes over and the civo cluster already has the correct
+		// release deployed (same version, values subset, no patches), Sveltos should skip
+		// the helm upgrade even in ContinuousWithDriftDetection mode.
+		// ResourceSummary is still deployed by postProcessDeployedHelmCharts so the
+		// drift-detection agent is correctly informed.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		clusterSummary.Spec.ClusterProfileSpec.SyncMode = configv1beta1.SyncModeContinuousWithDriftDetection
+
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			FullValues:   map[string]interface{}{"replicaCount": 1},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ChartVersion:    "v1.0.0",
+			HelmChartAction: configv1beta1.HelmChartActionInstall,
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeFalse())
+	})
+
+	It("shouldUpgrade returns true on second reconciliation with ContinuousWithDriftDetection (stored ValuesHash present)", func() {
+		// Once a ValuesHash is stored in HelmReleaseSummaries, every reconciliation must
+		// trigger an upgrade so the drift-detection agent can repair configuration drift.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		clusterSummary.Spec.ClusterProfileSpec.SyncMode = configv1beta1.SyncModeContinuousWithDriftDetection
+		clusterSummary.Status.HelmReleaseSummaries = []configv1beta1.HelmChartSummary{
+			{
+				ReleaseName:      "nginx-latest",
+				ReleaseNamespace: "nginx",
+				ValuesHash:       []byte("previously-stored-hash"),
+				Status:           configv1beta1.HelmChartStatusManaging,
+			},
+		}
+
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			FullValues:   map[string]interface{}{"replicaCount": 1},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ReleaseName:      "nginx-latest",
+			ReleaseNamespace: "nginx",
+			ChartVersion:     "v1.0.0",
+			HelmChartAction:  configv1beta1.HelmChartActionInstall,
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
+	})
+
+	It("shouldUpgrade returns true when no stored state with ContinuousWithDriftDetection but patches are configured", func() {
+		// This is the nginx case: even though version and values are unchanged, patches are
+		// defined in the ClusterProfile. Sveltos cannot infer from the live release whether
+		// those patches were applied previously, so it must re-deploy to be safe.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: clusterSummary.Spec.ClusterNamespace}}
+		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
+
+		cluster := &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummary.Spec.ClusterName,
+				Namespace: clusterSummary.Spec.ClusterNamespace,
+			},
+		}
+		Expect(testEnv.Create(context.TODO(), cluster)).To(Succeed())
+		Expect(waitForObject(context.TODO(), testEnv.Client, cluster)).To(Succeed())
+
+		clusterSummary.Spec.ClusterProfileSpec.SyncMode = configv1beta1.SyncModeContinuousWithDriftDetection
+		clusterSummary.Spec.ClusterProfileSpec.Patches = []libsveltosv1beta1.Patch{
+			{
+				Patch: `- op: add
+  path: /metadata/annotations/projectsveltos.io~1managed
+  value: "true"`,
+				Target: &libsveltosv1beta1.PatchSelector{
+					Kind: "Deployment",
+				},
+			},
+		}
+
+		// Same version, desired values (empty) are a subset of live FullValues — the
+		// first-reconciliation skip would fire if there were no patches.
+		currentRelease := &controllers.ReleaseInfo{
+			Status:       releasecommon.StatusDeployed.String(),
+			ChartVersion: "v1.0.0",
+			FullValues:   map[string]interface{}{"replicaCount": 1},
+		}
+		requestChart := &configv1beta1.HelmChart{
+			ChartVersion:    "v1.0.0",
+			HelmChartAction: configv1beta1.HelmChartActionInstall,
+		}
+
+		Expect(controllers.ShouldUpgrade(context.TODO(), currentRelease, requestChart,
+			controllers.NewDeploymentContext(clusterSummary, nil, nil),
+			textlogger.NewLogger(textlogger.NewConfig()))).To(BeTrue())
+	})
+
 	It("UpdateStatusForeferencedHelmReleases updates ClusterSummary.Status.HelmReleaseSummaries", func() {
 		calicoChart := &configv1beta1.HelmChart{
 			RepositoryURL:    "https://projectcalico.docs.tigera.io/charts",


### PR DESCRIPTION
## Problem

When a new management cluster takes over and reconciles a cluster that already has helm charts deployed (e.g. after mgmt cluster replacement), Sveltos had no stored state in the new ClusterSummary. This caused two categories of spurious work:

**1. Spurious helm upgrade (Continuous mode)**
The ClusterSummary had no stored \`ValuesHash\`, so \`shouldUpgrade\` always returned true and triggered \`helm upgrade\` on every release — even when nothing had changed. Users would see revision numbers increment unnecessarily.

**2. Spurious helm upgrade (ContinuousWithDriftDetection mode)**
Same root cause: no stored state → \`shouldUpgrade\` always returned true. For this mode, *subsequent* reconciliations should always upgrade (that is intentional — it's how drift is repaired). But the *very first* reconciliation when taking over an already-correct cluster should not re-deploy just because the history was lost.

**What is NOT skipped (intentional)**

- **Patches configured**: Sveltos cannot infer from a live Helm release whether patches were previously applied. Any ClusterProfile with \`patches:\` always re-deploys on first reconciliation, regardless of mode. This was the observed behaviour for \`deploy-nginx\` in testing — it got revision 2 because it has patches, while all other charts (no patches) were correctly skipped.

- **ContinuousWithDriftDetection subsequent reconciliations**: After the first reconciliation, a \`ValuesHash\` is stored in \`ClusterSummary.Status.HelmReleaseSummaries\`. Every reconciliation after that triggers an upgrade as before, so the drift-detection agent can repair configuration drift on the managed cluster.

- **ResourceSummary deployment**: Skipping the helm upgrade does NOT skip ResourceSummary. \`postProcessDeployedHelmCharts\` runs unconditionally after all charts are processed and deploys the ResourceSummary, so the drift-detection agent running on the cluster is always correctly informed about which resources to watch.
