### PR TITLE
(bug) Fix HelmCharts/KustomizationRefs/PolicyRefs order not preserved

### DIFF
--- a/controllers/clusterpromotion_controller.go
+++ b/controllers/clusterpromotion_controller.go
@@ -371,7 +371,7 @@ func (r *ClusterPromotionReconciler) getProfileSpecHash(profileSpec *configv1bet
 
 	h := sha256.New()
 
-	specCopy := profileSpec
+	specCopy := *profileSpec
 
 	specCopy.HelmCharts = getSortedHelmCharts(profileSpec.HelmCharts)
 	specCopy.KustomizationRefs = getSortedKustomizationRefs(profileSpec.KustomizationRefs)


### PR DESCRIPTION
When ClusterPromotion creates ClusterProfiles, the order of HelmCharts, KustomizationRefs and PolicyRefs must be preserved. This PR fixes a bug which was causing the order in ClusterProfiles to be different than ClusterPromotion one.

Fixes #1733 