### PR TITLE
fix: add a check for the existence of the drift detection manager before upgrade

### DIFF
--- a/controllers/drift_detection_upgrade.go
+++ b/controllers/drift_detection_upgrade.go
@@ -296,7 +296,12 @@ func skipUpgrading(ctx context.Context, c client.Client, cluster client.Object,
 		return true, err
 	}
 
-	// Verify if ResourceSummary CRD is present. Th
+	_, hasDrift := clustersWithDriftDetection[*clusterRef]
+	if !hasDrift && !isDriftDetectionManagerDeployedInCluster(ctx, managedClient) {
+		return true, nil // nothing to upgrade
+	}
+
+	// Verify if ResourceSummary CRD is present. The CRD is installed when drift detection manager is deployed.
 	resourceCRDPresent, err := isResourceSummaryCRDPresent(ctx, managedClient, logger)
 	if err != nil {
 		return true, err
@@ -307,6 +312,18 @@ func skipUpgrading(ctx context.Context, c client.Client, cluster client.Object,
 	}
 
 	return false, nil
+}
+
+func isDriftDetectionManagerDeployedInCluster(ctx context.Context, c client.Client) bool {
+	deployments := &appsv1.DeploymentList{}
+	listOptions := []client.ListOption{
+		client.InNamespace(projectsveltos),
+		client.MatchingLabels{driftDetectionFeatureLabelKey: driftDetectionFeatureLabelValue},
+	}
+	if err := c.List(ctx, deployments, listOptions...); err != nil {
+		return false
+	}
+	return len(deployments.Items) > 0
 }
 
 func isResourceSummaryCRDPresent(ctx context.Context, c client.Client, logger logr.Logger) (bool, error) {

--- a/controllers/drift_detection_upgrade.go
+++ b/controllers/drift_detection_upgrade.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -296,51 +295,17 @@ func skipUpgrading(ctx context.Context, c client.Client, cluster client.Object,
 		return true, err
 	}
 
-	_, hasDrift := clustersWithDriftDetection[*clusterRef]
-	if !hasDrift && !isDriftDetectionManagerDeployedInCluster(ctx, managedClient) {
+	if !isDriftDetectionManagerDeployedInCluster(ctx, managedClient) {
 		return true, nil // nothing to upgrade
-	}
-
-	// Verify if ResourceSummary CRD is present. The CRD is installed when drift detection manager is deployed.
-	resourceCRDPresent, err := isResourceSummaryCRDPresent(ctx, managedClient, logger)
-	if err != nil {
-		return true, err
-	}
-
-	if !resourceCRDPresent {
-		return true, nil
 	}
 
 	return false, nil
 }
 
 func isDriftDetectionManagerDeployedInCluster(ctx context.Context, c client.Client) bool {
-	deployments := &appsv1.DeploymentList{}
-	listOptions := []client.ListOption{
-		client.InNamespace(projectsveltos),
-		client.MatchingLabels{driftDetectionFeatureLabelKey: driftDetectionFeatureLabelValue},
-	}
-	if err := c.List(ctx, deployments, listOptions...); err != nil {
-		return false
-	}
-	return len(deployments.Items) > 0
-}
-
-func isResourceSummaryCRDPresent(ctx context.Context, c client.Client, logger logr.Logger) (bool, error) {
-	resourceSummaryCRD := &apiextensionsv1.CustomResourceDefinition{}
-
-	err := c.Get(ctx, types.NamespacedName{Name: "resourcesummaries.lib.projectsveltos.io"},
-		resourceSummaryCRD)
-
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, nil
-		}
-		logger.V(logs.LogInfo).Error(err, "failed to verify presence of ResourceSummary CRD")
-		return false, err
-	}
-
-	return true, nil
+	deployment := &appsv1.Deployment{}
+	err := c.Get(ctx, types.NamespacedName{Namespace: projectsveltos, Name: "drift-detection-manager"}, deployment)
+	return err == nil
 }
 
 func getListOfClustersWithDriftDetection(ctx context.Context, c client.Client,

--- a/controllers/drift_detection_upgrade_test.go
+++ b/controllers/drift_detection_upgrade_test.go
@@ -223,13 +223,13 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeFalse())
 	})
 
-	It("isDriftDetectionManagerDeployedInCluster returns true when drift-detection deployment exists", func() {
+	It("isDriftDetectionManagerDeployedInCluster returns true when drift-detection-manager deployment exists", func() {
 		depl := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "drift-detection-manager",
 				Namespace: "projectsveltos",
 				Labels: map[string]string{
-					"feature": "drift-detection",
+					"control-plane": "drift-detection-manager",
 				},
 			},
 		}
@@ -237,13 +237,13 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeTrue())
 	})
 
-	It("isDriftDetectionManagerDeployedInCluster returns false when deployment has wrong label", func() {
+	It("isDriftDetectionManagerDeployedInCluster returns false when deployment has wrong name", func() {
 		depl := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "drift-detection-manager",
+				Name:      "some-other-deployment",
 				Namespace: "projectsveltos",
 				Labels: map[string]string{
-					"feature": "something-else",
+					"control-plane": "drift-detection-manager",
 				},
 			},
 		}
@@ -257,7 +257,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 				Name:      "drift-detection-manager",
 				Namespace: "default",
 				Labels: map[string]string{
-					"feature": "drift-detection",
+					"control-plane": "drift-detection-manager",
 				},
 			},
 		}

--- a/controllers/drift_detection_upgrade_test.go
+++ b/controllers/drift_detection_upgrade_test.go
@@ -23,10 +23,12 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2/textlogger"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/projectsveltos/addon-controller/controllers"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
@@ -205,7 +207,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 
 		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, sveltosClusterReadyAndNotPaused, nil, logger)
 		Expect(err).To(BeNil())
-		Expect(skip).To(BeFalse())
+		Expect(skip).To(BeTrue())
 
 		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, capiClusterPaused, nil, logger)
 		Expect(err).To(BeNil())
@@ -213,6 +215,53 @@ var _ = Describe("Drift Detection Upgrade", func() {
 
 		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, capiClusterNotPaused, nil, logger)
 		Expect(err).To(BeNil())
-		Expect(skip).To(BeFalse())
+		Expect(skip).To(BeTrue())
+	})
+
+	It("isDriftDetectionManagerDeployedInCluster returns false when no deployment exists", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeFalse())
+	})
+
+	It("isDriftDetectionManagerDeployedInCluster returns true when drift-detection deployment exists", func() {
+		depl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "drift-detection-manager",
+				Namespace: "projectsveltos",
+				Labels: map[string]string{
+					"feature": "drift-detection",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(depl).Build()
+		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeTrue())
+	})
+
+	It("isDriftDetectionManagerDeployedInCluster returns false when deployment has wrong label", func() {
+		depl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "drift-detection-manager",
+				Namespace: "projectsveltos",
+				Labels: map[string]string{
+					"feature": "something-else",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(depl).Build()
+		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeFalse())
+	})
+
+	It("isDriftDetectionManagerDeployedInCluster returns false when deployment is in wrong namespace", func() {
+		depl := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "drift-detection-manager",
+				Namespace: "default",
+				Labels: map[string]string{
+					"feature": "drift-detection",
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(depl).Build()
+		Expect(controllers.IsDriftDetectionManagerDeployedInCluster(context.TODO(), c)).To(BeFalse())
 	})
 })

--- a/controllers/drift_detection_upgrade_test.go
+++ b/controllers/drift_detection_upgrade_test.go
@@ -65,16 +65,6 @@ var _ = Describe("Drift Detection Upgrade", func() {
 			},
 		}
 
-		sveltosClusterReadyAndNotPaused := &libsveltosv1beta1.SveltosCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      randomString(),
-				Namespace: namespace,
-			},
-			Spec: libsveltosv1beta1.SveltosClusterSpec{
-				Paused: false,
-			},
-		}
-
 		capiClusterPaused := &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      randomString(),
@@ -85,15 +75,6 @@ var _ = Describe("Drift Detection Upgrade", func() {
 			},
 		}
 
-		initialized := true
-		capiClusterNotPaused := &clusterv1.Cluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      randomString(),
-				Namespace: namespace,
-			},
-			Spec: clusterv1.ClusterSpec{},
-		}
-
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
@@ -102,24 +83,6 @@ var _ = Describe("Drift Detection Upgrade", func() {
 
 		Expect(testEnv.Create(context.TODO(), ns)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv, ns)).To(Succeed())
-
-		Expect(testEnv.Create(context.TODO(), sveltosClusterReadyAndNotPaused)).To(Succeed())
-		Expect(waitForObject(context.TODO(), testEnv, sveltosClusterReadyAndNotPaused)).To(Succeed())
-
-		sveltosClusterReadyAndNotPaused.Status = libsveltosv1beta1.SveltosClusterStatus{
-			Ready: true,
-		}
-		Expect(testEnv.Status().Update(context.TODO(), sveltosClusterReadyAndNotPaused)).To(Succeed())
-
-		Expect(testEnv.Create(context.TODO(), capiClusterNotPaused)).To(Succeed())
-		Expect(waitForObject(context.TODO(), testEnv, capiClusterNotPaused)).To(Succeed())
-
-		capiClusterNotPaused.Status = clusterv1.ClusterStatus{
-			Initialization: clusterv1.ClusterInitializationStatus{
-				ControlPlaneInitialized: &initialized,
-			},
-		}
-		Expect(testEnv.Status().Update(context.TODO(), capiClusterNotPaused)).To(Succeed())
 
 		Expect(testEnv.Create(context.TODO(), sveltosClusterPaused)).To(Succeed())
 		Expect(waitForObject(context.TODO(), testEnv, sveltosClusterPaused)).To(Succeed())
@@ -132,9 +95,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 
 		Expect(addTypeInformationToObject(scheme, sveltosClusterPaused)).To(Succeed())
 		Expect(addTypeInformationToObject(scheme, sveltosClusterNotReady)).To(Succeed())
-		Expect(addTypeInformationToObject(scheme, sveltosClusterReadyAndNotPaused)).To(Succeed())
 		Expect(addTypeInformationToObject(scheme, capiClusterPaused)).To(Succeed())
-		Expect(addTypeInformationToObject(scheme, capiClusterNotPaused)).To(Succeed())
 
 		By("Create the secrets with cluster kubeconfig")
 		secret := &corev1.Secret{
@@ -164,31 +125,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      sveltosClusterReadyAndNotPaused.Name + sveltosKubeconfigPostfix,
-			},
-			Data: map[string][]byte{
-				"value": testEnv.Kubeconfig,
-			},
-		}
-		Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
-		Expect(waitForObject(context.TODO(), testEnv, secret)).To(Succeed())
-
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
 				Name:      capiClusterPaused.Name + kubeconfigPostfix,
-			},
-			Data: map[string][]byte{
-				"value": testEnv.Kubeconfig,
-			},
-		}
-		Expect(testEnv.Create(context.TODO(), secret)).To(Succeed())
-		Expect(waitForObject(context.TODO(), testEnv, secret)).To(Succeed())
-
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      capiClusterNotPaused.Name + kubeconfigPostfix,
 			},
 			Data: map[string][]byte{
 				"value": testEnv.Kubeconfig,
@@ -205,17 +142,10 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		Expect(err).To(BeNil())
 		Expect(skip).To(BeTrue())
 
-		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, sveltosClusterReadyAndNotPaused, nil, logger)
-		Expect(err).To(BeNil())
-		Expect(skip).To(BeTrue())
-
 		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, capiClusterPaused, nil, logger)
 		Expect(err).To(BeNil())
 		Expect(skip).To(BeTrue())
 
-		skip, err = controllers.SkipUpgrading(context.TODO(), testEnv, capiClusterNotPaused, nil, logger)
-		Expect(err).To(BeNil())
-		Expect(skip).To(BeTrue())
 	})
 
 	It("isDriftDetectionManagerDeployedInCluster returns false when no deployment exists", func() {

--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -222,7 +222,8 @@ var (
 )
 
 var (
-	SkipUpgrading = skipUpgrading
+	SkipUpgrading                            = skipUpgrading
+	IsDriftDetectionManagerDeployedInCluster = isDriftDetectionManagerDeployedInCluster
 )
 
 var (

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,6 @@ github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
-github.com/opencontainers/go-digest v1.0.1-0.20260318163012-137fd2bb009d h1:QZUC8fu3Kn4FhwIPx+9tnSZWtfcoNCXAKPX6yyJCoss=
-github.com/opencontainers/go-digest v1.0.1-0.20260318163012-137fd2bb009d/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
 github.com/opencontainers/go-digest v1.0.1-0.20260423074420-acc66fb5367c h1:dTJQx6HDrRNmA3p5JlfVYw81R3g2RfWdG0+ZBaJeqcc=
 github.com/opencontainers/go-digest v1.0.1-0.20260423074420-acc66fb5367c/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
 github.com/opencontainers/go-digest/blake3 v0.0.0-20250116041648-1e56c6daea3b h1:nAiL9bmUK4IzFrKoVMRykv0iYGdoit5vpbPaVCZ+fI4=
@@ -276,8 +274,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260422123949-ee3c3d0f960e h1:6U0OrYtquxjcuHLROBpcva1fofBae9c+nGhRg6xqgRI=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260422123949-ee3c3d0f960e/go.mod h1:0K9ZLuYL/g0OonfhRVkHMyDYWuFt24EhvTtjTbUu3+Y=
 github.com/projectsveltos/libsveltos v1.8.1-0.20260422193357-a670bbae8df8 h1:XR0ebx6/L4q+GvYlmvNEhyrF5ALMMVSySgkJ5bW6iAw=
 github.com/projectsveltos/libsveltos v1.8.1-0.20260422193357-a670bbae8df8/go.mod h1:0K9ZLuYL/g0OonfhRVkHMyDYWuFt24EhvTtjTbUu3+Y=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=


### PR DESCRIPTION
This change adds a check that the drift detection manager is actually installed before proceeding with an upgrade. Otherwise, the upgrade ends up installing it. 

Fixes #1742 