### PR TITLE
(bug) DryRun: keep ClusterSummary alive when cluster stops matching

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -28,6 +28,7 @@ var (
 	UpdateClusterSummary                  = updateClusterSummary
 	UpdateClusterConfigurationWithProfile = updateClusterConfigurationWithProfile
 	CleanClusterConfiguration             = cleanClusterConfiguration
+	CleanClusterConfigurations            = cleanClusterConfigurations
 	CleanClusterReports                   = cleanClusterReports
 	CleanClusterSummaries                 = cleanClusterSummaries
 	UpdateClusterSummarySyncMode          = updateClusterSummarySyncMode

--- a/controllers/profile_utils.go
+++ b/controllers/profile_utils.go
@@ -397,6 +397,13 @@ func cleanClusterConfigurations(ctx context.Context, c client.Client, profileSco
 			continue
 		}
 
+		// In DryRun mode, keep the ClusterConfiguration intact so the ClusterSummary
+		// reconciler can access it during DryRun reconciliation (e.g., ChartManager init).
+		// Cleanup happens when the user commits the change and DryRun is disabled.
+		if profileScope.IsDryRunSync() {
+			continue
+		}
+
 		err = cleanClusterConfiguration(ctx, c, profileScope.Profile, cc)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err
@@ -840,6 +847,26 @@ func cleanClusterSummaries(ctx context.Context, c client.Client, profileScope *s
 		if util.IsOwnedByObject(cs, profileScope.Profile, targetGK) {
 			if _, ok := matching[getClusterInfo(cs.Spec.ClusterNamespace, cs.Spec.ClusterName, cs.Spec.ClusterType)]; !ok {
 				clusterRef := getClusterObjectReferenceFromClusterSummary(cs)
+
+				if profileScope.IsDryRunSync() {
+					// In DryRun mode do not delete the ClusterSummary. Instead clear its
+					// helmCharts/policyRefs/kustomizationRefs and set syncMode to DryRun so
+					// that the next DryRun reconciliation shows all resources as being removed.
+					// The ClusterSummary stays alive so that if the user reverts the selector
+					// change there is no unnecessary undeploy+redeploy cycle.
+					if err := clearClusterSummaryRefs(ctx, c, cs, profileScope.GetSpec().SyncMode); err != nil {
+						profileScope.Error(err, fmt.Sprintf("failed to clear ClusterSummary refs for cluster %s/%s",
+							cs.Namespace, cs.Name))
+						return err
+					}
+					if err := createClusterReport(ctx, c, profileScope.Profile, clusterRef); err != nil {
+						profileScope.Error(err, fmt.Sprintf("failed to create ClusterReport for cluster %s/%s",
+							cs.Namespace, cs.Name))
+						return err
+					}
+					continue
+				}
+
 				currentClusterSummary, err := updateClusterSummary(ctx, c, profileScope, cs, clusterRef)
 				if err != nil {
 					profileScope.Error(err, fmt.Sprintf("failed to update ClusterSummary for cluster %s/%s",
@@ -865,6 +892,33 @@ func cleanClusterSummaries(ctx context.Context, c client.Client, profileScope *s
 		return fmt.Errorf("clusterSummaries still present")
 	}
 	return nil
+}
+
+// clearClusterSummaryRefs zeros out the deployable content of a ClusterSummary and sets its
+// syncMode without deleting it. Used in DryRun mode when a cluster stops matching: the next
+// DryRun reconciliation will report all resources as pending removal, while the ClusterSummary
+// remains so it can be recovered cheaply if the selector is reverted.
+func clearClusterSummaryRefs(ctx context.Context, c client.Client,
+	clusterSummary *configv1beta1.ClusterSummary, syncMode configv1beta1.SyncMode) error {
+
+	cs := &configv1beta1.ClusterSummary{}
+	if err := c.Get(ctx, types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name}, cs); err != nil {
+		return err
+	}
+
+	if cs.Spec.ClusterProfileSpec.HelmCharts == nil &&
+		cs.Spec.ClusterProfileSpec.PolicyRefs == nil &&
+		cs.Spec.ClusterProfileSpec.KustomizationRefs == nil &&
+		cs.Spec.ClusterProfileSpec.SyncMode == syncMode {
+
+		return nil
+	}
+
+	cs.Spec.ClusterProfileSpec.HelmCharts = nil
+	cs.Spec.ClusterProfileSpec.PolicyRefs = nil
+	cs.Spec.ClusterProfileSpec.KustomizationRefs = nil
+	cs.Spec.ClusterProfileSpec.SyncMode = syncMode
+	return c.Update(ctx, cs)
 }
 
 func updateClusterSummarySyncMode(ctx context.Context, c client.Client,

--- a/controllers/profile_utils_test.go
+++ b/controllers/profile_utils_test.go
@@ -603,6 +603,125 @@ var _ = Describe("Profile: Reconciler", func() {
 		Expect(len(clusterSummaryList.Items)).To(BeZero())
 	})
 
+	It("cleanClusterSummaries in DryRun mode keeps ClusterSummary alive with cleared refs when cluster stops matching", func() {
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeDryRun
+		clusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
+			{
+				Kind:      string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+				Namespace: randomString(),
+				Name:      randomString(),
+			},
+		}
+
+		// ClusterSummary has Continuous syncMode and non-empty refs — as it was before the profile changed
+		clusterSummaryName := clusterops.GetClusterSummaryName(configv1beta1.ClusterProfileKind,
+			clusterProfile.Name, nonMatchingCluster.Name, false)
+		clusterSummary := &configv1beta1.ClusterSummary{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterSummaryName,
+				Namespace: nonMatchingCluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: clusterProfile.APIVersion,
+						Kind:       clusterProfile.Kind,
+						Name:       clusterProfile.Name,
+					},
+				},
+			},
+			Spec: configv1beta1.ClusterSummarySpec{
+				ClusterNamespace: nonMatchingCluster.Namespace,
+				ClusterName:      nonMatchingCluster.Name,
+				ClusterProfileSpec: configv1beta1.Spec{
+					SyncMode:   configv1beta1.SyncModeContinuous,
+					PolicyRefs: clusterProfile.Spec.PolicyRefs,
+				},
+				ClusterType: libsveltosv1beta1.ClusterTypeCapi,
+			},
+		}
+		addLabelsToClusterSummary(clusterSummary, clusterProfile.Name, nonMatchingCluster.Name,
+			libsveltosv1beta1.ClusterTypeCapi)
+
+		initObjects := []client.Object{
+			clusterProfile,
+			nonMatchingCluster,
+			clusterSummary,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
+
+		profileScope, err := scope.NewProfileScope(scope.ProfileScopeParams{
+			Client:         c,
+			Logger:         logger,
+			Profile:        clusterProfile,
+			ControllerName: "clusterprofile",
+		})
+		Expect(err).To(BeNil())
+
+		// DryRun: cleanClusterSummaries must not delete the ClusterSummary and must not return an error
+		Expect(controllers.CleanClusterSummaries(context.TODO(), c, profileScope)).To(Succeed())
+
+		// ClusterSummary is still present
+		currentClusterSummary := &configv1beta1.ClusterSummary{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterSummary.Namespace, Name: clusterSummary.Name},
+			currentClusterSummary)).To(Succeed())
+
+		// Refs are cleared and syncMode is updated to DryRun
+		Expect(currentClusterSummary.Spec.ClusterProfileSpec.PolicyRefs).To(BeNil())
+		Expect(currentClusterSummary.Spec.ClusterProfileSpec.HelmCharts).To(BeNil())
+		Expect(currentClusterSummary.Spec.ClusterProfileSpec.KustomizationRefs).To(BeNil())
+		Expect(currentClusterSummary.Spec.ClusterProfileSpec.SyncMode).To(Equal(configv1beta1.SyncModeDryRun))
+
+		// A ClusterReport is created for the deselected cluster
+		clusterReportList := &configv1beta1.ClusterReportList{}
+		Expect(c.List(context.TODO(), clusterReportList)).To(Succeed())
+		Expect(len(clusterReportList.Items)).To(Equal(1))
+	})
+
+	It("cleanClusterConfigurations in DryRun mode keeps ClusterConfiguration intact when cluster stops matching", func() {
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeDryRun
+
+		clusterConfiguration := &configv1beta1.ClusterConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: nonMatchingCluster.Namespace,
+				Name:      controllers.GetClusterConfigurationName(nonMatchingCluster.Name, libsveltosv1beta1.ClusterTypeCapi),
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						Kind:       clusterProfile.Kind,
+						Name:       clusterProfile.Name,
+						APIVersion: clusterProfile.APIVersion,
+						UID:        clusterProfile.UID,
+					},
+				},
+			},
+		}
+
+		initObjects := []client.Object{
+			clusterProfile,
+			nonMatchingCluster,
+			clusterConfiguration,
+		}
+
+		c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(initObjects...).WithObjects(initObjects...).Build()
+
+		// No matching clusters: the ClusterConfiguration is not in the matching set
+		profileScope, err := scope.NewProfileScope(scope.ProfileScopeParams{
+			Client:         c,
+			Logger:         logger,
+			Profile:        clusterProfile,
+			ControllerName: "clusterprofile",
+		})
+		Expect(err).To(BeNil())
+
+		Expect(controllers.CleanClusterConfigurations(context.TODO(), c, profileScope)).To(Succeed())
+
+		// ClusterConfiguration must still exist — the DryRun reconciler needs it
+		currentClusterConfiguration := &configv1beta1.ClusterConfiguration{}
+		Expect(c.Get(context.TODO(),
+			types.NamespacedName{Namespace: clusterConfiguration.Namespace, Name: clusterConfiguration.Name},
+			currentClusterConfiguration)).To(Succeed())
+	})
+
 	It("updateClusterSummarySyncMode updates ClusterSummary SyncMode", func() {
 		clusterSummary := &configv1beta1.ClusterSummary{
 			ObjectMeta: metav1.ObjectMeta{

--- a/test/fv/dryrun_test.go
+++ b/test/fv/dryrun_test.go
@@ -585,7 +585,7 @@ var _ = Describe("DryRun", Serial, func() {
 			// Since ClusterProfile is in DryRun mode, ClusterSummary should be marked as deleted but not removed
 			// In DryRun mode ClusterReport still needs to be updated.
 
-			// First wait for clusterSummary to be marked for deletion
+			// First wait for clusterSummary to be marked for removal (helmCharts/PolicyRefs are all nil)
 			Eventually(func() bool {
 				currentClusterSummary := &configv1beta1.ClusterSummary{}
 				err = k8sClient.Get(context.TODO(),
@@ -593,7 +593,8 @@ var _ = Describe("DryRun", Serial, func() {
 				if err != nil {
 					return false
 				}
-				return !currentClusterSummary.DeletionTimestamp.IsZero()
+				return len(currentClusterSummary.Spec.ClusterProfileSpec.HelmCharts) == 0 &&
+					len(currentClusterSummary.Spec.ClusterProfileSpec.PolicyRefs) == 0
 			}, timeout, pollingInterval).Should(BeTrue())
 
 			// Then verify ClusterSummary is not removed.
@@ -604,7 +605,8 @@ var _ = Describe("DryRun", Serial, func() {
 				if err != nil {
 					return false
 				}
-				return !currentClusterSummary.DeletionTimestamp.IsZero()
+				return len(currentClusterSummary.Spec.ClusterProfileSpec.HelmCharts) == 0 &&
+					len(currentClusterSummary.Spec.ClusterProfileSpec.PolicyRefs) == 0
 			}, timeout/2, pollingInterval).Should(BeTrue())
 
 			mariadDBRR = &libsveltosv1beta1.ResourceReport{


### PR DESCRIPTION
When a ClusterProfile is edited to simultaneously change the cluster selector (deselecting a cluster) and switch the sync mode to DryRun, the expected behavior is for a ClusterReport to be generated showing what resources would be removed.

Instead, two bugs caused this to fail silently:

Bug 1: When a cluster stopped matching, the system immediately marked the ClusterSummary for deletion. This triggered actual undeploy logic before DryRun mode could take effect, leaving no ClusterReport behind.

Bug 2: In DryRun ClusterSummary must not be deleted. If the profile change is reverted, goal is for Sveltos to remove nothing.

Fix: When a cluster stops matching a profile that is in DryRun mode:

- The ClusterSummary is kept alive rather than deleted, but its deployable content (Helm charts, policy refs, kustomization refs) is cleared and its sync mode is updated to DryRun atomically in a single update. This ensures the reconciler treats it as a DryRun from the moment it next runs.
- A ClusterReport is created immediately so the DryRun reconciliation has something to write its diff into.
- The ClusterConfiguration for the deselected cluster is left intact so the reconciler can access it during DryRun processing.

If the user reverts the selector change, the ClusterSummary is still present and can be restored without an unnecessary undeploy/redeploy cycle. If the user commits the change by switching off DryRun, the normal deletion and cleanup path runs as expected.

Fixes #1476 