### PR TITLE
(chore) add test to validate drift-detection content

### DIFF
--- a/controllers/drift_detection_upgrade.go
+++ b/controllers/drift_detection_upgrade.go
@@ -295,17 +295,28 @@ func skipUpgrading(ctx context.Context, c client.Client, cluster client.Object,
 		return true, err
 	}
 
-	if !isDriftDetectionManagerDeployedInCluster(ctx, managedClient) {
-		return true, nil // nothing to upgrade
+	present, err := isDriftDetectionManagerDeployedInCluster(ctx, managedClient)
+	if err != nil {
+		logger.V(logs.LogInfo).Error(err, "failed to verify presence of drift-detection-manager deployment")
+		return true, err
 	}
 
-	return false, nil
+	return present, nil
 }
 
-func isDriftDetectionManagerDeployedInCluster(ctx context.Context, c client.Client) bool {
+func isDriftDetectionManagerDeployedInCluster(ctx context.Context, c client.Client) (bool, error) {
 	deployment := &appsv1.Deployment{}
+	// A test in pkg/drift-detection makes sure this name is correct
 	err := c.Get(ctx, types.NamespacedName{Namespace: projectsveltos, Name: "drift-detection-manager"}, deployment)
-	return err == nil
+
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func getListOfClustersWithDriftDetection(ctx context.Context, c client.Client,

--- a/pkg/drift-detection/drift_manager_test.go
+++ b/pkg/drift-detection/drift_manager_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driftdetection_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	driftdetection "github.com/projectsveltos/addon-controller/pkg/drift-detection"
+	"github.com/projectsveltos/libsveltos/lib/deployer"
+	"github.com/projectsveltos/libsveltos/lib/k8s_utils"
+)
+
+var _ = Describe("Validate drift-detection-manager YAML", func() {
+	It("Deployment name validation", func() {
+		driftDetectionManagerYAML := string(driftdetection.GetDriftDetectionManagerYAML())
+		Expect(len(driftDetectionManagerYAML)).ToNot(BeZero())
+
+		elements, err := deployer.CustomSplit(driftDetectionManagerYAML)
+		Expect(err).To(BeNil())
+		for i := range elements {
+			policy, err := k8s_utils.GetUnstructured([]byte(elements[i]))
+			Expect(err).To(BeNil())
+			if policy.GetKind() == "Deployment" {
+				// drift-detection upgrade logic (isDriftDetectionManagerDeployedInCluster)
+				// assumes this is the name
+				Expect(policy.GetName()).To(Equal("drift-detection-manager"))
+				Expect(policy.GetNamespace()).To(Equal("projectsveltos"))
+			}
+		}
+	})
+})

--- a/pkg/drift-detection/suite_test.go
+++ b/pkg/drift-detection/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package driftdetection_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestScope(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Scope Suite")
+}

--- a/pkg/scope/set_test.go
+++ b/pkg/scope/set_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"


### PR DESCRIPTION
Drift detection upgrade path, assumes the name of drift-detection-manager. This PR adds a test making sure that name is correct and that a name change is caught by ut.

This PR also handles error while verifying the presence of drift-detection-manager on a managed cluster