### PR TITLE
(bug) Undeploy Helm Charts in pull mode

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -403,6 +403,12 @@ func undeployHelmChartsInPullMode(ctx context.Context, c client.Client, clusterS
 		string(libsveltosv1beta1.FeatureHelm), logger)
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
+			if pullmode.IsActionNotSetToDeploy(err) {
+				// CG is already in ActionRemove state — RemoveDeployedResources was called in a previous
+				// cycle. processUndeployResultInPullMode monitors completion via GetRemoveStatus and will
+				// call TerminateDeploymentTracking once the agent finishes. Nothing to do here.
+				return nil
+			}
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to GetDeploymentStatus: %v", err))
 			return err
 		}

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
@@ -46,6 +45,7 @@ import (
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
 	"github.com/projectsveltos/libsveltos/lib/patcher"
 	pullmode "github.com/projectsveltos/libsveltos/lib/pullmode"
+	"github.com/projectsveltos/libsveltos/lib/randutils"
 )
 
 const (
@@ -507,7 +507,7 @@ func getInstantiatedObjectName(objects []client.Object) (name string, err error)
 		// be picked
 		prefix := "drift-detection-"
 		const nameLength = 20
-		name = prefix + util.RandomString(nameLength)
+		name = prefix + randutils.RandomString(nameLength)
 		err = nil
 	case 1:
 		name = objects[0].GetName()

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.8.1-0.20260430141146-b84cd584e5f2
+	github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,6 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
-github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
@@ -274,8 +272,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260430141146-b84cd584e5f2 h1:GCC25qLsQQrfsuedrI8yl3EBO1DMS/tP8f/71AYfgVY=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260430141146-b84cd584e5f2/go.mod h1:CLKZ+yNQY6x+IzFn5ms9CKms9DzvbuxYwrnzTKYDCWI=
+github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7 h1:4n1Cx2Y/hVblvTmM/UPALV8q8jgVhDkRdCHgDepsM5A=
+github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7/go.mod h1:CLKZ+yNQY6x+IzFn5ms9CKms9DzvbuxYwrnzTKYDCWI=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=


### PR DESCRIPTION
If the ConfigurationGroup is already in ActionRemove state (undeploy was already initiated). Just return nil, let
_processUndeployResultInPullMode_ handle completion