### PR TITLE
(bug) Fix a bug updating ClusterConfiguration OwnerReferences

### DIFF
--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -320,7 +320,6 @@ func (r *ClusterSummaryReconciler) proceedDeployingFeatureInPullMode(ctx context
 				// The agent has not yet processed the current ConfigurationGroup generation or
 				// requestor hash. Back off using HealthErrorRetryTime so the addon-controller
 				// does not update the ConfigurationGroup again before the agent is done.
-				logger.V(logs.LogInfo).Info("MGIANLUC isProcessingMismatch")
 				return &clusterops.HealthCheckError{
 					FeatureID:   f.id,
 					CheckName:   "agent-processing",
@@ -589,6 +588,7 @@ func (r *ClusterSummaryReconciler) processUndeployResultInPullMode(ctx context.C
 		}
 		errorMsg := err.Error()
 		clusterSummaryScope.SetFailureMessage(f.id, &errorMsg)
+		return err
 	} else {
 		if agentStatus != nil {
 			if agentStatus.DeploymentStatus != nil && *agentStatus.DeploymentStatus == libsveltosv1beta1.FeatureStatusRemoved {

--- a/controllers/profile_utils.go
+++ b/controllers/profile_utils.go
@@ -275,9 +275,10 @@ func updateClusterConfigurationOwnerReferences(ctx context.Context, c client.Cli
 			return err
 		}
 
-		currentClusterConfiguration.OwnerReferences = util.EnsureOwnerRef(clusterConfiguration.OwnerReferences, ownerRef)
+		currentClusterConfiguration.OwnerReferences = util.EnsureOwnerRef(currentClusterConfiguration.OwnerReferences, ownerRef)
 		return c.Update(ctx, currentClusterConfiguration)
 	})
+
 	return err
 }
 
@@ -347,7 +348,6 @@ func updateClusterConfigurations(ctx context.Context, c client.Client, profileSc
 				cluster.Namespace, cluster.Name))
 			return err
 		}
-
 		// Update ClusterConfiguration
 		err = updateClusterConfigurationWithProfile(ctx, c, profileScope.Profile, &cluster)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.40.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7
+	github.com/projectsveltos/libsveltos v1.8.1-0.20260504084132-12f98fc4a775
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7 h1:4n1Cx2Y/hVblvTmM/UPALV8q8jgVhDkRdCHgDepsM5A=
-github.com/projectsveltos/libsveltos v1.8.1-0.20260503183018-cf85218400d7/go.mod h1:CLKZ+yNQY6x+IzFn5ms9CKms9DzvbuxYwrnzTKYDCWI=
+github.com/projectsveltos/libsveltos v1.8.1-0.20260504084132-12f98fc4a775 h1:VtGEtCLH/A6jMji4aDFBmuit9o/+BtLatwFEEkCTTlw=
+github.com/projectsveltos/libsveltos v1.8.1-0.20260504084132-12f98fc4a775/go.mod h1:CLKZ+yNQY6x+IzFn5ms9CKms9DzvbuxYwrnzTKYDCWI=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier@sha256:c2c9575d7bae7608ea238e7f000ed131a254d8fda5da8e73de336c09b8528a56
+        image: docker.io/projectsveltos/sveltos-applier@sha256:38cffd83ded4a5c21173b5931372f4af47e523c29ae3ffaa1f6dd34a71482025
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Code was incorrectly updating ClusterConfiguration OwnerReferences causing the ClusterConfiguration instance to be incorrectly deleted. This PR fixes that.

This PR also removes a log that was incorrectly merged to main.