### PR TITLE
(feat) allow configurable namespace for Sveltos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OS ?= $(shell uname -s)
 OS := $(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
 K8S_LATEST_VER ?= $(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.10.0
+TAG ?= main
 
 .PHONY: all
 all: build

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,6 +110,7 @@ const (
 	defaulReportMode    = int(controllers.CollectFromManagementCluster)
 	mebibytes_bytes     = 1 << 20
 	gibibytes_per_bytes = 1 << 30
+	sveltosNamespace    = "NAMESPACE"
 )
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -124,15 +125,17 @@ func main() {
 
 	setupLogging()
 
+	sveltosNamespace := os.Getenv(sveltosNamespace)
+	if sveltosNamespace == "" {
+		setupLog.V(logs.LogInfo).Error(nil, "Missing required environment variables NAMESPACE")
+		os.Exit(1)
+	}
+
 	reportMode = controllers.ReportMode(tmpReportMode)
 	ctrl.SetLogger(klog.Background())
 	ctrlOptions := getCtrlOptions(scheme)
 
-	restConfig := ctrl.GetConfigOrDie()
-	restConfig.QPS = restConfigQPS
-	restConfig.Burst = restConfigBurst
-	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent("addon-controller")
-	restConfig.WarningHandler = apiwarnings.DefaultHandler(klog.Background().WithName("API Server Warning"))
+	restConfig := getRestConfig()
 
 	ctx := ctrl.SetupSignalHandler()
 
@@ -143,6 +146,7 @@ func main() {
 	controllers.SetCAPIOnboardAnnotation(capiOnboardAnnotation)
 	controllers.SetDriftDetectionRegistry(registry)
 	controllers.SetAgentInMgmtCluster(agentInMgmtCluster)
+	controllers.SetSveltosNamespace(sveltosNamespace)
 
 	if isInitContainer() {
 		runInitContainerWork(ctx, restConfig, scheme)
@@ -175,7 +179,7 @@ func main() {
 	controllers.NewLicenseManager()
 
 	if shardKey == "" && !disableTelemetry {
-		err = telemetry.StartCollecting(ctx, mgr.GetConfig(), mgr.GetClient(), version)
+		err = telemetry.StartCollecting(ctx, mgr.GetConfig(), mgr.GetClient(), sveltosNamespace, version)
 		if err != nil {
 			setupLog.Error(err, "failed starting telemetry client")
 		}
@@ -256,10 +260,10 @@ func initFlags(fs *pflag.FlagSet) {
 		"Bind address to expose the pprof profiler (e.g. localhost:6060)")
 
 	fs.StringVar(&driftDetectionConfigMap, "drift-detection-config", "",
-		"The name of the ConfigMap in the projectsveltos namespace containing the drift-detection-manager configuration")
+		"The name of the ConfigMap in the namespace where projectsveltos is deployed containing the drift-detection-manager configuration")
 
 	fs.StringVar(&luaConfigMap, "lua-methods", "",
-		"The name of the ConfigMap in the projectsveltos namespace containing lua utilities to be loaded."+
+		"The name of the ConfigMap in the namespace where projectsveltos is deployed containing lua utilities to be loaded."+
 			"Changing the content of the ConfigMap does not cause Sveltos to redeploy.")
 
 	fs.StringVar(&registry, "registry", "",
@@ -796,4 +800,13 @@ func setupLogging() {
 	pflag.Parse()
 
 	ctrl.SetLogger(klog.Background())
+}
+
+func getRestConfig() *rest.Config {
+	restConfig := ctrl.GetConfigOrDie()
+	restConfig.QPS = restConfigQPS
+	restConfig.Burst = restConfigBurst
+	restConfig.UserAgent = remote.DefaultClusterAPIUserAgent("addon-controller")
+	restConfig.WarningHandler = apiwarnings.DefaultHandler(klog.Background().WithName("API Server Warning"))
+	return restConfig
 }

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -14,6 +14,19 @@ spec:
         - "--report-mode=0"
         - --shard-key=
         - "--agent-in-mgmt-cluster=false"
+        env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       containers:
       - name: controller
         args:
@@ -22,7 +35,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.10.0"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT
@@ -33,3 +46,7 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,8 +7,8 @@ spec:
   template:
     spec:
       initContainers:
-      - image: docker.io/projectsveltos/addon-controller:v1.10.0
+      - image: docker.io/projectsveltos/addon-controller:main
         name: initialization
       containers:
-      - image: docker.io/projectsveltos/addon-controller:v1.10.0
+      - image: docker.io/projectsveltos/addon-controller:main
         name: controller

--- a/controllers/clusterpromotion_controller.go
+++ b/controllers/clusterpromotion_controller.go
@@ -1319,7 +1319,7 @@ func (r *ClusterPromotionReconciler) verifyStageEligibility(ctx context.Context,
 		return false, err
 	}
 
-	result := license.VerifyLicenseSecret(ctx, r.Client, publicKey, logger)
+	result := license.VerifyLicenseSecret(ctx, r.Client, getSveltosNamespace(), publicKey, logger)
 	if result.Message != "" {
 		logger.V(logs.LogDebug).Info(result.Message)
 	}

--- a/controllers/clustersummary_controller.go
+++ b/controllers/clustersummary_controller.go
@@ -414,7 +414,7 @@ func (r *ClusterSummaryReconciler) postFinalizerCleanup(ctx context.Context,
 
 	cs := clusterSummaryScope.ClusterSummary
 	if err := sharding.UnregisterClusterShard(ctx, r.Client, libsveltosv1beta1.ComponentAddonManager,
-		string(libsveltosv1beta1.FeatureHelm), cs.Spec.ClusterNamespace, cs.Spec.ClusterName,
+		getSveltosNamespace(), string(libsveltosv1beta1.FeatureHelm), cs.Spec.ClusterNamespace, cs.Spec.ClusterName,
 		cs.Spec.ClusterType); err != nil {
 		logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to unregister cluster shard: %v", err))
 		return err
@@ -1048,7 +1048,7 @@ func (r *ClusterSummaryReconciler) updateMaps(ctx context.Context, clusterSummar
 			currentReferences.Insert(&corev1.ObjectReference{
 				APIVersion: corev1.SchemeGroupVersion.String(),
 				Kind:       string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
-				Namespace:  projectsveltos,
+				Namespace:  getSveltosNamespace(),
 				Name:       driftDetectionConfigMap,
 			})
 		}
@@ -1608,8 +1608,8 @@ func (r *ClusterSummaryReconciler) updateClusterShardPair(ctx context.Context,
 	}
 
 	if hasShardChanged, err := sharding.RegisterClusterShard(ctx, r.Client, libsveltosv1beta1.ComponentAddonManager,
-		string(libsveltosv1beta1.FeatureHelm), r.ShardKey, clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
-		clusterSummary.Spec.ClusterType); err != nil {
+		getSveltosNamespace(), string(libsveltosv1beta1.FeatureHelm), r.ShardKey, clusterSummary.Spec.ClusterNamespace,
+		clusterSummary.Spec.ClusterName, clusterSummary.Spec.ClusterType); err != nil {
 		logger.V(logs.LogDebug).Info(fmt.Sprintf("failed to check/update cluster:shard pair %v", err))
 		return err
 	} else if hasShardChanged {
@@ -1938,7 +1938,7 @@ func (r *ClusterSummaryReconciler) verifyPullModeEligibility(ctx context.Context
 		return false, err
 	}
 
-	result := license.VerifyLicenseSecret(ctx, r.Client, publicKey, logger)
+	result := license.VerifyLicenseSecret(ctx, r.Client, getSveltosNamespace(), publicKey, logger)
 	maxClusters := 0
 	if result.Payload != nil {
 		maxClusters = result.Payload.MaxClusters

--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -51,10 +51,11 @@ import (
 )
 
 var (
-	testEnv *helpers.TestEnvironment
-	cancel  context.CancelFunc
-	ctx     context.Context
-	scheme  *runtime.Scheme
+	testEnv          *helpers.TestEnvironment
+	cancel           context.CancelFunc
+	ctx              context.Context
+	scheme           *runtime.Scheme
+	sveltosNamespace string
 )
 
 func TestControllers(t *testing.T) {
@@ -86,7 +87,9 @@ var _ = BeforeSuite(func() {
 		panic(err)
 	}
 
+	sveltosNamespace = randomString()
 	controllers.SetManagementClusterAccess(testEnv.Client, testEnv.Config, dc)
+	controllers.SetSveltosNamespace(sveltosNamespace)
 	controllers.CreatFeatureHandlerMaps()
 
 	Expect(index.AddDefaultIndexes(ctx, testEnv.Manager)).To(Succeed())
@@ -137,7 +140,7 @@ var _ = BeforeSuite(func() {
 
 	projectsveltosNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "projectsveltos",
+			Name: sveltosNamespace,
 		},
 	}
 	Expect(testEnv.Create(context.TODO(), projectsveltosNs)).To(Succeed())

--- a/controllers/drift_detection_upgrade.go
+++ b/controllers/drift_detection_upgrade.go
@@ -49,7 +49,9 @@ func upgradeDriftDetection(ctx context.Context, shardKey string, logger logr.Log
 	upgradeDriftDetectionDeploymentsInManagedClusters(ctx, shardKey, logger)
 }
 
-func upgradeDriftDetectionDeploymentsInManagedClusters(ctx context.Context, shardKey string, logger logr.Logger) {
+func upgradeDriftDetectionDeploymentsInManagedClusters(ctx context.Context, shardKey string,
+	logger logr.Logger) {
+
 	const two = 2
 	const maxRetryAfter = two * time.Minute // Maximum sleep duration
 	retryAfter := 10 * time.Second
@@ -308,7 +310,7 @@ func skipUpgrading(ctx context.Context, c client.Client, cluster client.Object,
 func isDriftDetectionManagerDeployedInCluster(ctx context.Context, c client.Client) (bool, error) {
 	deployment := &appsv1.Deployment{}
 	// A test in pkg/drift-detection makes sure this name is correct
-	err := c.Get(ctx, types.NamespacedName{Namespace: projectsveltos, Name: "drift-detection-manager"}, deployment)
+	err := c.Get(ctx, types.NamespacedName{Namespace: getSveltosNamespace(), Name: "drift-detection-manager"}, deployment)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/controllers/drift_detection_upgrade_test.go
+++ b/controllers/drift_detection_upgrade_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		depl := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "drift-detection-manager",
-				Namespace: "projectsveltos",
+				Namespace: sveltosNamespace,
 				Labels: map[string]string{
 					"control-plane": "drift-detection-manager",
 				},
@@ -171,7 +171,7 @@ var _ = Describe("Drift Detection Upgrade", func() {
 		depl := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "some-other-deployment",
-				Namespace: "projectsveltos",
+				Namespace: sveltosNamespace,
 				Labels: map[string]string{
 					"control-plane": "drift-detection-manager",
 				},

--- a/controllers/management_cluster.go
+++ b/controllers/management_cluster.go
@@ -34,6 +34,7 @@ var (
 	managementClusterMapper          *restmapper.DeferredDiscoveryRESTMapper
 	managementClusterCachedDiscovery discovery.CachedDiscoveryInterface
 
+	sveltosNamespace        string
 	driftdetectionConfigMap string
 	luaConfigMap            string
 	capiOnboardAnnotation   string
@@ -79,6 +80,10 @@ func SetAgentInMgmtCluster(isInMgmtCluster bool) {
 	agentInMgmtCluster = isInMgmtCluster
 }
 
+func SetSveltosNamespace(namespace string) {
+	sveltosNamespace = namespace
+}
+
 func getManagementClusterConfig() *rest.Config {
 	return managementClusterConfig
 }
@@ -119,6 +124,10 @@ func getAgentInMgmtCluster() bool {
 	return agentInMgmtCluster
 }
 
+func getSveltosNamespace() string {
+	return sveltosNamespace
+}
+
 func resetManagementClusterMapper() {
 	managementClusterMapper.Reset()
 }
@@ -131,7 +140,7 @@ func collectDriftDetectionConfigMap(ctx context.Context) (*corev1.ConfigMap, err
 	c := getManagementClusterClient()
 	configMap := &corev1.ConfigMap{}
 
-	err := c.Get(ctx, types.NamespacedName{Namespace: projectsveltos, Name: getDriftDetectionConfigMap()},
+	err := c.Get(ctx, types.NamespacedName{Namespace: sveltosNamespace, Name: getDriftDetectionConfigMap()},
 		configMap)
 	if err != nil {
 		return nil, err
@@ -144,7 +153,7 @@ func collectLuaConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 	c := getManagementClusterClient()
 	configMap := &corev1.ConfigMap{}
 
-	err := c.Get(ctx, types.NamespacedName{Namespace: projectsveltos, Name: getLuaConfigMap()},
+	err := c.Get(ctx, types.NamespacedName{Namespace: sveltosNamespace, Name: getLuaConfigMap()},
 		configMap)
 	if err != nil {
 		return nil, err

--- a/controllers/metrics.go
+++ b/controllers/metrics.go
@@ -30,7 +30,7 @@ import (
 var (
 	programResourceDurationHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Namespace: "projectsveltos",
+			Namespace: getSveltosNamespace(),
 			Name:      "program_resources_time_seconds",
 			Help:      "Program Resources on a workload cluster duration distribution",
 			Buckets:   []float64{0.5, 1, 1.5, 2, 3, 5, 10, 30, 60, 90, 120},
@@ -39,7 +39,7 @@ var (
 
 	programChartDurationHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Namespace: "projectsveltos",
+			Namespace: getSveltosNamespace(),
 			Name:      "program_charts_time_seconds",
 			Help:      "Program Helm charts on a workload cluster duration distribution",
 			Buckets:   []float64{0.5, 1, 1.5, 2, 3, 5, 10, 30, 60, 90, 120},
@@ -48,7 +48,7 @@ var (
 
 	reconciliationCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "projectsveltos",
+			Namespace: getSveltosNamespace(),
 			Name:      "reconcile_operations_total",
 			Help:      "Total number of reconcile operations for Helm, Resources, and Kustomization",
 		},
@@ -57,7 +57,7 @@ var (
 
 	driftCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: "projectsveltos",
+			Namespace: getSveltosNamespace(),
 			Name:      "total_drifts",
 			Help:      "Total number of drifts for a given cluster indexed via type, namespace/name and feature id",
 		},

--- a/controllers/resourcesummary.go
+++ b/controllers/resourcesummary.go
@@ -49,7 +49,6 @@ import (
 )
 
 const (
-	projectsveltos = "projectsveltos"
 	deploymentKind = "Deployment"
 
 	driftDetectionClusterNamespaceLabel = "cluster-namespace"
@@ -76,13 +75,14 @@ const (
 	driftDetectionOverrideAnnotation = "driftdetection.projectsveltos.io/config-override-ref"
 )
 
-func getDriftDetectionNamespaceInMgmtCluster() string {
-	return projectsveltos
+func getDriftDetectionNamespaceInMgmtCluster(sveltosNamespace string) string {
+	return sveltosNamespace
 }
 
 func deployDriftDetectionManagerInCluster(ctx context.Context, c client.Client,
-	clusterNamespace, clusterName, applicant, featureID string, clusterType libsveltosv1beta1.ClusterType,
-	isPullMode, startInMgmtCluster bool, logger logr.Logger) error {
+	clusterNamespace, clusterName, applicant, featureID string,
+	clusterType libsveltosv1beta1.ClusterType, isPullMode, startInMgmtCluster bool,
+	logger logr.Logger) error {
 
 	logger = logger.WithValues("clustersummary", applicant)
 	logger = logger.WithValues("cluster", fmt.Sprintf("%s:%s/%s", clusterType, clusterNamespace, clusterName))
@@ -112,8 +112,8 @@ func deployDriftDetectionManagerInCluster(ctx context.Context, c client.Client,
 	// Deploy DriftDetectionManager
 	if startInMgmtCluster && !isPullMode {
 		restConfig := getManagementClusterConfig()
-		return deployDriftDetectionManagerInManagementCluster(ctx, restConfig, clusterNamespace,
-			clusterName, "do-not-send-updates", clusterType, patches, logger)
+		return deployDriftDetectionManagerInManagementCluster(ctx, restConfig, clusterNamespace, clusterName,
+			"do-not-send-updates", clusterType, patches, logger)
 	}
 
 	return deployDriftDetectionManagerInManagedCluster(ctx, clusterNamespace, clusterName,
@@ -269,7 +269,7 @@ func deployDriftDetectionManagerInManagedCluster(ctx context.Context,
 // deployDriftDetectionManagerInManagementCluster deploys drift-detection-manager in the management cluster
 // When deploying drift-detection-manager in the management cluster, there is one Deployment instance
 // of drift-detection-manager per cluster.
-// Those instances are all running in the "projectsveltos" namespace.
+// Those instances are all running in the namespace where projectsveltos is deployed
 func deployDriftDetectionManagerInManagementCluster(ctx context.Context, restConfig *rest.Config,
 	clusterNamespace, clusterName, mode string, clusterType libsveltosv1beta1.ClusterType,
 	patches []libsveltosv1beta1.Patch, logger logr.Logger) error {
@@ -335,6 +335,10 @@ func deployDriftDetectionManagerResources(ctx context.Context, restConfig *rest.
 					return err
 				}
 			}
+		}
+
+		if policy.GetNamespace() != "" {
+			policy.SetNamespace(getSveltosNamespace())
 		}
 
 		var referencedUnstructured []*unstructured.Unstructured
@@ -453,7 +457,8 @@ func unDeployResourceSummaryInstance(ctx context.Context, clusterNamespace, clus
 
 // getDriftDetectionManagerDeploymentName returns the name for a given drift-detection-manager deployment
 // started in the management cluster for a given cluster.
-func getDriftDetectionManagerDeploymentName(ctx context.Context, restConfig *rest.Config, lbls map[string]string,
+func getDriftDetectionManagerDeploymentName(ctx context.Context, restConfig *rest.Config,
+	lbls map[string]string,
 ) (name string, err error) {
 
 	labelSelector := metav1.LabelSelector{
@@ -472,7 +477,8 @@ func getDriftDetectionManagerDeploymentName(ctx context.Context, restConfig *res
 	}
 
 	// using client and a List would require permission at cluster level. So using clientset instead
-	deployments, err := clientset.AppsV1().Deployments(getDriftDetectionNamespaceInMgmtCluster()).List(ctx, listOptions)
+	deployments, err := clientset.AppsV1().Deployments(getDriftDetectionNamespaceInMgmtCluster(getSveltosNamespace())).
+		List(ctx, listOptions)
 	if err != nil {
 		return "", err
 	}
@@ -483,8 +489,9 @@ func getDriftDetectionManagerDeploymentName(ctx context.Context, restConfig *res
 		// doesn't exist.
 		for i := range deployments.Items {
 			// Ignore eventual error, since we are returning an error anyway
-			_ = clientset.AppsV1().Deployments(getDriftDetectionNamespaceInMgmtCluster()).Delete(ctx,
-				deployments.Items[i].Name, metav1.DeleteOptions{})
+			_ = clientset.AppsV1().Deployments(getDriftDetectionNamespaceInMgmtCluster(getSveltosNamespace())).
+				Delete(ctx,
+					deployments.Items[i].Name, metav1.DeleteOptions{})
 		}
 		err = fmt.Errorf("more than one drift-detection deployment found")
 		return name, err
@@ -605,6 +612,10 @@ func removeDriftDetectionManagerFromManagementCluster(ctx context.Context,
 			return err
 		}
 
+		if policy.GetNamespace() != "" {
+			policy.SetNamespace(getSveltosNamespace())
+		}
+
 		dr, err := k8s_utils.GetDynamicResourceInterface(restConfig, policy.GroupVersionKind(), policy.GetNamespace())
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get dynamic client: %v", err))
@@ -629,7 +640,7 @@ func getDriftDetectionManagerPatchesOld(ctx context.Context, c client.Client,
 	configMap := &corev1.ConfigMap{}
 	if configMapName != "" {
 		err := c.Get(ctx,
-			types.NamespacedName{Namespace: projectsveltos, Name: configMapName},
+			types.NamespacedName{Namespace: getSveltosNamespace(), Name: configMapName},
 			configMap)
 		if err != nil {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf("failed to get ConfigMap %s: %v",
@@ -733,7 +744,7 @@ func getGlobalDriftDetectionManagerPatches(ctx context.Context, c client.Client,
 
 	configMapName := getDriftDetectionConfigMap()
 
-	patches, err := getDriftDetectionManagerPatchesNew(ctx, c, projectsveltos, configMapName, logger)
+	patches, err := getDriftDetectionManagerPatchesNew(ctx, c, getSveltosNamespace(), configMapName, logger)
 	if err == nil {
 		return patches, nil
 	}
@@ -823,7 +834,7 @@ func getResourceSummaryNameInfo(clusterNamespace, clusterSummaryName string) typ
 		resourceSummaryNamespace = clusterNamespace
 		resourceSummaryName = clusterops.GetResourceSummaryNameInManagemntCluster(clusterSummaryName)
 	} else {
-		resourceSummaryNamespace = clusterops.GetResourceSummaryNamespaceInManagedCluster()
+		resourceSummaryNamespace = clusterops.GetResourceSummaryNamespaceInManagedCluster(getSveltosNamespace())
 		resourceSummaryName = clusterops.GetResourceSummaryNameInManagedCluster(clusterNamespace, clusterSummaryName)
 	}
 

--- a/controllers/resourcesummary_collection.go
+++ b/controllers/resourcesummary_collection.go
@@ -50,8 +50,8 @@ var (
 )
 
 // Periodically collects ResourceSummaries from each CAPI/Sveltos cluster.
-func collectAndProcessResourceSummaries(ctx context.Context, c client.Client, shardkey, version string,
-	logger logr.Logger) {
+func collectAndProcessResourceSummaries(ctx context.Context, c client.Client,
+	shardkey, version string, logger logr.Logger) {
 
 	const interval = 10 * time.Second
 
@@ -327,8 +327,8 @@ func collectResourceSummariesFromCluster(ctx context.Context, c client.Client, c
 			return nil
 		}
 
-		if !sveltos_upgrade.IsDriftDetectionVersionCompatible(ctx, getManagementClusterClient(), version, cluster.Namespace,
-			cluster.Name, clusterproxy.GetClusterType(clusterRef), getAgentInMgmtCluster(), logger) {
+		if !sveltos_upgrade.IsDriftDetectionVersionCompatible(ctx, getManagementClusterClient(), getSveltosNamespace(), version,
+			cluster.Namespace, cluster.Name, clusterproxy.GetClusterType(clusterRef), getAgentInMgmtCluster(), logger) {
 
 			msg := "compatibility checks failed"
 			logger.V(logs.LogDebug).Info(msg)

--- a/controllers/resourcesummary_collection_test.go
+++ b/controllers/resourcesummary_collection_test.go
@@ -39,10 +39,6 @@ import (
 	"github.com/projectsveltos/libsveltos/lib/sveltos_upgrade"
 )
 
-const (
-	resourceSummaryNamespace = "projectsveltos"
-)
-
 var _ = Describe("ResourceSummary Collection", func() {
 	It("collectResourceSummariesFromCluster collects and processes ResourceSummaries from clusters", func() {
 		cluster := prepareCluster()
@@ -86,7 +82,7 @@ var _ = Describe("ResourceSummary Collection", func() {
 		// are created
 		ns := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: resourceSummaryNamespace,
+				Name: sveltosNamespace,
 			},
 		}
 		err := testEnv.Create(context.TODO(), ns)
@@ -105,20 +101,20 @@ var _ = Describe("ResourceSummary Collection", func() {
 
 		currentResourceSummary := &libsveltosv1beta1.ResourceSummary{}
 		Expect(testEnv.Get(context.TODO(),
-			types.NamespacedName{Namespace: resourceSummaryNamespace, Name: resourceSummary.Name},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: resourceSummary.Name},
 			currentResourceSummary)).To(Succeed())
 		currentResourceSummary.Status.HelmResourcesChanged = true
 		Expect(testEnv.Status().Update(context.TODO(), currentResourceSummary))
 
 		Eventually(func() bool {
 			err = testEnv.Get(context.TODO(),
-				types.NamespacedName{Namespace: resourceSummaryNamespace, Name: resourceSummary.Name},
+				types.NamespacedName{Namespace: sveltosNamespace, Name: resourceSummary.Name},
 				currentResourceSummary)
 			return err == nil && currentResourceSummary.Status.HelmResourcesChanged
 		}, timeout, pollingInterval).Should(BeTrue())
 
 		Expect(testEnv.Get(context.TODO(),
-			types.NamespacedName{Namespace: resourceSummaryNamespace, Name: resourceSummary.Name},
+			types.NamespacedName{Namespace: sveltosNamespace, Name: resourceSummary.Name},
 			currentResourceSummary)).To(Succeed())
 		Expect(currentResourceSummary.Status.HelmResourcesChanged).To(BeTrue())
 
@@ -150,7 +146,7 @@ var _ = Describe("ResourceSummary Collection", func() {
 		// Eventual loop so testEnv Cache is synced
 		Eventually(func() bool {
 			err = testEnv.Get(context.TODO(),
-				types.NamespacedName{Namespace: resourceSummaryNamespace, Name: resourceSummary.Name},
+				types.NamespacedName{Namespace: sveltosNamespace, Name: resourceSummary.Name},
 				currentResourceSummary)
 			return err == nil && !currentResourceSummary.Status.HelmResourcesChanged
 		}, timeout, pollingInterval).Should(BeTrue())
@@ -319,7 +315,7 @@ func getResourceSummary(resource, helmResource *corev1.ObjectReference) *libsvel
 	rs := &libsveltosv1beta1.ResourceSummary{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      randomString(),
-			Namespace: resourceSummaryNamespace,
+			Namespace: sveltosNamespace,
 		},
 	}
 

--- a/controllers/resourcesummary_test.go
+++ b/controllers/resourcesummary_test.go
@@ -18,6 +18,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -74,19 +75,6 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		cluster := prepareCluster()
 		clusterSummaryName := randomString()
 
-		// In managed cluster this is the namespace where ResourceSummaries
-		// are created
-		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: resourceSummaryNamespace,
-			},
-		}
-		err := testEnv.Create(context.TODO(), ns)
-		if err != nil {
-			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
-		}
-		Expect(waitForObject(context.TODO(), testEnv.Client, ns)).To(Succeed())
-
 		// Just verify result is success (testEnv is used to simulate both management and workload cluster and because
 		// classifier is expected in the management cluster, above line is required
 		Expect(controllers.DeployDriftDetectionManagerInCluster(context.TODO(), testEnv.Client, cluster.Namespace,
@@ -113,7 +101,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 		expectedLabels := controllers.GetDriftDetectionManagerLabels(clusterNamespace, clusterName, clusterType)
 
 		listOptions := []client.ListOption{
-			client.InNamespace(controllers.GetDriftDetectionNamespaceInMgmtCluster()),
+			client.InNamespace(controllers.GetDriftDetectionNamespaceInMgmtCluster(sveltosNamespace)),
 		}
 		Eventually(func() bool {
 			deployments := &appsv1.DeploymentList{}
@@ -156,7 +144,7 @@ var _ = Describe("ResourceSummary Deployer", func() {
 	})
 
 	It("getGlobalDriftDetectionManagerPatches reads old post render patches from ConfigMap", func() {
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-patch: |-
             image-patch: |-
@@ -176,7 +164,7 @@ data:
 kind: ConfigMap
 metadata:
   name: drift-detection-config-old
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -196,7 +184,7 @@ metadata:
 	})
 
 	It("getDriftDetectionManagerPatches reads post render patches from ConfigMap", func() {
-		cmYAML := `apiVersion: v1
+		cmYAML := fmt.Sprintf(`apiVersion: v1
 data:
   deployment-patch: |-
       patch: |-
@@ -227,7 +215,7 @@ data:
 kind: ConfigMap
 metadata:
   name: drift-detection-config
-  namespace: projectsveltos`
+  namespace: %s`, sveltosNamespace)
 
 		cm, err := deployer.GetUnstructured([]byte(cmYAML), logger)
 		Expect(err).To(BeNil())
@@ -324,7 +312,7 @@ func prepareCluster() *clusterv1.Cluster {
 	By("Create the ConfigMap with drift-detection version")
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: resourceSummaryNamespace,
+			Namespace: sveltosNamespace,
 			Name:      "drift-detection-version",
 		},
 		Data: map[string]string{

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -586,7 +586,7 @@ metadata:
 			driftDetectionManager := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      randomString(),
-					Namespace: "projectsveltos",
+					Namespace: sveltosNamespace,
 					Labels:    lbls,
 				},
 				Spec: appsv1.DeploymentSpec{

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.3
 	github.com/onsi/gomega v1.41.0
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.10.0
+	github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f
 	github.com/prometheus/client_golang v1.23.2
 	github.com/robfig/cron v1.2.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,6 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/docker/cli v29.5.0+incompatible h1:FPUvKJoKpeP4Njz8NrQdeUN8o247P7ndTiILtaP5/l4=
-github.com/docker/cli v29.5.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v29.5.2+incompatible h1:ubykJ1Y8LmNRGJ2BuMQ0kHOt/RO1YzGNswqWMJgivuQ=
 github.com/docker/cli v29.5.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker-credential-helpers v0.9.5 h1:EFNN8DHvaiK8zVqFA2DT6BjXE0GzfLOZ38ggPTKePkY=
@@ -104,8 +102,6 @@ github.com/fluxcd/pkg/tar v1.2.0 h1:T6WFB5M0YRHktlrgdKNskqpdp76TVDdWTOeuWz33CFs=
 github.com/fluxcd/pkg/tar v1.2.0/go.mod h1:Wlalp5vIVe+BbckkKkqExKcoHAeeWJPAzwK7ONeFcS0=
 github.com/fluxcd/pkg/testserver v0.14.0 h1:wVv/JPY3i4OEJ8xakfriuN2oHiUyZZ+BfhC/6RCD2nI=
 github.com/fluxcd/pkg/testserver v0.14.0/go.mod h1:6D6/SeGl8jT8L8pb5+k+mkE5CtqV1ozC5uqXRuTEBas=
-github.com/fluxcd/source-controller/api v1.8.4 h1:ZJIh7OFhjxZgsD81ahxxbu3ggA7qySIjKWbK5+PKmOI=
-github.com/fluxcd/source-controller/api v1.8.4/go.mod h1:sio4t49RDx+S1etHRFAEEw8qfVuw0KKlOg8bRVlEYPM=
 github.com/fluxcd/source-controller/api v1.8.5 h1:mLKc9YVMk46JCt1BQbkG6irkrpBZp95kiXh2+GYB6KQ=
 github.com/fluxcd/source-controller/api v1.8.5/go.mod h1:sio4t49RDx+S1etHRFAEEw8qfVuw0KKlOg8bRVlEYPM=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
@@ -260,8 +256,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
 github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
 github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/opencontainers/go-digest v1.0.1-0.20260423074420-acc66fb5367c h1:dTJQx6HDrRNmA3p5JlfVYw81R3g2RfWdG0+ZBaJeqcc=
@@ -279,8 +273,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.10.0 h1:+Gk34qCEOryHMT7xDFSIniiqk3VymhiKs/3EdK5gJ58=
-github.com/projectsveltos/libsveltos v1.10.0/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f h1:XrgpnRRH59AwSkSEIcKPUDpAME0Sl4sXLeEhDIaYQMU=
+github.com/projectsveltos/libsveltos v1.10.1-0.20260521153750-a1f348424b3f/go.mod h1:AzKBiyMTL3KSTLYMii5QdR3ieWyUKBHZCMFWIVCfm6A=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=

--- a/internal/telemetry/report.go
+++ b/internal/telemetry/report.go
@@ -46,7 +46,8 @@ import (
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=clusterhealthchecks,verbs=get;list;watch
 
 type instance struct {
-	version string
+	sveltosNamespace string
+	version          string
 	client.Client
 	config *rest.Config
 }
@@ -61,15 +62,18 @@ const (
 	domain          = "http://telemetry.projectsveltos.io/"
 )
 
-func StartCollecting(ctx context.Context, config *rest.Config, c client.Client, sveltosVersion string) error {
+func StartCollecting(ctx context.Context, config *rest.Config, c client.Client,
+	sveltosNamespace, sveltosVersion string) error {
+
 	if telemetryInstance == nil {
 		lock.Lock()
 		defer lock.Unlock()
 		if telemetryInstance == nil {
 			telemetryInstance = &instance{
-				Client:  c,
-				version: sveltosVersion,
-				config:  config,
+				Client:           c,
+				sveltosNamespace: sveltosNamespace,
+				version:          sveltosVersion,
+				config:           config,
 			}
 
 			go telemetryInstance.reportData(ctx)
@@ -98,7 +102,7 @@ func (m *instance) reportData(ctx context.Context) {
 
 func (m *instance) retrieveUUID(ctx context.Context) (string, error) {
 	var sveltosNS corev1.Namespace
-	if err := m.Get(ctx, types.NamespacedName{Name: "projectsveltos"}, &sveltosNS); err != nil {
+	if err := m.Get(ctx, types.NamespacedName{Name: m.sveltosNamespace}, &sveltosNS); err != nil {
 		return "", errors.Wrap(err, "cannot start the telemetry controller")
 	}
 

--- a/lib/clusterops/clusterops_suite_test.go
+++ b/lib/clusterops/clusterops_suite_test.go
@@ -53,10 +53,11 @@ import (
 )
 
 var (
-	testEnv *helpers.TestEnvironment
-	cancel  context.CancelFunc
-	ctx     context.Context
-	scheme  *runtime.Scheme
+	testEnv          *helpers.TestEnvironment
+	cancel           context.CancelFunc
+	ctx              context.Context
+	scheme           *runtime.Scheme
+	sveltosNamespace string
 )
 
 const (
@@ -134,9 +135,10 @@ var _ = BeforeSuite(func() {
 	Expect(testEnv.Create(context.TODO(), clusterSetCRD)).To(Succeed())
 	Expect(waitForObject(context.TODO(), testEnv, clusterSetCRD)).To(Succeed())
 
+	sveltosNamespace = randomString()
 	projectsveltosNs := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "projectsveltos",
+			Name: sveltosNamespace,
 		},
 	}
 	Expect(testEnv.Create(context.TODO(), projectsveltosNs)).To(Succeed())

--- a/lib/clusterops/reloader_utils_test.go
+++ b/lib/clusterops/reloader_utils_test.go
@@ -41,9 +41,8 @@ import (
 )
 
 const (
-	kubeconfigPostfix        = "-kubeconfig"
-	resourceSummaryNamespace = "projectsveltos"
-	version                  = "v0.31.0"
+	kubeconfigPostfix = "-kubeconfig"
+	version           = "v0.31.0"
 )
 
 var _ = Describe("Reloader utils", func() {
@@ -412,7 +411,7 @@ func prepareCluster() *clusterv1.Cluster {
 	By("Create the ConfigMap with drift-detection version")
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: resourceSummaryNamespace,
+			Namespace: sveltosNamespace,
 			Name:      "drift-detection-version",
 		},
 		Data: map[string]string{

--- a/lib/clusterops/resource_summary.go
+++ b/lib/clusterops/resource_summary.go
@@ -20,12 +20,8 @@ import (
 	"fmt"
 )
 
-const (
-	projectsveltos = "projectsveltos"
-)
-
-func GetResourceSummaryNamespaceInManagedCluster() string {
-	return projectsveltos
+func GetResourceSummaryNamespaceInManagedCluster(sveltosNamespacxe string) string {
+	return sveltosNamespacxe
 }
 
 func GetResourceSummaryNameInManagedCluster(clusterSummaryNamespace, clusterSummaryName string) string {

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
@@ -39,7 +39,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -83,9 +87,21 @@ spec:
         - --shard-key=
         - --agent-in-mgmt-cluster=true
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -39,7 +39,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -83,9 +87,21 @@ spec:
         - --shard-key={{.SHARD}}
         - --agent-in-mgmt-cluster=false
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -9044,7 +9044,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.10.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -9057,7 +9057,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -9101,9 +9105,21 @@ spec:
         - --shard-key=
         - --agent-in-mgmt-cluster=false
         env:
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.10.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -44,10 +44,23 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.10.0
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:f843e92513ee60cc7f19c1921b894634fdfdca05e4e9cb31b7fa529223dc85bd
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:308c6983cf12a4fe6abedf0dae98d22f3b68001683de56c1a45a51712c32db89
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -77,7 +90,7 @@ spec:
             cpu: 500m
             memory: 512Mi
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -26,10 +26,23 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.10.0
+        - --version=main
         command:
         - /manager
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:f843e92513ee60cc7f19c1921b894634fdfdca05e4e9cb31b7fa529223dc85bd
+        env:
+        - name: TOTAL_MEMORY_LIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.cpu
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:308c6983cf12a4fe6abedf0dae98d22f3b68001683de56c1a45a51712c32db89
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -59,7 +72,7 @@ spec:
             cpu: 500m
             memory: 512Mi
           requests:
-            cpu: 10m
+            cpu: 100m
             memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -146,7 +146,7 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.10.0
+        - --version=main
         command:
         - /manager
         env:
@@ -158,7 +158,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:f843e92513ee60cc7f19c1921b894634fdfdca05e4e9cb31b7fa529223dc85bd
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:308c6983cf12a4fe6abedf0dae98d22f3b68001683de56c1a45a51712c32db89
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -128,7 +128,7 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.10.0
+        - --version=main
         command:
         - /manager
         env:
@@ -140,7 +140,11 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.cpu
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:f843e92513ee60cc7f19c1921b894634fdfdca05e4e9cb31b7fa529223dc85bd
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:308c6983cf12a4fe6abedf0dae98d22f3b68001683de56c1a45a51712c32db89
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/pullmode-sveltosapplier.yaml
+++ b/test/pullmode-sveltosapplier.yaml
@@ -83,11 +83,11 @@ spec:
         - --cluster-type=sveltos
         - --secret-with-kubeconfig=clusterapi-workload-sveltos-kubeconfig
         - --v=5
-        - --version=v1.9.0
+        - --version=main
         command:
         - /manager
         env:
-        - name: GOMEMLIMIT
+        - name: TOTAL_MEMORY_LIMIT
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
@@ -99,7 +99,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/sveltos-applier:v1.9.0
+        image: docker.io/projectsveltos/sveltos-applier@sha256:9e7170faec7d9bf58c857d193f9c682f286eef20c3875a9a05a71fb74cf203e3
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Historically, the Sveltos namespace has been hardcoded/fixed to `projectsveltos`.
This PR is part of series that will remove this limitation.