### PR TITLE
Remove push trigger from sanity workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,10 +1,6 @@
 name: main
 on:
   workflow_dispatch:
-  push:
-    branches:
-    - 'main'
-    - 'dev'
   pull_request:
     types: [opened, edited, synchronize, reopened]
 


### PR DESCRIPTION
Sanity should only run on open PRs, not after they are merged to main.