### PR TITLE
(opt) Replace unconditional 30s sleep in CRD upgrade with condition-based wait

### DIFF
--- a/controllers/export_test.go
+++ b/controllers/export_test.go
@@ -257,6 +257,10 @@ var (
 	CreateFileWithKeyring       = createFileWithKeyring
 )
 
+var (
+	IsCRDEstablished = isCRDEstablished
+)
+
 type (
 	ReferencedObject = referencedObject
 )

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -104,6 +104,7 @@ const (
 	defaultMaxHistory          = 2
 	defaultDeletionPropagation = "background"
 	defaultChartVersion        = "0.1.0"
+	conditionStatusTrue        = "True"
 )
 
 type registryClientOptions struct {
@@ -2406,11 +2407,11 @@ func prepareChartAndDependencies(
 }
 
 func upgradeCRDsInFile(ctx context.Context, dr dynamic.ResourceInterface, chartFile *common.File,
-	logger logr.Logger) (int, error) {
+	logger logr.Logger) ([]string, error) {
 
 	crds, err := deployer.GetUnstructured(chartFile.Data, logger)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	forceConflict := true
@@ -2419,23 +2420,84 @@ func upgradeCRDsInFile(ctx context.Context, dr dynamic.ResourceInterface, chartF
 		Force:        &forceConflict,
 	}
 
-	upgradedCRDs := 0
+	var appliedCRDs []string
 
 	for i := range crds {
 		crdData, err := runtime.Encode(unstructured.UnstructuredJSONScheme, crds[i])
 		if err != nil {
-			return upgradedCRDs, err
+			return appliedCRDs, err
 		}
 
 		_, err = dr.Patch(ctx, crds[i].GetName(), types.ApplyPatchType, crdData, options)
 		if err != nil {
-			return upgradedCRDs, err
+			return appliedCRDs, err
 		}
 
-		upgradedCRDs += 1
+		appliedCRDs = append(appliedCRDs, crds[i].GetName())
 	}
 
-	return upgradedCRDs, nil
+	return appliedCRDs, nil
+}
+
+// isCRDEstablished returns true when the CRD has both Established and NamesAccepted conditions set to True.
+func isCRDEstablished(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	established := false
+	namesAccepted := false
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(cond, "type")
+		condStatus, _, _ := unstructured.NestedString(cond, "status")
+		switch condType {
+		case "Established":
+			established = condStatus == conditionStatusTrue
+		case "NamesAccepted":
+			namesAccepted = condStatus == conditionStatusTrue
+		}
+	}
+	return established && namesAccepted
+}
+
+// waitForCRDsEstablished polls each named CRD until Established=True and NamesAccepted=True,
+// returning immediately for CRDs that are already established (no-op upgrades pay no delay).
+func waitForCRDsEstablished(ctx context.Context, dr dynamic.ResourceInterface, crdNames []string,
+	logger logr.Logger) error {
+
+	const pollInterval = 2 * time.Second
+
+	pending := make(map[string]struct{}, len(crdNames))
+	for _, name := range crdNames {
+		pending[name] = struct{}{}
+	}
+
+	for len(pending) > 0 {
+		for name := range pending {
+			obj, err := dr.Get(ctx, name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if isCRDEstablished(obj) {
+				delete(pending, name)
+			} else {
+				logger.V(logs.LogDebug).Info(fmt.Sprintf("CRD %s not established yet", name))
+			}
+		}
+		if len(pending) == 0 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+	return nil
 }
 
 // upgradeCRDs upgrades CRDs
@@ -2463,22 +2525,22 @@ func upgradeCRDs(ctx context.Context, requestedChart *configv1beta1.HelmChart, k
 		return err
 	}
 
-	upgradedCRDs := 0
+	var appliedCRDs []string
 
 	for _, obj := range crds {
-		tmpUpgradedCRDs, err := upgradeCRDsInFile(ctx, dr, obj.File, logger)
+		names, err := upgradeCRDsInFile(ctx, dr, obj.File, logger)
 		if err != nil {
 			return err
 		}
-
-		upgradedCRDs += tmpUpgradedCRDs
+		appliedCRDs = append(appliedCRDs, names...)
 	}
 
-	if upgradedCRDs > 0 {
-		const waitForCRDs = 30
-		time.Sleep(waitForCRDs * time.Second)
+	if len(appliedCRDs) > 0 {
+		if err := waitForCRDsEstablished(ctx, dr, appliedCRDs, logger); err != nil {
+			return err
+		}
 	}
-	logger.V(logs.LogDebug).Info(fmt.Sprintf("CRDs upgraded: %d", upgradedCRDs))
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("CRDs upgraded: %d", len(appliedCRDs)))
 	return nil
 }
 

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -33,6 +33,7 @@ import (
 	releasecommon "helm.sh/helm/v4/pkg/release/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2/textlogger"
@@ -2253,5 +2254,61 @@ var _ = Describe("requeueLowerTierChallengers", func() {
 		}
 		Expect(helmFS).NotTo(BeNil())
 		Expect(helmFS.Status).To(Equal(libsveltosv1beta1.FeatureStatusFailedNonRetriable))
+	})
+})
+
+var _ = Describe("IsCRDEstablished", func() {
+	makeCondition := func(condType, status string) map[string]interface{} {
+		return map[string]interface{}{"type": condType, "status": status}
+	}
+
+	makeCRD := func(conditions []map[string]interface{}) *unstructured.Unstructured {
+		raw := []interface{}{}
+		for _, c := range conditions {
+			raw = append(raw, c)
+		}
+		obj := &unstructured.Unstructured{}
+		obj.SetName("test-crd")
+		if len(raw) > 0 {
+			_ = unstructured.SetNestedSlice(obj.Object, raw, "status", "conditions")
+		}
+		return obj
+	}
+
+	It("returns false when status conditions are absent", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetName("no-status")
+		Expect(controllers.IsCRDEstablished(obj)).To(BeFalse())
+	})
+
+	It("returns false when only Established is True", func() {
+		obj := makeCRD([]map[string]interface{}{
+			makeCondition("Established", "True"),
+			makeCondition("NamesAccepted", "False"),
+		})
+		Expect(controllers.IsCRDEstablished(obj)).To(BeFalse())
+	})
+
+	It("returns false when only NamesAccepted is True", func() {
+		obj := makeCRD([]map[string]interface{}{
+			makeCondition("Established", "False"),
+			makeCondition("NamesAccepted", "True"),
+		})
+		Expect(controllers.IsCRDEstablished(obj)).To(BeFalse())
+	})
+
+	It("returns true when both Established and NamesAccepted are True", func() {
+		obj := makeCRD([]map[string]interface{}{
+			makeCondition("Established", "True"),
+			makeCondition("NamesAccepted", "True"),
+		})
+		Expect(controllers.IsCRDEstablished(obj)).To(BeTrue())
+	})
+
+	It("returns false when neither condition is present", func() {
+		obj := makeCRD([]map[string]interface{}{
+			makeCondition("SomeOther", "True"),
+		})
+		Expect(controllers.IsCRDEstablished(obj)).To(BeFalse())
 	})
 })


### PR DESCRIPTION
When a Helm chart is deployed with UpgradeCRDs: true, the controller used to sleep for 30 seconds after applying the chart's CRD files, every time. The counter that triggered the sleep incremented for every server-side-apply patch regardless of whether the CRD actually changed. In ContinuousWithDriftDetection sync mode, where the upgrade path runs on every reconcile after the first deploy, this meant 30 seconds per chart per reconcile cycle.

The fix replaces the sleep with a poll against the destination cluster's CRD status. After applying, the controller checks each CRD's Established and NamesAccepted conditions and returns as soon as they are all true. For CRDs that were already established before the apply (the common case in drift-detection reconciles), this returns on the first check with effectively zero delay. For genuine CRD upgrades it waits only as long as actually needed.

Fixes #1843 