### PR TITLE
(feat) Add OCI scheme support to RemoteURL

### DIFF
--- a/api/v1beta1/spec.go
+++ b/api/v1beta1/spec.go
@@ -746,34 +746,41 @@ type PolicyRef struct {
 	// +optional
 	SkipNamespaceCreation bool `json:"skipNamespaceCreation,omitempty"`
 
-	// RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+	// RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
 	// When set, Kind/Name/Namespace must be omitted.
 	// +optional
 	RemoteURL *RemoteURL `json:"remoteURL,omitempty"`
 }
 
-// RemoteURL groups all fields related to fetching policy content from an HTTP/HTTPS endpoint.
+// RemoteURL groups all fields related to fetching policy content from a remote source.
+// Supports HTTP/HTTPS endpoints and OCI registries.
 type RemoteURL struct {
-	// URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+	// URL is the remote source serving raw YAML/JSON content.
 	// Sveltos fetches the content on every reconciliation and redeploys if the
 	// content hash has changed.
-	// +kubebuilder:validation:Pattern=`^https?://`
+	// Supported schemes:
+	//   "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+	//   "oci://"                — OCI registry artifact containing YAML manifests
+	// +kubebuilder:validation:Pattern=`^(https?|oci)://`
 	URL string `json:"url"`
 
-	// Interval defines how often Sveltos re-fetches the URL to detect changes.
+	// Interval defines how often Sveltos re-fetches the source to detect changes.
 	// Defaults to 5 minutes.
 	// +optional
 	Interval *metav1.Duration `json:"interval,omitempty"`
 
 	// SecretRef references a Secret in the management cluster containing optional
-	// credentials for fetching the URL. Supported Secret keys:
+	// credentials for fetching the source. Both Name and Namespace must be set,
+	// allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+	// a single Secret can be shared across clusters without replication.
+	// Supported Secret keys:
 	//   "token"              — Bearer token (Authorization: Bearer <token>)
-	//   "username"+"password" — HTTP Basic Auth
+	//   "username"+"password" — HTTP Basic Auth or OCI registry basic auth
 	//   "caFile"             — PEM-encoded CA certificate for TLS verification
 	// +optional
-	SecretRef *corev1.LocalObjectReference `json:"secretRef,omitempty"`
+	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 
-	// Template indicates that the content served at URL is a Go template that
+	// Template indicates that the fetched content is a Go template that
 	// must be instantiated using cluster fields and templateResourceRefs values
 	// before deployment. Equivalent to the projectsveltos.io/template annotation
 	// on a ConfigMap or Secret.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1337,7 +1337,7 @@ func (in *RemoteURL) DeepCopyInto(out *RemoteURL) {
 	}
 	if in.SecretRef != nil {
 		in, out := &in.SecretRef, &out.SecretRef
-		*out = new(corev1.LocalObjectReference)
+		*out = new(corev1.SecretReference)
 		**out = **in
 	}
 }

--- a/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterprofiles.yaml
@@ -1094,46 +1094,51 @@ spec:
                       type: string
                     remoteURL:
                       description: |-
-                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                         When set, Kind/Name/Namespace must be omitted.
                       properties:
                         interval:
                           description: |-
-                            Interval defines how often Sveltos re-fetches the URL to detect changes.
+                            Interval defines how often Sveltos re-fetches the source to detect changes.
                             Defaults to 5 minutes.
                           type: string
                         secretRef:
                           description: |-
                             SecretRef references a Secret in the management cluster containing optional
-                            credentials for fetching the URL. Supported Secret keys:
+                            credentials for fetching the source. Both Name and Namespace must be set,
+                            allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                            a single Secret can be shared across clusters without replication.
+                            Supported Secret keys:
                               "token"              — Bearer token (Authorization: Bearer <token>)
-                              "username"+"password" — HTTP Basic Auth
+                              "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                               "caFile"             — PEM-encoded CA certificate for TLS verification
                           properties:
                             name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         template:
                           description: |-
-                            Template indicates that the content served at URL is a Go template that
+                            Template indicates that the fetched content is a Go template that
                             must be instantiated using cluster fields and templateResourceRefs values
                             before deployment. Equivalent to the projectsveltos.io/template annotation
                             on a ConfigMap or Secret.
                           type: boolean
                         url:
                           description: |-
-                            URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                            URL is the remote source serving raw YAML/JSON content.
                             Sveltos fetches the content on every reconciliation and redeploys if the
                             content hash has changed.
-                          pattern: ^https?://
+                            Supported schemes:
+                              "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                              "oci://"                — OCI registry artifact containing YAML manifests
+                          pattern: ^(https?|oci)://
                           type: string
                       required:
                       - url

--- a/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clusterpromotions.yaml
@@ -996,46 +996,51 @@ spec:
                           type: string
                         remoteURL:
                           description: |-
-                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                             When set, Kind/Name/Namespace must be omitted.
                           properties:
                             interval:
                               description: |-
-                                Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                Interval defines how often Sveltos re-fetches the source to detect changes.
                                 Defaults to 5 minutes.
                               type: string
                             secretRef:
                               description: |-
                                 SecretRef references a Secret in the management cluster containing optional
-                                credentials for fetching the URL. Supported Secret keys:
+                                credentials for fetching the source. Both Name and Namespace must be set,
+                                allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                a single Secret can be shared across clusters without replication.
+                                Supported Secret keys:
                                   "token"              — Bearer token (Authorization: Bearer <token>)
-                                  "username"+"password" — HTTP Basic Auth
+                                  "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                   "caFile"             — PEM-encoded CA certificate for TLS verification
                               properties:
                                 name:
-                                  default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: name is unique within a namespace to
+                                    reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within
+                                    which the secret name must be unique.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             template:
                               description: |-
-                                Template indicates that the content served at URL is a Go template that
+                                Template indicates that the fetched content is a Go template that
                                 must be instantiated using cluster fields and templateResourceRefs values
                                 before deployment. Equivalent to the projectsveltos.io/template annotation
                                 on a ConfigMap or Secret.
                               type: boolean
                             url:
                               description: |-
-                                URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                URL is the remote source serving raw YAML/JSON content.
                                 Sveltos fetches the content on every reconciliation and redeploys if the
                                 content hash has changed.
-                              pattern: ^https?://
+                                Supported schemes:
+                                  "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                  "oci://"                — OCI registry artifact containing YAML manifests
+                              pattern: ^(https?|oci)://
                               type: string
                           required:
                           - url
@@ -2205,46 +2210,52 @@ spec:
                                     type: string
                                   remoteURL:
                                     description: |-
-                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                                       When set, Kind/Name/Namespace must be omitted.
                                     properties:
                                       interval:
                                         description: |-
-                                          Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                          Interval defines how often Sveltos re-fetches the source to detect changes.
                                           Defaults to 5 minutes.
                                         type: string
                                       secretRef:
                                         description: |-
                                           SecretRef references a Secret in the management cluster containing optional
-                                          credentials for fetching the URL. Supported Secret keys:
+                                          credentials for fetching the source. Both Name and Namespace must be set,
+                                          allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                          a single Secret can be shared across clusters without replication.
+                                          Supported Secret keys:
                                             "token"              — Bearer token (Authorization: Bearer <token>)
-                                            "username"+"password" — HTTP Basic Auth
+                                            "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                             "caFile"             — PEM-encoded CA certificate for TLS verification
                                         properties:
                                           name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: name is unique within a namespace
+                                              to reference a secret resource.
+                                            type: string
+                                          namespace:
+                                            description: namespace defines the space
+                                              within which the secret name must be
+                                              unique.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       template:
                                         description: |-
-                                          Template indicates that the content served at URL is a Go template that
+                                          Template indicates that the fetched content is a Go template that
                                           must be instantiated using cluster fields and templateResourceRefs values
                                           before deployment. Equivalent to the projectsveltos.io/template annotation
                                           on a ConfigMap or Secret.
                                         type: boolean
                                       url:
                                         description: |-
-                                          URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                          URL is the remote source serving raw YAML/JSON content.
                                           Sveltos fetches the content on every reconciliation and redeploys if the
                                           content hash has changed.
-                                        pattern: ^https?://
+                                          Supported schemes:
+                                            "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                            "oci://"                — OCI registry artifact containing YAML manifests
+                                        pattern: ^(https?|oci)://
                                         type: string
                                     required:
                                     - url
@@ -2558,46 +2569,52 @@ spec:
                                     type: string
                                   remoteURL:
                                     description: |-
-                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                                       When set, Kind/Name/Namespace must be omitted.
                                     properties:
                                       interval:
                                         description: |-
-                                          Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                          Interval defines how often Sveltos re-fetches the source to detect changes.
                                           Defaults to 5 minutes.
                                         type: string
                                       secretRef:
                                         description: |-
                                           SecretRef references a Secret in the management cluster containing optional
-                                          credentials for fetching the URL. Supported Secret keys:
+                                          credentials for fetching the source. Both Name and Namespace must be set,
+                                          allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                          a single Secret can be shared across clusters without replication.
+                                          Supported Secret keys:
                                             "token"              — Bearer token (Authorization: Bearer <token>)
-                                            "username"+"password" — HTTP Basic Auth
+                                            "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                             "caFile"             — PEM-encoded CA certificate for TLS verification
                                         properties:
                                           name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: name is unique within a namespace
+                                              to reference a secret resource.
+                                            type: string
+                                          namespace:
+                                            description: namespace defines the space
+                                              within which the secret name must be
+                                              unique.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       template:
                                         description: |-
-                                          Template indicates that the content served at URL is a Go template that
+                                          Template indicates that the fetched content is a Go template that
                                           must be instantiated using cluster fields and templateResourceRefs values
                                           before deployment. Equivalent to the projectsveltos.io/template annotation
                                           on a ConfigMap or Secret.
                                         type: boolean
                                       url:
                                         description: |-
-                                          URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                          URL is the remote source serving raw YAML/JSON content.
                                           Sveltos fetches the content on every reconciliation and redeploys if the
                                           content hash has changed.
-                                        pattern: ^https?://
+                                          Supported schemes:
+                                            "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                            "oci://"                — OCI registry artifact containing YAML manifests
+                                        pattern: ^(https?|oci)://
                                         type: string
                                     required:
                                     - url

--- a/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
+++ b/config/crd/bases/config.projectsveltos.io_clustersummaries.yaml
@@ -1133,46 +1133,51 @@ spec:
                           type: string
                         remoteURL:
                           description: |-
-                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                             When set, Kind/Name/Namespace must be omitted.
                           properties:
                             interval:
                               description: |-
-                                Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                Interval defines how often Sveltos re-fetches the source to detect changes.
                                 Defaults to 5 minutes.
                               type: string
                             secretRef:
                               description: |-
                                 SecretRef references a Secret in the management cluster containing optional
-                                credentials for fetching the URL. Supported Secret keys:
+                                credentials for fetching the source. Both Name and Namespace must be set,
+                                allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                a single Secret can be shared across clusters without replication.
+                                Supported Secret keys:
                                   "token"              — Bearer token (Authorization: Bearer <token>)
-                                  "username"+"password" — HTTP Basic Auth
+                                  "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                   "caFile"             — PEM-encoded CA certificate for TLS verification
                               properties:
                                 name:
-                                  default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: name is unique within a namespace to
+                                    reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within
+                                    which the secret name must be unique.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             template:
                               description: |-
-                                Template indicates that the content served at URL is a Go template that
+                                Template indicates that the fetched content is a Go template that
                                 must be instantiated using cluster fields and templateResourceRefs values
                                 before deployment. Equivalent to the projectsveltos.io/template annotation
                                 on a ConfigMap or Secret.
                               type: boolean
                             url:
                               description: |-
-                                URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                URL is the remote source serving raw YAML/JSON content.
                                 Sveltos fetches the content on every reconciliation and redeploys if the
                                 content hash has changed.
-                              pattern: ^https?://
+                                Supported schemes:
+                                  "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                  "oci://"                — OCI registry artifact containing YAML manifests
+                              pattern: ^(https?|oci)://
                               type: string
                           required:
                           - url

--- a/config/crd/bases/config.projectsveltos.io_profiles.yaml
+++ b/config/crd/bases/config.projectsveltos.io_profiles.yaml
@@ -1094,46 +1094,51 @@ spec:
                       type: string
                     remoteURL:
                       description: |-
-                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                         When set, Kind/Name/Namespace must be omitted.
                       properties:
                         interval:
                           description: |-
-                            Interval defines how often Sveltos re-fetches the URL to detect changes.
+                            Interval defines how often Sveltos re-fetches the source to detect changes.
                             Defaults to 5 minutes.
                           type: string
                         secretRef:
                           description: |-
                             SecretRef references a Secret in the management cluster containing optional
-                            credentials for fetching the URL. Supported Secret keys:
+                            credentials for fetching the source. Both Name and Namespace must be set,
+                            allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                            a single Secret can be shared across clusters without replication.
+                            Supported Secret keys:
                               "token"              — Bearer token (Authorization: Bearer <token>)
-                              "username"+"password" — HTTP Basic Auth
+                              "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                               "caFile"             — PEM-encoded CA certificate for TLS verification
                           properties:
                             name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         template:
                           description: |-
-                            Template indicates that the content served at URL is a Go template that
+                            Template indicates that the fetched content is a Go template that
                             must be instantiated using cluster fields and templateResourceRefs values
                             before deployment. Equivalent to the projectsveltos.io/template annotation
                             on a ConfigMap or Secret.
                           type: boolean
                         url:
                           description: |-
-                            URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                            URL is the remote source serving raw YAML/JSON content.
                             Sveltos fetches the content on every reconciliation and redeploys if the
                             content hash has changed.
-                          pattern: ^https?://
+                            Supported schemes:
+                              "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                              "oci://"                — OCI registry artifact containing YAML manifests
+                          pattern: ^(https?|oci)://
                           type: string
                       required:
                       - url

--- a/controllers/clustersummary_deployer.go
+++ b/controllers/clustersummary_deployer.go
@@ -101,6 +101,8 @@ func (r *ClusterSummaryReconciler) deployFeature(ctx context.Context, clusterSum
 	if err != nil {
 		var nrErr *configv1beta1.NonRetriableError
 		if !errors.As(err, &nrErr) && !apierrors.IsNotFound(err) {
+			failedStatus := libsveltosv1beta1.FeatureStatusFailed
+			r.updateFeatureStatus(clusterSummaryScope, f.id, &failedStatus, nil, err, logger)
 			return err
 		}
 	}

--- a/controllers/handlers_resources.go
+++ b/controllers/handlers_resources.go
@@ -629,7 +629,9 @@ func urlPolicyRefsHash(ctx context.Context, clusterSummary *configv1beta1.Cluste
 		if ref.RemoteURL == nil {
 			continue
 		}
-		body, err := fetchURL(ctx, ref.RemoteURL.URL, ref.RemoteURL.SecretRef, clusterSummary.Namespace, logger)
+		body, err := fetchContent(ctx, ref.RemoteURL.URL, ref.RemoteURL.SecretRef,
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName,
+			clusterSummary.Spec.ClusterType, logger)
 		if err != nil {
 			if ref.Optional {
 				logger.V(logs.LogInfo).Info(fmt.Sprintf(

--- a/controllers/handlers_utils.go
+++ b/controllers/handlers_utils.go
@@ -78,7 +78,7 @@ type referencedObject struct {
 	// URL and related fields are set only for URL-based PolicyRefs (Kind == urlSourceKind).
 	URL        string
 	IsTemplate bool
-	SecretRef  *corev1.LocalObjectReference
+	SecretRef  *corev1.SecretReference
 }
 
 func getClusterSummaryAnnotationValue(clusterSummary *configv1beta1.ClusterSummary) string {

--- a/controllers/url_source.go
+++ b/controllers/url_source.go
@@ -17,24 +17,33 @@ limitations under the License.
 package controllers
 
 import (
+	"archive/tar"
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
+	orasremote "oras.land/oras-go/v2/registry/remote"
+	orasauth "oras.land/oras-go/v2/registry/remote/auth"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
 	logs "github.com/projectsveltos/libsveltos/lib/logsettings"
+	libsveltostemplate "github.com/projectsveltos/libsveltos/lib/template"
 )
 
 const (
@@ -44,10 +53,13 @@ const (
 )
 
 // fetchURL retrieves the raw content from rawURL.
-// If secretRef is non-nil, the Secret named secretRef.Name in secretNamespace is read
-// for optional auth credentials (keys: "token", "username"+"password", "caFile").
-func fetchURL(ctx context.Context, rawURL string, secretRef *corev1.LocalObjectReference,
-	secretNamespace string, logger logr.Logger) ([]byte, error) {
+// If secretRef is non-nil, the referenced Secret is read for optional auth
+// credentials (keys: "token", "username"+"password", "caFile").
+// The secretRef Name and Namespace support Go templating against the target cluster.
+// When Namespace is empty it defaults to clusterNamespace.
+func fetchURL(ctx context.Context, rawURL string, secretRef *corev1.SecretReference,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) ([]byte, error) {
 
 	transport := http.DefaultTransport
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, http.NoBody)
@@ -56,18 +68,28 @@ func fetchURL(ctx context.Context, rawURL string, secretRef *corev1.LocalObjectR
 	}
 
 	if secretRef != nil {
+		ns, err := libsveltostemplate.GetReferenceResourceNamespace(ctx, getManagementClusterClient(),
+			clusterNamespace, clusterName, secretRef.Namespace, clusterType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate secret namespace for URL %s: %w", rawURL, err)
+		}
+		name, err := libsveltostemplate.GetReferenceResourceName(ctx, getManagementClusterClient(),
+			clusterNamespace, clusterName, secretRef.Name, clusterType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate secret name for URL %s: %w", rawURL, err)
+		}
 		secret, err := getSecret(ctx, getManagementClusterClient(),
-			types.NamespacedName{Namespace: secretNamespace, Name: secretRef.Name})
+			types.NamespacedName{Namespace: ns, Name: name})
 		if err != nil {
 			return nil, fmt.Errorf("failed to get auth secret %s/%s for URL %s: %w",
-				secretNamespace, secretRef.Name, rawURL, err)
+				ns, name, rawURL, err)
 		}
 
 		if token, ok := secret.Data["token"]; ok {
-			req.Header.Set("Authorization", "Bearer "+string(token))
+			req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
 		} else if username, ok := secret.Data["username"]; ok {
 			if password, ok := secret.Data["password"]; ok {
-				req.SetBasicAuth(string(username), string(password))
+				req.SetBasicAuth(strings.TrimSpace(string(username)), strings.TrimSpace(string(password)))
 			}
 		}
 
@@ -75,7 +97,7 @@ func fetchURL(ctx context.Context, rawURL string, secretRef *corev1.LocalObjectR
 			pool := x509.NewCertPool()
 			if !pool.AppendCertsFromPEM(caFile) {
 				return nil, fmt.Errorf("failed to parse caFile from secret %s/%s",
-					secretNamespace, secretRef.Name)
+					ns, name)
 			}
 			transport = &http.Transport{
 				TLSClientConfig: &tls.Config{RootCAs: pool},
@@ -107,14 +129,182 @@ func fetchURL(ctx context.Context, rawURL string, secretRef *corev1.LocalObjectR
 	return body, nil
 }
 
-// deployContentOfURL fetches YAML/JSON content from a remote URL and deploys it
+// fetchContent retrieves raw manifest bytes from a remote source.
+// It dispatches on the URL scheme: "oci://" routes to fetchOCI; everything
+// else is handled by fetchURL.
+// The secretRef Name and Namespace are treated as Go templates and instantiated
+// against the target cluster, following the same convention as PolicyRef ConfigMap/Secret
+// references. When Namespace is empty it defaults to clusterNamespace.
+func fetchContent(ctx context.Context, rawURL string, secretRef *corev1.SecretReference,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) ([]byte, error) {
+
+	if strings.HasPrefix(rawURL, "oci://") {
+		return fetchOCI(ctx, rawURL, secretRef, clusterNamespace, clusterName, clusterType, logger)
+	}
+	return fetchURL(ctx, rawURL, secretRef, clusterNamespace, clusterName, clusterType, logger)
+}
+
+// fetchOCI pulls an OCI artifact and returns its YAML content.
+// The artifact layers are read as gzipped tar archives; if a layer is not a
+// valid tar archive it is used as-is (raw YAML blob). All .yaml/.yml/.json
+// files found across all layers are concatenated and returned.
+// Supported Secret keys: "token" (pre-obtained bearer token), "username"+"password" (basic auth
+// exchanged for a registry token), "caFile" (PEM CA for TLS verification).
+// The secretRef Name and Namespace support Go templating against the target cluster.
+// When Namespace is empty it defaults to clusterNamespace.
+func fetchOCI(ctx context.Context, rawURL string, secretRef *corev1.SecretReference,
+	clusterNamespace, clusterName string, clusterType libsveltosv1beta1.ClusterType,
+	logger logr.Logger) ([]byte, error) {
+
+	ref := strings.TrimPrefix(rawURL, "oci://")
+
+	repo, err := orasremote.NewRepository(ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse OCI reference %s: %w", rawURL, err)
+	}
+
+	authClient := &orasauth.Client{}
+
+	if secretRef != nil {
+		ns, err := libsveltostemplate.GetReferenceResourceNamespace(ctx, getManagementClusterClient(),
+			clusterNamespace, clusterName, secretRef.Namespace, clusterType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate secret namespace for OCI %s: %w", rawURL, err)
+		}
+		name, err := libsveltostemplate.GetReferenceResourceName(ctx, getManagementClusterClient(),
+			clusterNamespace, clusterName, secretRef.Name, clusterType)
+		if err != nil {
+			return nil, fmt.Errorf("failed to instantiate secret name for OCI %s: %w", rawURL, err)
+		}
+		secret, err := getSecret(ctx, getManagementClusterClient(),
+			types.NamespacedName{Namespace: ns, Name: name})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get auth secret %s/%s for OCI %s: %w",
+				ns, name, rawURL, err)
+		}
+
+		var cred orasauth.Credential
+		if token, ok := secret.Data["token"]; ok {
+			cred = orasauth.Credential{AccessToken: strings.TrimSpace(string(token))}
+		} else if username, ok := secret.Data["username"]; ok {
+			if password, ok := secret.Data["password"]; ok {
+				cred = orasauth.Credential{
+					Username: strings.TrimSpace(string(username)),
+					Password: strings.TrimSpace(string(password)),
+				}
+			}
+		}
+		authClient.Credential = orasauth.StaticCredential(repo.Reference.Registry, cred)
+
+		if caFile, ok := secret.Data["caFile"]; ok {
+			pool := x509.NewCertPool()
+			if !pool.AppendCertsFromPEM(caFile) {
+				return nil, fmt.Errorf("failed to parse caFile from secret %s/%s", ns, name)
+			}
+			authClient.Client = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: pool},
+				},
+			}
+		}
+	}
+
+	repo.Client = authClient
+
+	logger.V(logs.LogDebug).Info(fmt.Sprintf("pulling OCI artifact %s", rawURL))
+
+	_, manifestRC, err := repo.FetchReference(ctx, ref)
+	if err != nil {
+		return nil, fmt.Errorf("failed to pull OCI artifact %s: %w", rawURL, err)
+	}
+	defer manifestRC.Close()
+
+	manifestBytes, err := io.ReadAll(manifestRC)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read OCI manifest %s: %w", rawURL, err)
+	}
+
+	var manifest struct {
+		Layers []ocispec.Descriptor `json:"layers"`
+	}
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to parse OCI manifest %s: %w", rawURL, err)
+	}
+
+	var buf bytes.Buffer
+	for _, layer := range manifest.Layers {
+		rc, err := repo.Fetch(ctx, layer)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch OCI layer from %s: %w", rawURL, err)
+		}
+		raw, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read OCI layer from %s: %w", rawURL, err)
+		}
+		content, err := extractYAMLFromLayer(raw, rawURL, logger)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(content)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// extractYAMLFromLayer extracts YAML/JSON manifest bytes from a single OCI layer.
+// It first attempts to parse the bytes as a tar archive and concatenates all
+// .yaml/.yml/.json files found inside. If the bytes are not a valid tar archive
+// (e.g. a raw YAML blob), they are returned as-is.
+func extractYAMLFromLayer(raw []byte, rawURL string, logger logr.Logger) ([]byte, error) {
+	tr := tar.NewReader(bytes.NewReader(raw))
+	hdr, err := tr.Next()
+	if err == io.EOF {
+		// Valid tar archive with no entries.
+		return []byte{}, nil
+	}
+	if err != nil {
+		// Not a tar archive — treat the raw bytes as YAML/JSON content directly.
+		logger.V(logs.LogDebug).Info(fmt.Sprintf(
+			"OCI layer from %s is not a tar archive, using as raw content", rawURL))
+		return raw, nil
+	}
+
+	var buf bytes.Buffer
+	for {
+		if hdr.Typeflag == tar.TypeReg {
+			ext := strings.ToLower(filepath.Ext(hdr.Name))
+			if ext == ".yaml" || ext == ".yml" || ext == ".json" {
+				content, err := io.ReadAll(tr)
+				if err != nil {
+					return nil, fmt.Errorf("failed to read %s from OCI artifact %s: %w",
+						hdr.Name, rawURL, err)
+				}
+				buf.Write(content)
+				buf.WriteString("\n---\n")
+			}
+		}
+		hdr, err = tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read tar from OCI artifact %s: %w", rawURL, err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+// deployContentOfURL fetches YAML/JSON content from a remote source and deploys it
 // to the destination cluster using the same pipeline as ConfigMap/Secret sources.
 func deployContentOfURL(ctx context.Context, deployingToMgmtCluster bool, destConfig *rest.Config,
 	destClient client.Client, ref *referencedObject, dCtx *deploymentContext,
 	logger logr.Logger) ([]libsveltosv1beta1.ResourceReport, error) {
 
-	secretNamespace := dCtx.clusterSummary.Namespace
-	body, err := fetchURL(ctx, ref.URL, ref.SecretRef, secretNamespace, logger)
+	body, err := fetchContent(ctx, ref.URL, ref.SecretRef,
+		dCtx.clusterSummary.Spec.ClusterNamespace, dCtx.clusterSummary.Spec.ClusterName,
+		dCtx.clusterSummary.Spec.ClusterType, logger)
 	if err != nil {
 		if ref.Optional {
 			logger.V(logs.LogInfo).Info(fmt.Sprintf(

--- a/controllers/url_source_test.go
+++ b/controllers/url_source_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"archive/tar"
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+)
+
+// buildTar creates an uncompressed tar archive containing the given files.
+// extractYAMLFromLayer receives already-uncompressed layer bytes, so no gzip
+// wrapper is needed in tests.
+func buildTar(files map[string]string) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, content := range files {
+		hdr := &tar.Header{
+			Name:     name,
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(content)),
+		}
+		Expect(tw.WriteHeader(hdr)).To(Succeed())
+		_, err := tw.Write([]byte(content))
+		Expect(err).ToNot(HaveOccurred())
+	}
+	Expect(tw.Close()).To(Succeed())
+	return buf.Bytes()
+}
+
+var _ = Describe("extractYAMLFromLayer", func() {
+	var logger logr.Logger
+	const rawURL = "oci://example.com/unit/space/slug:head"
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+	})
+
+	It("returns raw bytes unchanged when the layer is not a tar archive", func() {
+		raw := []byte("apiVersion: v1\nkind: ConfigMap\n")
+		got, err := extractYAMLFromLayer(raw, rawURL, logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(raw))
+	})
+
+	It("extracts .yaml and .yml files from a tar archive", func() {
+		cm := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\n"
+		dep := "apiVersion: apps/v1\nkind: Deployment\n"
+		raw := buildTar(map[string]string{
+			"cm.yaml":    cm,
+			"deploy.yml": dep,
+			"README.txt": "should be ignored",
+		})
+
+		got, err := extractYAMLFromLayer(raw, rawURL, logger)
+		Expect(err).ToNot(HaveOccurred())
+		s := string(got)
+		Expect(s).To(ContainSubstring(cm))
+		Expect(s).To(ContainSubstring(dep))
+		Expect(s).NotTo(ContainSubstring("README"))
+	})
+
+	It("extracts .json files from a tar archive", func() {
+		json := `{"apiVersion":"v1","kind":"ConfigMap"}`
+		raw := buildTar(map[string]string{"resource.json": json})
+
+		got, err := extractYAMLFromLayer(raw, rawURL, logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(got)).To(ContainSubstring(json))
+	})
+
+	It("returns empty bytes when the tar contains no YAML or JSON files", func() {
+		raw := buildTar(map[string]string{
+			"README.md": "no manifests here",
+			"notes.txt": "nothing",
+		})
+
+		got, err := extractYAMLFromLayer(raw, rawURL, logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(BeEmpty())
+	})
+
+	It("returns empty bytes for an empty tar archive", func() {
+		raw := buildTar(map[string]string{})
+
+		got, err := extractYAMLFromLayer(raw, rawURL, logger)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(BeEmpty())
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/projectsveltos/libsveltos v1.11.2-0.20260622062629-79f5f1f526c0
 	github.com/prometheus/client_golang v1.23.2
@@ -36,6 +37,7 @@ require (
 	k8s.io/component-base v0.36.2
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260617174310-a95e086a2553
+	oras.land/oras-go/v2 v2.6.1
 	sigs.k8s.io/cluster-api v1.13.3
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/kustomize/api v0.21.1
@@ -213,7 +215,6 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/go-digest/blake3 v0.0.0-20260615172202-b50d36f46dea // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
@@ -298,7 +299,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260603220949-865597e52e25 // indirect
 	k8s.io/kubectl v0.36.1 // indirect
 	k8s.io/streaming v0.36.2 // indirect
-	oras.land/oras-go/v2 v2.6.1 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -1403,46 +1403,51 @@ spec:
                       type: string
                     remoteURL:
                       description: |-
-                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                         When set, Kind/Name/Namespace must be omitted.
                       properties:
                         interval:
                           description: |-
-                            Interval defines how often Sveltos re-fetches the URL to detect changes.
+                            Interval defines how often Sveltos re-fetches the source to detect changes.
                             Defaults to 5 minutes.
                           type: string
                         secretRef:
                           description: |-
                             SecretRef references a Secret in the management cluster containing optional
-                            credentials for fetching the URL. Supported Secret keys:
+                            credentials for fetching the source. Both Name and Namespace must be set,
+                            allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                            a single Secret can be shared across clusters without replication.
+                            Supported Secret keys:
                               "token"              — Bearer token (Authorization: Bearer <token>)
-                              "username"+"password" — HTTP Basic Auth
+                              "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                               "caFile"             — PEM-encoded CA certificate for TLS verification
                           properties:
                             name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         template:
                           description: |-
-                            Template indicates that the content served at URL is a Go template that
+                            Template indicates that the fetched content is a Go template that
                             must be instantiated using cluster fields and templateResourceRefs values
                             before deployment. Equivalent to the projectsveltos.io/template annotation
                             on a ConfigMap or Secret.
                           type: boolean
                         url:
                           description: |-
-                            URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                            URL is the remote source serving raw YAML/JSON content.
                             Sveltos fetches the content on every reconciliation and redeploys if the
                             content hash has changed.
-                          pattern: ^https?://
+                            Supported schemes:
+                              "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                              "oci://"                — OCI registry artifact containing YAML manifests
+                          pattern: ^(https?|oci)://
                           type: string
                       required:
                       - url
@@ -3577,46 +3582,51 @@ spec:
                           type: string
                         remoteURL:
                           description: |-
-                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                             When set, Kind/Name/Namespace must be omitted.
                           properties:
                             interval:
                               description: |-
-                                Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                Interval defines how often Sveltos re-fetches the source to detect changes.
                                 Defaults to 5 minutes.
                               type: string
                             secretRef:
                               description: |-
                                 SecretRef references a Secret in the management cluster containing optional
-                                credentials for fetching the URL. Supported Secret keys:
+                                credentials for fetching the source. Both Name and Namespace must be set,
+                                allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                a single Secret can be shared across clusters without replication.
+                                Supported Secret keys:
                                   "token"              — Bearer token (Authorization: Bearer <token>)
-                                  "username"+"password" — HTTP Basic Auth
+                                  "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                   "caFile"             — PEM-encoded CA certificate for TLS verification
                               properties:
                                 name:
-                                  default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: name is unique within a namespace to
+                                    reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within
+                                    which the secret name must be unique.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             template:
                               description: |-
-                                Template indicates that the content served at URL is a Go template that
+                                Template indicates that the fetched content is a Go template that
                                 must be instantiated using cluster fields and templateResourceRefs values
                                 before deployment. Equivalent to the projectsveltos.io/template annotation
                                 on a ConfigMap or Secret.
                               type: boolean
                             url:
                               description: |-
-                                URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                URL is the remote source serving raw YAML/JSON content.
                                 Sveltos fetches the content on every reconciliation and redeploys if the
                                 content hash has changed.
-                              pattern: ^https?://
+                                Supported schemes:
+                                  "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                  "oci://"                — OCI registry artifact containing YAML manifests
+                              pattern: ^(https?|oci)://
                               type: string
                           required:
                           - url
@@ -4786,46 +4796,52 @@ spec:
                                     type: string
                                   remoteURL:
                                     description: |-
-                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                                       When set, Kind/Name/Namespace must be omitted.
                                     properties:
                                       interval:
                                         description: |-
-                                          Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                          Interval defines how often Sveltos re-fetches the source to detect changes.
                                           Defaults to 5 minutes.
                                         type: string
                                       secretRef:
                                         description: |-
                                           SecretRef references a Secret in the management cluster containing optional
-                                          credentials for fetching the URL. Supported Secret keys:
+                                          credentials for fetching the source. Both Name and Namespace must be set,
+                                          allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                          a single Secret can be shared across clusters without replication.
+                                          Supported Secret keys:
                                             "token"              — Bearer token (Authorization: Bearer <token>)
-                                            "username"+"password" — HTTP Basic Auth
+                                            "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                             "caFile"             — PEM-encoded CA certificate for TLS verification
                                         properties:
                                           name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: name is unique within a namespace
+                                              to reference a secret resource.
+                                            type: string
+                                          namespace:
+                                            description: namespace defines the space
+                                              within which the secret name must be
+                                              unique.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       template:
                                         description: |-
-                                          Template indicates that the content served at URL is a Go template that
+                                          Template indicates that the fetched content is a Go template that
                                           must be instantiated using cluster fields and templateResourceRefs values
                                           before deployment. Equivalent to the projectsveltos.io/template annotation
                                           on a ConfigMap or Secret.
                                         type: boolean
                                       url:
                                         description: |-
-                                          URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                          URL is the remote source serving raw YAML/JSON content.
                                           Sveltos fetches the content on every reconciliation and redeploys if the
                                           content hash has changed.
-                                        pattern: ^https?://
+                                          Supported schemes:
+                                            "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                            "oci://"                — OCI registry artifact containing YAML manifests
+                                        pattern: ^(https?|oci)://
                                         type: string
                                     required:
                                     - url
@@ -5139,46 +5155,52 @@ spec:
                                     type: string
                                   remoteURL:
                                     description: |-
-                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                                      RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                                       When set, Kind/Name/Namespace must be omitted.
                                     properties:
                                       interval:
                                         description: |-
-                                          Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                          Interval defines how often Sveltos re-fetches the source to detect changes.
                                           Defaults to 5 minutes.
                                         type: string
                                       secretRef:
                                         description: |-
                                           SecretRef references a Secret in the management cluster containing optional
-                                          credentials for fetching the URL. Supported Secret keys:
+                                          credentials for fetching the source. Both Name and Namespace must be set,
+                                          allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                          a single Secret can be shared across clusters without replication.
+                                          Supported Secret keys:
                                             "token"              — Bearer token (Authorization: Bearer <token>)
-                                            "username"+"password" — HTTP Basic Auth
+                                            "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                             "caFile"             — PEM-encoded CA certificate for TLS verification
                                         properties:
                                           name:
-                                            default: ""
-                                            description: |-
-                                              Name of the referent.
-                                              This field is effectively required, but due to backwards compatibility is
-                                              allowed to be empty. Instances of this type with an empty value here are
-                                              almost certainly wrong.
-                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            description: name is unique within a namespace
+                                              to reference a secret resource.
+                                            type: string
+                                          namespace:
+                                            description: namespace defines the space
+                                              within which the secret name must be
+                                              unique.
                                             type: string
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       template:
                                         description: |-
-                                          Template indicates that the content served at URL is a Go template that
+                                          Template indicates that the fetched content is a Go template that
                                           must be instantiated using cluster fields and templateResourceRefs values
                                           before deployment. Equivalent to the projectsveltos.io/template annotation
                                           on a ConfigMap or Secret.
                                         type: boolean
                                       url:
                                         description: |-
-                                          URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                          URL is the remote source serving raw YAML/JSON content.
                                           Sveltos fetches the content on every reconciliation and redeploys if the
                                           content hash has changed.
-                                        pattern: ^https?://
+                                          Supported schemes:
+                                            "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                            "oci://"                — OCI registry artifact containing YAML manifests
+                                        pattern: ^(https?|oci)://
                                         type: string
                                     required:
                                     - url
@@ -6751,46 +6773,51 @@ spec:
                           type: string
                         remoteURL:
                           description: |-
-                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                            RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                             When set, Kind/Name/Namespace must be omitted.
                           properties:
                             interval:
                               description: |-
-                                Interval defines how often Sveltos re-fetches the URL to detect changes.
+                                Interval defines how often Sveltos re-fetches the source to detect changes.
                                 Defaults to 5 minutes.
                               type: string
                             secretRef:
                               description: |-
                                 SecretRef references a Secret in the management cluster containing optional
-                                credentials for fetching the URL. Supported Secret keys:
+                                credentials for fetching the source. Both Name and Namespace must be set,
+                                allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                                a single Secret can be shared across clusters without replication.
+                                Supported Secret keys:
                                   "token"              — Bearer token (Authorization: Bearer <token>)
-                                  "username"+"password" — HTTP Basic Auth
+                                  "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                                   "caFile"             — PEM-encoded CA certificate for TLS verification
                               properties:
                                 name:
-                                  default: ""
-                                  description: |-
-                                    Name of the referent.
-                                    This field is effectively required, but due to backwards compatibility is
-                                    allowed to be empty. Instances of this type with an empty value here are
-                                    almost certainly wrong.
-                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  description: name is unique within a namespace to
+                                    reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within
+                                    which the secret name must be unique.
                                   type: string
                               type: object
                               x-kubernetes-map-type: atomic
                             template:
                               description: |-
-                                Template indicates that the content served at URL is a Go template that
+                                Template indicates that the fetched content is a Go template that
                                 must be instantiated using cluster fields and templateResourceRefs values
                                 before deployment. Equivalent to the projectsveltos.io/template annotation
                                 on a ConfigMap or Secret.
                               type: boolean
                             url:
                               description: |-
-                                URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                                URL is the remote source serving raw YAML/JSON content.
                                 Sveltos fetches the content on every reconciliation and redeploys if the
                                 content hash has changed.
-                              pattern: ^https?://
+                                Supported schemes:
+                                  "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                                  "oci://"                — OCI registry artifact containing YAML manifests
+                              pattern: ^(https?|oci)://
                               type: string
                           required:
                           - url
@@ -8956,46 +8983,51 @@ spec:
                       type: string
                     remoteURL:
                       description: |-
-                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint.
+                        RemoteURL configures fetching content from an HTTP/HTTPS endpoint or an OCI registry.
                         When set, Kind/Name/Namespace must be omitted.
                       properties:
                         interval:
                           description: |-
-                            Interval defines how often Sveltos re-fetches the URL to detect changes.
+                            Interval defines how often Sveltos re-fetches the source to detect changes.
                             Defaults to 5 minutes.
                           type: string
                         secretRef:
                           description: |-
                             SecretRef references a Secret in the management cluster containing optional
-                            credentials for fetching the URL. Supported Secret keys:
+                            credentials for fetching the source. Both Name and Namespace must be set,
+                            allowing the Secret to live in any namespace (e.g. projectsveltos) so that
+                            a single Secret can be shared across clusters without replication.
+                            Supported Secret keys:
                               "token"              — Bearer token (Authorization: Bearer <token>)
-                              "username"+"password" — HTTP Basic Auth
+                              "username"+"password" — HTTP Basic Auth or OCI registry basic auth
                               "caFile"             — PEM-encoded CA certificate for TLS verification
                           properties:
                             name:
-                              default: ""
-                              description: |-
-                                Name of the referent.
-                                This field is effectively required, but due to backwards compatibility is
-                                allowed to be empty. Instances of this type with an empty value here are
-                                almost certainly wrong.
-                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
                         template:
                           description: |-
-                            Template indicates that the content served at URL is a Go template that
+                            Template indicates that the fetched content is a Go template that
                             must be instantiated using cluster fields and templateResourceRefs values
                             before deployment. Equivalent to the projectsveltos.io/template annotation
                             on a ConfigMap or Secret.
                           type: boolean
                         url:
                           description: |-
-                            URL is an HTTP/HTTPS endpoint serving raw YAML/JSON/KYAML content.
+                            URL is the remote source serving raw YAML/JSON content.
                             Sveltos fetches the content on every reconciliation and redeploys if the
                             content hash has changed.
-                          pattern: ^https?://
+                            Supported schemes:
+                              "http://" or "https://" — HTTP/HTTPS endpoint returning raw YAML/JSON
+                              "oci://"                — OCI registry artifact containing YAML manifests
+                          pattern: ^(https?|oci)://
                           type: string
                       required:
                       - url

--- a/test/fv/oci_remoteurl_test.go
+++ b/test/fv/oci_remoteurl_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fv_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+
+	configv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
+	"github.com/projectsveltos/addon-controller/lib/clusterops"
+	libsveltosv1beta1 "github.com/projectsveltos/libsveltos/api/v1beta1"
+)
+
+var _ = Describe("OCI RemoteURL", func() {
+	const (
+		namePrefix   = "oci-remoteurl-"
+		ociTestURL   = "oci://ghcr.io/gianlucam76/sveltos-oci-test:head"
+		ociConfigMap = "oci-test"
+		ociNamespace = "default"
+	)
+
+	It("Deploys resources from a public OCI artifact", Label("FV", "PULLMODE", "EXTENDED"), func() {
+		Byf("Create a ClusterProfile matching Cluster %s/%s", kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeContinuous
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		verifyClusterSummary(clusterops.ClusterProfileLabelName, clusterProfile.Name, &clusterProfile.Spec,
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
+
+		Byf("Update ClusterProfile %s to deploy OCI artifact %s", clusterProfile.Name, ociTestURL)
+		currentClusterProfile := &configv1beta1.ClusterProfile{}
+
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Expect(k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+			currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
+				{
+					RemoteURL: &configv1beta1.RemoteURL{
+						URL:      ociTestURL,
+						Interval: &metav1.Duration{Duration: 5 * time.Minute},
+					},
+				},
+			}
+			return k8sClient.Update(context.TODO(), currentClusterProfile)
+		})
+		Expect(err).To(BeNil())
+
+		Expect(k8sClient.Get(context.TODO(),
+			types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+
+		clusterSummary := verifyClusterSummary(clusterops.ClusterProfileLabelName,
+			currentClusterProfile.Name, &currentClusterProfile.Spec,
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(), getClusterType())
+
+		Byf("Getting client to access the workload cluster")
+		workloadClient, err := getKindWorkloadClusterKubeconfig()
+		Expect(err).To(BeNil())
+		Expect(workloadClient).ToNot(BeNil())
+
+		Byf("Verifying ConfigMap %s/%s is created in the workload cluster", ociNamespace, ociConfigMap)
+		Eventually(func() error {
+			cm := &corev1.ConfigMap{}
+			return workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: ociNamespace, Name: ociConfigMap}, cm)
+		}, timeout, pollingInterval).Should(BeNil())
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Resources feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name, libsveltosv1beta1.FeatureResources)
+
+		policies := []policy{
+			{kind: kindConfigMap, name: ociConfigMap, namespace: ociNamespace, group: ""},
+		}
+		verifyClusterConfiguration(configv1beta1.ClusterProfileKind, clusterProfile.Name,
+			clusterSummary.Spec.ClusterNamespace, clusterSummary.Spec.ClusterName, libsveltosv1beta1.FeatureResources,
+			policies, nil)
+
+		Byf("Removing OCI artifact reference from ClusterProfile %s", clusterProfile.Name)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			Expect(k8sClient.Get(context.TODO(),
+				types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+			currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{}
+			return k8sClient.Update(context.TODO(), currentClusterProfile)
+		})
+		Expect(err).To(BeNil())
+
+		Byf("Verifying ConfigMap %s/%s is removed from the workload cluster", ociNamespace, ociConfigMap)
+		Eventually(func() bool {
+			cm := &corev1.ConfigMap{}
+			err = workloadClient.Get(context.TODO(),
+				types.NamespacedName{Namespace: ociNamespace, Name: ociConfigMap}, cm)
+			return apierrors.IsNotFound(err)
+		}, timeout, pollingInterval).Should(BeTrue())
+
+		deleteClusterProfile(clusterProfile)
+	})
+})


### PR DESCRIPTION
RemoteURL in PolicyRef now accepts oci:// URLs in addition to http:// and https://.

When a URL starts with oci://, Sveltos pulls the OCI artifact from the registry on each reconciliation using the configured interval, computes a content hash, and redeploys if the content has changed. Identical to the existing HTTP polling behaviour.

Authentication is controlled by the same secretRef field with the same Secret keys:
- token — Bearer token (OCI RegistryToken)
- username + password — basic auth
- caFile — PEM-encoded CA certificate for TLS verification

Content extraction handles two common OCI artifact layouts: a tar archive (the standard ORAS/Flux format), where .yaml, .yml, and .json files are extracted and concatenated; or a raw YAML/JSON blob where the bytes are used directly.