### PR TITLE
fix: allow helm upgrade force to actually apply

### DIFF
--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -4463,7 +4463,8 @@ func getHelmUpgradeClient(requestedChart *configv1beta1.HelmChart, actionConfig 
 	upgradeClient.ResetValues = getResetValues(requestedChart.Options)
 	upgradeClient.ReuseValues = getReuseValues(requestedChart.Options)
 	upgradeClient.ResetThenReuseValues = getResetThenReuseValues(requestedChart.Options)
-	upgradeClient.ForceReplace = getForceValue(requestedChart.Options)
+	force := getForceValue(requestedChart.Options)
+	upgradeClient.ForceReplace = force
 	upgradeClient.Labels = getLabelsValue(requestedChart.Options)
 	upgradeClient.Description = getDescriptionValue(requestedChart.Options)
 	upgradeClient.MaxHistory = getMaxHistoryValue(requestedChart.Options)
@@ -4474,8 +4475,15 @@ func getHelmUpgradeClient(requestedChart *configv1beta1.HelmChart, actionConfig 
 	upgradeClient.CaFile = registryOptions.caPath
 	upgradeClient.PassCredentialsAll = getPassCredentialsToAllValue(requestedChart.Options)
 	upgradeClient.TakeOwnership = getTakeOwnershipHelmValue(requestedChart.Options, true)
-	upgradeClient.ServerSideApply = stringTrue
-	upgradeClient.ForceConflicts = true
+	if force {
+		// ForceReplace (delete+recreate) is rejected by the Helm SDK when combined
+		// with server-side apply or ForceConflicts; disable both in that case.
+		upgradeClient.ServerSideApply = stringFalse
+		upgradeClient.ForceConflicts = false
+	} else {
+		upgradeClient.ServerSideApply = stringTrue
+		upgradeClient.ForceConflicts = true
+	}
 
 	if actionConfig.RegistryClient != nil {
 		upgradeClient.SetRegistryClient(actionConfig.RegistryClient)

--- a/controllers/handlers_helm_test.go
+++ b/controllers/handlers_helm_test.go
@@ -2350,3 +2350,39 @@ var _ = Describe("getHelmUpgradeClient PostRenderStrategy", func() {
 		Expect(upgradeClient.PostRenderStrategy).To(Equal(action.PostRenderStrategyCombined))
 	})
 })
+
+var _ = Describe("getHelmUpgradeClient Force", func() {
+	It("disables server-side apply and force conflicts when force is set", func() {
+		requestedChart := &configv1beta1.HelmChart{
+			ReleaseName:      randomString(),
+			ReleaseNamespace: randomString(),
+			Options: &configv1beta1.HelmOptions{
+				UpgradeOptions: configv1beta1.HelmUpgradeOptions{
+					Force: true,
+				},
+			},
+		}
+
+		upgradeClient := controllers.GetHelmUpgradeClient(requestedChart, &action.Configuration{},
+			&controllers.RegistryClientOptions{}, nil)
+
+		Expect(upgradeClient.ForceReplace).To(BeTrue())
+		Expect(upgradeClient.ServerSideApply).To(Equal("false"))
+		Expect(upgradeClient.ForceConflicts).To(BeFalse())
+	})
+
+	It("defaults to server-side apply with force conflicts when force is not set", func() {
+		requestedChart := &configv1beta1.HelmChart{
+			ReleaseName:      randomString(),
+			ReleaseNamespace: randomString(),
+			Options:          &configv1beta1.HelmOptions{},
+		}
+
+		upgradeClient := controllers.GetHelmUpgradeClient(requestedChart, &action.Configuration{},
+			&controllers.RegistryClientOptions{}, nil)
+
+		Expect(upgradeClient.ForceReplace).To(BeFalse())
+		Expect(upgradeClient.ServerSideApply).To(Equal("true"))
+		Expect(upgradeClient.ForceConflicts).To(BeTrue())
+	})
+})

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -66,6 +66,7 @@ const (
 	controllerNameClusterSummary        = "clustersummary"
 	appsGroupName                       = "apps"
 	stringTrue                          = "true"
+	stringFalse                         = "false"
 	annotationValueOk                   = "ok"
 )
 


### PR DESCRIPTION
Before this PR that was conflicting with server-side apply

`getHelmUpgradeClient` also unconditionally set `ServerSideApply` and `ForceConflicts` on every upgrade. The Helm SDK rejects that combination outright:

```
invalid operation: cannot use force conflicts and force replace together
```

so the `force` option could never actually run. Any upgrade that set it failed immediately, before Helm even attempted the patch.

This surfaces for instance when a chart changes a Deployment's `strategy.type` from unset, defaulted by the API server to `RollingUpdate` to `Recreate`. The live object still carries the server-defaulted `rollingUpdate` values, which the API server now rejects as forbidden alongside `Recreate`. A normal server-side apply patch can't clear a field it never owned, so the upgrade is stuck. `force` (delete+recreate) is the intended escape hatch, but it was unusable.

Now `ServerSideApply`/`ForceConflicts` are only enabled when `force` is not set; when `force` is set, both are disabled so `ForceReplace` can proceed as Helm expects.