### PR TITLE
fix: cleanup of ClusterProfile with reloader knob set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ OS ?= $(shell uname -s)
 OS := $(shell echo $(OS) | tr '[:upper:]' '[:lower:]')
 K8S_LATEST_VER ?= $(shell curl -s https://dl.k8s.io/release/stable.txt)
 export CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= v1.13.0
+TAG ?= main
 
 # SSH key with read access to the private github.com/projectsveltos/sveltos-enterprise repo,
 # forwarded into the enterprise docker-buildx build (see Dockerfile.enterprise) so it can

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -35,7 +35,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - "--v=5"
-        - "--version=v1.13.0"
+        - "--version=main"
         - "--agent-in-mgmt-cluster=false"
         env:
         - name: GOMEMLIMIT

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,8 +7,8 @@ spec:
   template:
     spec:
       initContainers:
-      - image: docker.io/projectsveltos/addon-controller:v1.13.0
+      - image: docker.io/projectsveltos/addon-controller:main
         name: initialization
       containers:
-      - image: docker.io/projectsveltos/addon-controller:v1.13.0
+      - image: docker.io/projectsveltos/addon-controller:main
         name: controller

--- a/controllers/handlers_helm.go
+++ b/controllers/handlers_helm.go
@@ -628,7 +628,7 @@ func undeployHelmChartResources(ctx context.Context, c client.Client, clusterSum
 		return err
 	}
 
-	err = updateReloaderWithDeployedResources(ctx, clusterSummary, profileRef, libsveltosv1beta1.FeatureKustomize,
+	err = updateReloaderWithDeployedResources(ctx, clusterSummary, profileRef, libsveltosv1beta1.FeatureHelm,
 		nil, true, logger)
 	if err != nil {
 		return err

--- a/manifest/deployment-agentless.yaml
+++ b/manifest/deployment-agentless.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --agent-in-mgmt-cluster=true
         command:
         - /manager
@@ -43,7 +43,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifest/deployment-shard.yaml
+++ b/manifest/deployment-shard.yaml
@@ -26,7 +26,7 @@ spec:
         - --shard-key={{.SHARD}}
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -43,7 +43,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -10970,7 +10970,7 @@ spec:
         - --shard-key=
         - --capi-onboard-annotation=
         - --v=5
-        - --version=v1.13.0
+        - --version=main
         - --agent-in-mgmt-cluster=false
         command:
         - /manager
@@ -10987,7 +10987,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -11045,7 +11045,7 @@ spec:
               fieldPath: metadata.namespace
         - name: IS_INITIALIZATION
           value: "true"
-        image: docker.io/projectsveltos/addon-controller:v1.13.0
+        image: docker.io/projectsveltos/addon-controller:main
         name: initialization
         securityContext:
           allowPrivilegeEscalation: false

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -44,7 +44,7 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.13.0
+        - --version=main
         command:
         - /manager
         env:
@@ -60,7 +60,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:51256ebd9562cb6899b56abea4afe7d84676b4c9a7381d15a67e294ea177e314
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:651ef898a5116d07f74fec85f533927f74af56f36422efed926d69ab481ff36d
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -26,7 +26,7 @@ spec:
         - --cluster-type=
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.13.0
+        - --version=main
         command:
         - /manager
         env:
@@ -42,7 +42,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:51256ebd9562cb6899b56abea4afe7d84676b4c9a7381d15a67e294ea177e314
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:651ef898a5116d07f74fec85f533927f74af56f36422efed926d69ab481ff36d
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -146,7 +146,7 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.13.0
+        - --version=main
         command:
         - /manager
         env:
@@ -162,7 +162,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:51256ebd9562cb6899b56abea4afe7d84676b4c9a7381d15a67e294ea177e314
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:651ef898a5116d07f74fec85f533927f74af56f36422efed926d69ab481ff36d
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -128,7 +128,7 @@ spec:
         - --cluster-type=
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-updates
-        - --version=v1.13.0
+        - --version=main
         command:
         - /manager
         env:
@@ -144,7 +144,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:51256ebd9562cb6899b56abea4afe7d84676b4c9a7381d15a67e294ea177e314
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:651ef898a5116d07f74fec85f533927f74af56f36422efed926d69ab481ff36d
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/test/fv/mgmt_cluster_local_test.go
+++ b/test/fv/mgmt_cluster_local_test.go
@@ -110,18 +110,25 @@ var _ = Describe("ClusterProfile matching the management cluster with deployment
 
 			Byf("Update ClusterProfile %s to reference ConfigMap %s/%s with deploymentType Local",
 				clusterProfile.Name, policyConfigMap.Namespace, policyConfigMap.Name)
+			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				currentClusterProfile := &configv1beta1.ClusterProfile{}
+				Expect(k8sClient.Get(context.TODO(),
+					types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
+				currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
+					{
+						Kind:           string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
+						Namespace:      policyConfigMap.Namespace,
+						Name:           policyConfigMap.Name,
+						DeploymentType: configv1beta1.DeploymentTypeLocal,
+					},
+				}
+				return k8sClient.Update(context.TODO(), currentClusterProfile)
+			})
+			Expect(err).To(BeNil())
+
 			currentClusterProfile := &configv1beta1.ClusterProfile{}
 			Expect(k8sClient.Get(context.TODO(),
 				types.NamespacedName{Name: clusterProfile.Name}, currentClusterProfile)).To(Succeed())
-			currentClusterProfile.Spec.PolicyRefs = []configv1beta1.PolicyRef{
-				{
-					Kind:           string(libsveltosv1beta1.ConfigMapReferencedResourceKind),
-					Namespace:      policyConfigMap.Namespace,
-					Name:           policyConfigMap.Name,
-					DeploymentType: configv1beta1.DeploymentTypeLocal,
-				},
-			}
-			Expect(k8sClient.Update(context.TODO(), currentClusterProfile)).To(Succeed())
 
 			clusterSummary := verifyClusterSummary(clusterops.ClusterProfileLabelName,
 				currentClusterProfile.Name, &currentClusterProfile.Spec,

--- a/test/fv/reloader_test.go
+++ b/test/fv/reloader_test.go
@@ -242,10 +242,128 @@ var _ = Describe("Reloader", func() {
 			}, timeout, pollingInterval).Should(BeTrue())
 		}
 	})
+
+	It("Deploy ClusterProfile with Reloader knob set for a Helm chart, then delete it", Label("FV", "PULLMODE", "EXTENDED"), func() {
+		Byf("Create a ClusterProfile with Reloader knob set matching Cluster %s/%s",
+			kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName())
+		clusterProfile := getClusterProfile(namePrefix, map[string]string{key: value})
+		clusterProfile.Spec.SyncMode = configv1beta1.SyncModeContinuous
+		clusterProfile.Spec.Reloader = true
+		clusterProfile.Spec.HelmCharts = []configv1beta1.HelmChart{
+			{
+				RepositoryURL:    jetstackURL,
+				RepositoryName:   jetstackName,
+				ChartName:        jetstackCertManagerChart,
+				ChartVersion:     externalDNSVersion1182,
+				ReleaseName:      certManager,
+				ReleaseNamespace: certManager,
+				HelmChartAction:  configv1beta1.HelmChartActionInstall,
+				Values:           crdsEnabledValues,
+			},
+		}
+		Expect(k8sClient.Create(context.TODO(), clusterProfile)).To(Succeed())
+
+		verifyClusterProfileMatches(clusterProfile)
+
+		clusterSummary := verifyClusterSummary(clusterops.ClusterProfileLabelName, clusterProfile.Name,
+			&clusterProfile.Spec, kindWorkloadCluster.GetNamespace(), kindWorkloadCluster.GetName(),
+			getClusterType())
+
+		Byf("Verifying ClusterSummary %s status is set to Deployed for Helm feature", clusterSummary.Name)
+		verifyFeatureStatusIsProvisioned(kindWorkloadCluster.GetNamespace(), clusterSummary.Name,
+			libsveltosv1beta1.FeatureHelm)
+
+		reloaderName := getReloaderNameForFeature(clusterProfile.Name, libsveltosv1beta1.FeatureHelm)
+
+		if isAgentLessMode() {
+			Byf("Verifying Reloader %s is present in the management cluster", reloaderName)
+			Eventually(func() error {
+				currentReloader := &libsveltosv1beta1.Reloader{}
+				return k8sClient.Get(context.TODO(), types.NamespacedName{Name: reloaderName}, currentReloader)
+			}, timeout, pollingInterval).Should(BeNil())
+
+			reloaderKey := mgmtagent.GetKeyForReloader(reloaderName)
+			configMapName := mgmtagent.GetConfigMapName(kindWorkloadCluster.GetName(),
+				libsveltosv1beta1.ClusterType(getClusterType()))
+
+			Byf("Verifying per-cluster ConfigMap %s/%s contains Reloader entry %s",
+				kindWorkloadCluster.GetNamespace(), configMapName, reloaderKey)
+			Eventually(func() bool {
+				perClusterCM := &corev1.ConfigMap{}
+				err := k8sClient.Get(context.TODO(),
+					types.NamespacedName{
+						Namespace: kindWorkloadCluster.GetNamespace(),
+						Name:      configMapName,
+					}, perClusterCM)
+				if err != nil {
+					return false
+				}
+				v, ok := perClusterCM.Data[reloaderKey]
+				return ok && v == reloaderName
+			}, timeout, pollingInterval).Should(BeTrue())
+		} else {
+			Byf("Verifying Reloader %s is present in the managed cluster", reloaderName)
+			workloadClient, err := getKindWorkloadClusterKubeconfig()
+			Expect(err).To(BeNil())
+			Expect(workloadClient).ToNot(BeNil())
+			Eventually(func() error {
+				currentReloader := &libsveltosv1beta1.Reloader{}
+				return workloadClient.Get(context.TODO(), types.NamespacedName{Name: reloaderName}, currentReloader)
+			}, timeout, pollingInterval).Should(BeNil())
+		}
+
+		deleteClusterProfile(clusterProfile)
+
+		if isAgentLessMode() {
+			Byf("Verifying Reloader %s is removed from the management cluster", reloaderName)
+			Eventually(func() bool {
+				currentReloader := &libsveltosv1beta1.Reloader{}
+				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: reloaderName}, currentReloader)
+				return err != nil && apierrors.IsNotFound(err)
+			}, timeout, pollingInterval).Should(BeTrue())
+
+			reloaderKey := mgmtagent.GetKeyForReloader(reloaderName)
+			configMapName := mgmtagent.GetConfigMapName(kindWorkloadCluster.GetName(),
+				libsveltosv1beta1.ClusterType(getClusterType()))
+
+			Byf("Verifying per-cluster ConfigMap %s/%s no longer contains Reloader entry %s",
+				kindWorkloadCluster.GetNamespace(), configMapName, reloaderKey)
+			Eventually(func() bool {
+				perClusterCM := &corev1.ConfigMap{}
+				err := k8sClient.Get(context.TODO(),
+					types.NamespacedName{
+						Namespace: kindWorkloadCluster.GetNamespace(),
+						Name:      configMapName,
+					}, perClusterCM)
+				if apierrors.IsNotFound(err) {
+					return true
+				}
+				if err != nil {
+					return false
+				}
+				_, ok := perClusterCM.Data[reloaderKey]
+				return !ok
+			}, timeout, pollingInterval).Should(BeTrue())
+		} else {
+			Byf("Verifying Reloader %s is removed from the workload cluster", reloaderName)
+			workloadClient, err := getKindWorkloadClusterKubeconfig()
+			Expect(err).To(BeNil())
+			Expect(workloadClient).ToNot(BeNil())
+			Eventually(func() bool {
+				currentReloader := &libsveltosv1beta1.Reloader{}
+				err = workloadClient.Get(context.TODO(), types.NamespacedName{Name: reloaderName}, currentReloader)
+				return err != nil && apierrors.IsNotFound(err)
+			}, timeout, pollingInterval).Should(BeTrue())
+		}
+	})
 })
 
-// getReloaderName returns the Reloader's name
+// getReloaderName returns the Reloader's name for the Resources feature
 func getReloaderName(clusterProfileName string) string {
-	feature := libsveltosv1beta1.FeatureResources
+	return getReloaderNameForFeature(clusterProfileName, libsveltosv1beta1.FeatureResources)
+}
+
+// getReloaderNameForFeature returns the Reloader's name for the given feature
+func getReloaderNameForFeature(clusterProfileName string, feature libsveltosv1beta1.FeatureID) string {
 	return fmt.Sprintf("%s--%s", clusterProfileName, strings.ToLower(string(feature)))
 }


### PR DESCRIPTION
When a ClusterProfile with `spec.reloader: true` deploying Helm charts is deleted (or stops matching its target cluster), the corresponding `Reloader` instance and in agentless mode its entry in the per-cluster ConfigMap were never cleaned up. Both would sit around indefinitely, referencing Deployments from a chart that's no longer deployed.

`undeployHelmChartResources` calls `updateReloaderWithDeployedResources` to remove the Reloader on undeploy, but passed `libsveltosv1beta1.FeatureKustomize` instead of `FeatureHelm`

Because the Reloader is looked up by label (`feature: Helm`) and the per-cluster ConfigMap key is derived from the feature name, passing the wrong constant makes both lookups silently miss the real Reloader/ConfigMap entry. No error is raised, it's a silent no-op on both sides. This only affects Helm-based ClusterProfiles; Resources and Kustomize were never mis-tagged and clean up correctly, which is why this went unnoticed.