### PR TITLE
chore: Advance libsveltos pin and drift-detection-manager image tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onsi/gomega v1.42.1
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.13.1-0.20260813141903-0bf44bc3c246
+	github.com/projectsveltos/libsveltos v1.13.1-0.20260814131235-7d76aa957079
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sigstore/cosign/v3 v3.1.3
 	github.com/sigstore/sigstore v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -639,8 +639,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.13.1-0.20260813141903-0bf44bc3c246 h1:ByiXtT8ebkKCnsFl3iwHH8ZbK3hvgc8TwmT7U4O0UuM=
-github.com/projectsveltos/libsveltos v1.13.1-0.20260813141903-0bf44bc3c246/go.mod h1:dgQKoyCm3xr5TV0vJxbq+dkuBLmwm4mqt6tMAgJiP+s=
+github.com/projectsveltos/libsveltos v1.13.1-0.20260814131235-7d76aa957079 h1:ZrE9xrYQ2QbcYanyMDWYr6UG7/iqq6UQf00kGnOSMLc=
+github.com/projectsveltos/libsveltos v1.13.1-0.20260814131235-7d76aa957079/go.mod h1:dgQKoyCm3xr5TV0vJxbq+dkuBLmwm4mqt6tMAgJiP+s=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.go
@@ -60,7 +60,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b69e6497fdb4bf2309b34d39412d10cd9eba158abe0cfff53a786509ebc38ddc
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:6c3ed34a17951a87da19126d820ec58dc2189a3cf1aca3f0f3196a1675089df5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
+++ b/pkg/drift-detection/drift-detection-manager-in-mgmt-cluster.yaml
@@ -42,7 +42,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b69e6497fdb4bf2309b34d39412d10cd9eba158abe0cfff53a786509ebc38ddc
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:6c3ed34a17951a87da19126d820ec58dc2189a3cf1aca3f0f3196a1675089df5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.go
+++ b/pkg/drift-detection/drift-detection-manager.go
@@ -162,7 +162,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b69e6497fdb4bf2309b34d39412d10cd9eba158abe0cfff53a786509ebc38ddc
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:6c3ed34a17951a87da19126d820ec58dc2189a3cf1aca3f0f3196a1675089df5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/drift-detection/drift-detection-manager.yaml
+++ b/pkg/drift-detection/drift-detection-manager.yaml
@@ -144,7 +144,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: docker.io/projectsveltos/drift-detection-manager@sha256:b69e6497fdb4bf2309b34d39412d10cd9eba158abe0cfff53a786509ebc38ddc
+        image: docker.io/projectsveltos/drift-detection-manager@sha256:6c3ed34a17951a87da19126d820ec58dc2189a3cf1aca3f0f3196a1675089df5
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
This will pick:
1. An optimization on the CustomResourceDefinition watcher: replaces the SharedIndexInformer used to watch CRDs with a lean client-go Reflector that forwards each Add/Update/Delete straight to the handler and discards the object, instead of retaining every CRD in an indexed cache for the process lifetime. Reduces memory consumption on every Sveltos component, including addon-controller, starting that watcher.
2. The same optimization applied to drift-detection-manager's per-GVK resource watchers: replaces the DynamicSharedInformerFactory backed informer used to watch tracked resources with the same reflector/discarding-store approach. Nothing there ever read the cached store back (drift checks always re fetch the resource live to evaluate if a configuration drift happened), so it was pure overhead, retained per watched GVK for as long as the watcher stayed active. Reduces drift-detection-manager memory on clusters tracking many resources across many GVKs.