### PR TITLE
chore: advance libsveltos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/onsi/gomega v1.43.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v1.14.1-0.20260901064342-1f002bcd7f58
+	github.com/projectsveltos/libsveltos v1.14.1-0.20260905063009-a8a9f4f0cfd4
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sigstore/cosign/v3 v3.1.3
 	github.com/sigstore/sigstore v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -641,8 +641,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v1.1.2 h1:QaNrNiZx0+Nar5dLgTVp5mXkyoVFIbepjyEoGSnhbAY=
 github.com/poy/onpar v1.1.2/go.mod h1:6X8FLNoxyr9kkmnlqpK6LSoiOtrO6MICtWwEuWkLjzg=
-github.com/projectsveltos/libsveltos v1.14.1-0.20260901064342-1f002bcd7f58 h1:4dGVa8AWhlLDAjLDR4RwAwpK8OkIxcGEpw1jcEf1Edg=
-github.com/projectsveltos/libsveltos v1.14.1-0.20260901064342-1f002bcd7f58/go.mod h1:U6iGj5KoC/PcTD2vh3XU6gy7g11suThT6sZSEpmLEkU=
+github.com/projectsveltos/libsveltos v1.14.1-0.20260905063009-a8a9f4f0cfd4 h1:A601K466dqM3yWv+U+BtFGPWHjbyAUo7p0iylNg+B74=
+github.com/projectsveltos/libsveltos v1.14.1-0.20260905063009-a8a9f4f0cfd4/go.mod h1:U6iGj5KoC/PcTD2vh3XU6gy7g11suThT6sZSEpmLEkU=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5 h1:khnc+994UszxZYu69J+R5FKiLA/Nk1JQj0EYAkwTWz0=
 github.com/projectsveltos/lua-utils/glua-json v0.0.0-20251212200258-2b3cdcb7c0f5/go.mod h1:yVL8KQFa9tmcxgwl9nwIMtKgtmIVC1zaFRSCfOwYvPY=
 github.com/projectsveltos/lua-utils/glua-runes v0.0.0-20251212200258-2b3cdcb7c0f5 h1:YbsebwRwTRhV8QacvEAdFqxcxHdeu7JTVtsBovbkgos=


### PR DESCRIPTION
This pick a change to self-evict cluster cache on 401/403

Fixes #1942 